### PR TITLE
taint2: added nullptr check in tp_ls_iter

### DIFF
--- a/panda/plugins/taint2/taint_api.cpp
+++ b/panda/plugins/taint2/taint_api.cpp
@@ -98,6 +98,9 @@ static void tp_label(Addr a, uint32_t l) {
 
 // retrieve ls for this addr
 static void tp_ls_iter(LabelSetP ls, int (*app)(uint32_t, void *), void *opaque) {
+    if(ls == nullptr){
+        return;
+    }
     for (uint32_t el : *ls) {
         if (app(el, opaque) != 0) break;
     }


### PR DESCRIPTION
Hi!
There are currently some lines of code in `taint_api.cpp` that are calling `tp_labelset_get` and passing its return value to `tp_ls_iter` without checking if it's null first (see 
https://github.com/panda-re/panda/blob/master/panda/plugins/taint2/taint_api.cpp#L232 )

I've figured that adding a nullptr check in tp_ls_iter itself would be the quickest fix (not sure if it's the cleanest though). This fix allows calling `taint2_labelset_ram_iter` without having to check if the address was actually tainted.

While I'm at it, is this comment https://github.com/panda-re/panda/blob/master/panda/plugins/taint2/taint_api.cpp#L61 still relevant? (there doesn't seem to be a copy, and the calling code is not freeing the pointer as far as I can tell)