### PR TITLE
Execution order for callbacks

### DIFF
--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -455,11 +455,15 @@ you may care about what order plugins' callbacks execute in, since some
 operations may not make sense if they're done out of order.
 
 The bad news is that PANDA does not guarantee any fixed ordering for its
-callbacks. In the current implementation, each callback of a given type will be
-executed in the order it was registered (which is usually the order in which the
-plugins were loaded; however, because callbacks can be registered at any time
-throughout a plugin's lifetime, even this is not guaranteed). This could change
-in the future, though, and in general it's not a good idea to rely on it.
+callbacks across different plugins. In the current implementation, each callback
+of a given type will be executed in the order it was registered.
+Although this creates a deterministic order for callbacks of a specific type
+within one plugin, a fixed callback execution order among multiple distinct
+plugins can not be ensured.
+(Usually, this order corresponds to the order in which the plugins were loaded;
+however, because callbacks can be registered at any time throughout a plugin's
+lifetime, this is not guaranteed to hold true). This could change in the future,
+though, and in general it's not a good idea to rely on it.
 
 The good news is that there's a better way to enforce an ordering. As described
 in the next section, plugins support explicit mechanisms for interacting with

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -218,6 +218,7 @@ void * panda_get_plugin_by_name(const char *plugin_name) {
 }
 
 void panda_register_callback(void *plugin, panda_cb_type type, panda_cb cb) {
+    panda_cb_list *plist;
     panda_cb_list *new_list = g_new0(panda_cb_list,1);
     new_list->entry = cb;
     new_list->owner = plugin;
@@ -225,10 +226,13 @@ void panda_register_callback(void *plugin, panda_cb_type type, panda_cb cb) {
     new_list->next = NULL;
     new_list->enabled = true;
     if(panda_cbs[type] != NULL) {
-        new_list->next = panda_cbs[type];
-        panda_cbs[type]->prev = new_list;
+        for(plist = panda_cbs[type]; panda_cb_list_next(plist) != NULL; plist = panda_cb_list_next(plist));
+        plist->next = new_list;
+        new_list->prev = plist;
     }
-    panda_cbs[type] = new_list;
+    else {
+        panda_cbs[type] = new_list;
+    }
 }
 
 


### PR DESCRIPTION
Hey,

Panda used to insert registered callbacks at the beginning of the callback-list, instead of the end. 
As it nice to have callbacks of the same type inside one plugin executed in the order in which they were registered, this PR fixes this.
Additionally, some changes in the documentation to stress the difference between execution order of callbacks inside one plugin andd across multiple plugins are included.

Best,
Marius