### PR TITLE
Several Minor Fixes

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -180,7 +180,17 @@ instr_type disas_block(CPUArchState* env, target_ulong pc, int size) {
 
 #if defined(TARGET_I386)
     csh handle = (env->hflags & HF_LMA_MASK) ? cs_handle_64 : cs_handle_32;
-#elif defined(TARGET_ARM) || defined(TARGET_PPC)
+#elif defined(TARGET_ARM)
+    csh handle = cs_handle_32;
+
+    if (env->thumb){
+        cs_option(handle, CS_OPT_MODE, CS_MODE_THUMB);
+    }
+    else {
+        cs_option(handle, CS_OPT_MODE, CS_MODE_ARM);
+    }
+
+#elif defined(TARGET_PPC)
     csh handle = cs_handle_32;
 #endif
 

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -226,7 +226,7 @@ void panda_register_callback(void *plugin, panda_cb_type type, panda_cb cb) {
     new_list->next = NULL;
     new_list->enabled = true;
     if(panda_cbs[type] != NULL) {
-        for(plist = panda_cbs[type]; panda_cb_list_next(plist) != NULL; plist = panda_cb_list_next(plist));
+        for(plist = panda_cbs[type]; plist->next != NULL; plist = plist->next);
         plist->next = new_list;
         new_list->prev = plist;
     }

--- a/panda/src/common.c
+++ b/panda/src/common.c
@@ -30,6 +30,7 @@ static inline uint32_t regime_el(CPUARMState *env, ARMMMUIdx mmu_idx)
     case ARMMMUIdx_S1SE1:
     case ARMMMUIdx_S1NSE0:
     case ARMMMUIdx_S1NSE1:
+    case ARMMMUIdx_S12NSE1:
         return 1;
     default:
         g_assert_not_reached();


### PR DESCRIPTION
Hi again,

This PR contains three distinct fixes:
a) I realized that I introduced a subtle bug with my PR yesterday, as I used panda_cb_list_next() to traverse the cb_list when registering a callback. As this function skips cbs for disabled plugins, this can result into pruning cbs for disabled plugins when they are at the end of the list. This is fixed by using plist->next when traversing the list.

b) callstack_instr always uses CS_MODE_ARM for generating disassembly for ARM-Targets. I added a check whether execution is currently in THUMB-Mode or not, and dynamically change the capstone mode to CS_MODE_THUMB or CS_MODE_ARM. 

c) the board we are working with returns ARMMMUIdx_S12NSE1 as ARMMMUIdx, which was not handled inside the regime_el-function.

For the future, what is your general contributing-policy? Would you prefer to have the fix for one feature in a self-containing PR, or is it fine to send you bundled fixes as done in this PR?

Best,
Marius