### PR TITLE
QMP-visibility for Panda-functions

### DIFF
--- a/panda/include/panda/rr/rr_log_all.h
+++ b/panda/include/panda/rr/rr_log_all.h
@@ -68,13 +68,6 @@ int rr_do_begin_replay(const char* name, CPUState* cpu_state);
 void rr_do_end_replay(int is_error);
 void rr_reset_state(CPUState* cpu_state);
 
-void qmp_begin_record(const char* file_name, Error** errp);
-void qmp_begin_record_from(const char* snapshot, const char* file_name,
-                                  Error** errp);
-void qmp_begin_replay(const char* file_name, Error** errp);
-void qmp_end_record(Error** errp);
-void qmp_end_replay(Error** errp);
-
 
 // mz display indication of replay progress
 extern void replay_progress(void);

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -784,13 +784,6 @@ void panda_free_args(panda_arg_list *args) {
 
 // QMP
 
-
-void qmp_load_plugin(const char *filename, Error **errp);
-void qmp_unload_plugin(int64_t index, Error **errp);
-void qmp_list_plugins(Error **errp);
-void qmp_plugin_cmd(const char * cmd, Error **errp);
-
-
 void qmp_load_plugin(const char *filename, Error **errp) {
     if(!panda_load_plugin(filename, NULL)) {
         // TODO: do something with errp here?

--- a/qapi-schema.json
+++ b/qapi-schema.json
@@ -6031,3 +6031,74 @@
 #
 ##
 { 'command': 'query-hotpluggable-cpus', 'returns': ['HotpluggableCPU'] }
+
+##
+# @begin_record:
+#
+# Requests that we begin recording for later replay
+# 
+# TRL 20120501
+##
+{ 'command': 'begin_record', 'data': { 'file_name': 'str' } }
+
+##
+# @begin_record_from:
+#
+# Requests that we revert to a snapshot and begin recording for later replay
+#
+##
+{ 'command': 'begin_record_from', 'data': { 'snapshot': 'str', 'file_name': 'str' } }
+
+##
+# @end_record:
+#
+# Requests that we begin recording for later replay
+# 
+# TRL 20120501
+##
+{ 'command': 'end_record' }
+
+##
+# @end_replay:
+#
+# Requests that we end replaying 
+# 
+# TRL 20120501
+##
+{ 'command': 'end_replay' } 
+
+##
+# @load_plugin:
+#
+# Loads a PANDA plugin
+# 
+# BDG 20120821
+##
+{ 'command': 'load_plugin', 'data': { 'file_name': 'str' } }
+
+##
+# @unload_plugin:
+#
+# Unloads a PANDA plugin
+# 
+# BDG 20120821
+##
+{ 'command': 'unload_plugin', 'data': { 'index': 'int' } }
+
+##
+# @list_plugins:
+#
+# List loaded PANDA plugins
+# 
+# BDG 20120821
+##
+{ 'command': 'list_plugins' }
+
+##
+# @plugin_cmd:
+#
+# Send a command to a loaded PANDA plugin
+# 
+# BDG 20120822
+##
+{ 'command': 'plugin_cmd', 'data': { 'cmd': 'str' } }


### PR DESCRIPTION
Hi there!

We figured that Panda2 does exposes the Panda-functionalities only to the Human Monitor, not to QMP.
Hence, we fixed it by simply copying and adjusting the according parts of qapi-scheme.json from Panda1.
As the according function-declarations are now automatically generated and part of qmp-commands.h, we had to remove those function declarations in some other files.
The changes were tested under Ubuntu16.04.

Please Note: While doing this, we noticed that there is currently no qmp_begin_replay()-function in Panda2 - accordingly, it's also not exposed to the qmp. Are there plans to make the replay-functionalities available to hmp/qmp, or will it just stay as commandline-feature? 

Cheers,
Marius & @mpuzz