### PR TITLE
record absolute address

### DIFF
--- a/memory_ldst.inc.c
+++ b/memory_ldst.inc.c
@@ -460,7 +460,7 @@ static inline void glue(address_space_stl_internal, SUFFIX)(ARG1_DECL,
             break;
         }
         if (rr_in_record() && (rr_record_in_progress || rr_record_in_main_loop_wait)) {
-            rr_device_mem_rw_call_record(addr1, ptr, l, /*is_write*/1);
+            rr_device_mem_rw_call_record(addr, ptr, l, /*is_write*/1);
         }
         INVALIDATE(mr, addr1, 4);
         r = MEMTX_OK;


### PR DESCRIPTION
should record the absolute address, currently the recorded address is offset in the mr, but the mr may have a none zero addr.