### PR TITLE
Start recording via commandline options

### DIFF
--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -382,7 +382,10 @@ end_record:
     be resumed and another recording can be made once the guest is
     resumed.
 
-Start replays from the command line using the `-replay <name>` option.
+A commandline flag `-record-from <snapshot>:<record-name>` to restores a
+qcow2 snapshot and immediately start recording is also provided for convenience.
+
+Start replays from the command line using the `-replay <name>` option. 
 
 Of course, just running a replay isn't very useful by itself, so you
 will probably want to run the replay with some plugins enabled that

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -4104,7 +4104,7 @@ DEF("generate-llvm", 0, QEMU_OPTION_generate_llvm,
 #endif
 
 DEF("record-from", HAS_ARG, QEMU_OPTION_record_from,
-    "-record-from <snapshot>\n"
+    "-record-from <snapshot>:<record-name>\n"
     "                load snapshot <snapshot> and begin recording\n", QEMU_ARCH_ALL)
 
 DEF("replay", HAS_ARG, QEMU_OPTION_replay,

--- a/vl.c
+++ b/vl.c
@@ -4863,6 +4863,12 @@ int main(int argc, char **argv, char **envp)
             }
             rec_name[r_i] = '\0';
         }
+
+        if(*rec_name == '\0'){
+            fprintf(stderr, "missing record name, usage: -record-from <snapshot>:<record-name>\n");
+            exit(1);
+        }
+
         qmp_begin_record_from(snap_name,rec_name, &err);
     }
 
@@ -4897,6 +4903,10 @@ int main(int argc, char **argv, char **envp)
     panda_in_main_loop = 1;
     main_loop();
     panda_in_main_loop = 0;
+
+    if(rr_in_record()){
+        rr_do_end_record();
+    }
 
     replay_disable_events();
     iothread_stop_all();


### PR DESCRIPTION
Hi! I needed a way to launch Panda in record-mode from a python script without having to send commands via QMP. I'm currently launching Panda with the undocumented `-record-from` commandline option, and I've added an `if rr_in_record() rr_do_end_record();` statement after the main loop to be able to cleanly stop recording when closing panda with SIGTERM.

Unfortunately, I don't have enough knowledge of qemu's internals to tell if that change is correct, but it seems to be working fine on my machine. I also don't know if that `record-from` option was undocumented for some good reason. Feel free to ask for changes or close the PR.

In this pull:
- the aforementioned `rr_end_record()` after `main_loop()`
- documentation for the `-record-from` option