### PR TITLE
QMP/HMP visibility for PANDA functionalities

### DIFF
--- a/hmp-commands.hx
+++ b/hmp-commands.hx
@@ -1799,6 +1799,38 @@ ETEXI
     },
 
     {
+        .name       = "begin_replay",
+        .args_type  = "file_name:s",
+        .params     = "[file_name]",
+        .help       = "begin to replay a record",
+        .cmd = hmp_begin_replay,
+    },
+
+    {
+        .name       = "load_plugin",
+        .args_type  = "plugin_name:s,plugin_args:s?",
+        .params     = "plugin_name [plugin_args]",
+        .help       = "Load a panda plugin",
+        .cmd = hmp_panda_load_plugin,
+    },
+
+    {
+        .name       = "unload_plugin",
+        .args_type  = "index:i",
+        .params     = "index",
+        .help       = "Unload a panda plugin",
+        .cmd = hmp_panda_unload_plugin,
+    },
+
+    {
+        .name       = "list_plugins",
+        .args_type  = "",
+        .params     = "",
+        .help       = "list the loaded plugins",
+        .cmd = hmp_panda_list_plugins,
+    },
+
+    {
         .name       = "end_replay",
         .args_type  = "",
         .params     = "",

--- a/hmp.h
+++ b/hmp.h
@@ -145,4 +145,9 @@ void hmp_begin_replay(Monitor *mon, const QDict *qdict);
 void hmp_end_record(Monitor *mon, const QDict *qdict);
 void hmp_end_replay(Monitor *mon, const QDict *qdict);
 
+// PANDA Plugins
+void hmp_panda_load_plugin(Monitor *mon, const QDict *qdict);
+void hmp_panda_unload_plugin(Monitor *mon, const QDict *qdict);
+void hmp_panda_list_plugins(Monitor *mon, const QDict *qdict);
+
 #endif

--- a/main-loop.c
+++ b/main-loop.c
@@ -481,13 +481,20 @@ static int os_host_main_loop_wait(int64_t timeout)
 }
 #endif
 
+
+#define RR_MAIN_WAIT_LOOP_TIMEOUT_IN_REPLAY 1000
+
+
 int main_loop_wait(int nonblocking)
 {
     int ret;
     uint32_t timeout = UINT32_MAX;
     int64_t timeout_ns;
 
-    if (nonblocking) {
+    if (rr_in_replay()) {
+        timeout = RR_MAIN_WAIT_LOOP_TIMEOUT_IN_REPLAY;
+    }
+    else if (nonblocking) {
         timeout = 0;
     }
 
@@ -495,7 +502,7 @@ int main_loop_wait(int nonblocking)
     g_array_set_size(gpollfds, 0); /* reset for new iteration */
     /* XXX: separate device handlers from system ones */
 #ifdef CONFIG_SLIRP
-    if (!rr_in_replay()) {
+    if (! (rr_in_replay() || rr_replay_requested)) {
         slirp_pollfds_fill(gpollfds, &timeout);
     }
 #endif
@@ -521,7 +528,7 @@ int main_loop_wait(int nonblocking)
     /* CPU thread can infinitely wait for event after
        missing the warp */
     // ru: add check if in in replay for running timers
-    if (!rr_in_replay()) {
+    if (! (rr_in_replay() || rr_replay_requested)) {
         qemu_start_warp_timer();
         rr_begin_main_loop_wait();
         qemu_clock_run_all_timers();

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -788,8 +788,31 @@ void panda_free_args(panda_arg_list *args) {
 
 // QMP
 
-void qmp_load_plugin(const char *filename, Error **errp) {
-    if(!panda_load_plugin(filename, NULL)) {
+void qmp_load_plugin(bool has_file_name, const char *file_name, const char *plugin_name, bool has_plugin_args, const char *plugin_args, Error **errp){
+
+    if(!has_file_name)
+        file_name = panda_plugin_path(plugin_name);
+
+    if (has_plugin_args){
+        char arg_str[255];
+        char *args = strdup(plugin_args);
+        char *args_start = args;
+        char *args_end = args;
+
+        while (args_end != NULL) {
+            args_end = strchr(args_start, ',');
+            if (args_end != NULL) *args_end = '\0';
+
+            snprintf(arg_str, 255, "%s:%s", plugin_name, args_start);
+            if( !panda_add_arg(arg_str, strlen(arg_str))){
+                // TODO: do something with errp here?
+            }
+            args_start = args_end + 1;
+        }
+        free(args);
+    }
+
+    if(!panda_load_plugin(file_name, plugin_name)) {
         // TODO: do something with errp here?
     }
 }
@@ -802,25 +825,41 @@ void qmp_unload_plugin(int64_t index, Error **errp) {
     }
 }
 
-void qmp_list_plugins(Error **errp) {
-    
+PandaPluginInfoList *qmp_list_plugins(Error **errp) {
+    PandaPluginInfoList *head = NULL;
+    int i;
+
+    for (i = 0; i < nb_panda_plugins; i++) {
+        PandaPluginInfoList *list_item = g_new0(typeof(*list_item), 1);
+        PandaPluginInfo *plugin_item = g_new0(typeof(*plugin_item), 1);
+
+        plugin_item->index = i;
+        plugin_item->name = g_strdup(panda_plugins[i].name);
+        plugin_item->address = (unsigned long) panda_plugins[i].plugin;
+
+        list_item->value = plugin_item;
+        list_item->next = head;
+        head = list_item;
+    }
+    return head;
 }
 
 void qmp_plugin_cmd(const char * cmd, Error **errp) {
     
 }
 
-void hmp_panda_load_plugin(Monitor *mon, const QDict *qdict);
-void hmp_panda_unload_plugin(Monitor *mon, const QDict *qdict);
-void hmp_panda_list_plugins(Monitor *mon, const QDict *qdict) ;
 void hmp_panda_plugin_cmd(Monitor *mon, const QDict *qdict);
 
 
 // HMP
 void hmp_panda_load_plugin(Monitor *mon, const QDict *qdict) {
     Error *err;
-    const char *filename = qdict_get_try_str(qdict, "filename");
-    qmp_load_plugin(filename, &err);
+    const char *file_name   = qdict_get_try_str(qdict, "file_name");
+    const char *plugin_name = qdict_get_try_str(qdict, "plugin_name");
+    const char *plugin_args = qdict_get_try_str(qdict, "plugin_args");
+    bool has_file_name   = file_name ? true : false;
+    bool has_plugin_args = plugin_args ? true : false;
+    qmp_load_plugin(has_file_name, file_name, plugin_name, has_plugin_args, plugin_args, &err);
 }
 
 void hmp_panda_unload_plugin(Monitor *mon, const QDict *qdict) {
@@ -831,12 +870,14 @@ void hmp_panda_unload_plugin(Monitor *mon, const QDict *qdict) {
 
 void hmp_panda_list_plugins(Monitor *mon, const QDict *qdict) {
     Error *err;
-    int i;
+    PandaPluginInfoList *plugin_item = qmp_list_plugins(&err);
     monitor_printf(mon, "idx\t%-20s\taddr\n", "name");
-    for (i = 0; i < nb_panda_plugins; i++) {
-        monitor_printf(mon, "%d\t%-20s\t%p\n", i, panda_plugins[i].name, panda_plugins[i].plugin);
+    while (plugin_item != NULL){
+        monitor_printf(mon, "%ld\t%-20s\t%lx\n", plugin_item->value->index, 
+                        plugin_item->value->name, plugin_item->value->address);
+        plugin_item = plugin_item->next;
+
     }
-    qmp_list_plugins(&err);
 }
 
 void hmp_panda_plugin_cmd(Monitor *mon, const QDict *qdict) {

--- a/panda/src/plog.c
+++ b/panda/src/plog.c
@@ -483,7 +483,7 @@ void unmarshall_chunk(uint32_t chunk_num) {
 }
 
 Panda__LogEntry *pandalog_read_entry(void) {
-    assert (in_read_mode);
+    assert (in_read_mode());
     PandalogChunk *plc = &(thePandalog->chunk);
     uint8_t done = 0;
     uint8_t new_chunk = 0;

--- a/panda/src/rr/rr_log.c
+++ b/panda/src/rr/rr_log.c
@@ -102,6 +102,7 @@ uint8_t rr_please_flush_tb = 0;
 
 // mz Flags set by monitor to indicate requested record/replay action
 volatile sig_atomic_t rr_record_requested = 0;
+volatile sig_atomic_t rr_replay_requested = 0;
 volatile sig_atomic_t rr_end_record_requested = 0;
 volatile sig_atomic_t rr_end_replay_requested = 0;
 char* rr_requested_name = NULL;
@@ -1246,6 +1247,12 @@ void qmp_end_record(Error** errp)
     rr_end_record_requested = 1;
 }
 
+void qmp_begin_replay(const char *file_name, Error **errp) {
+  rr_replay_requested = 1;
+  rr_requested_name = g_strdup(file_name);
+  gettimeofday(&replay_start_time, 0);
+}
+
 void qmp_end_replay(Error** errp)
 {
     qmp_stop(NULL);
@@ -1278,6 +1285,13 @@ void hmp_end_record(Monitor* mon, const QDict* qdict)
 {
     Error* err;
     qmp_end_record(&err);
+}
+
+void hmp_begin_replay(Monitor *mon, const QDict *qdict)
+{
+  Error *err;
+  const char *file_name = qdict_get_try_str(qdict, "file_name");
+  qmp_begin_replay(file_name, &err);
 }
 
 void hmp_end_replay(Monitor* mon, const QDict* qdict)

--- a/qapi-schema.json
+++ b/qapi-schema.json
@@ -6059,6 +6059,15 @@
 { 'command': 'end_record' }
 
 ##
+# @begin_replay:
+#
+# Requests that we begin replaying
+# 
+# TRL 20120501
+##
+{ 'command': 'begin_replay', 'data': { 'file_name': 'str' } }
+
+##
 # @end_replay:
 #
 # Requests that we end replaying 
@@ -6074,7 +6083,8 @@
 # 
 # BDG 20120821
 ##
-{ 'command': 'load_plugin', 'data': { 'file_name': 'str' } }
+{ 'command': 'load_plugin', 'data': { '*file_name': 'str', 'plugin_name': 'str',
+                                      '*plugin_args': 'str'} }
 
 ##
 # @unload_plugin:
@@ -6085,6 +6095,14 @@
 ##
 { 'command': 'unload_plugin', 'data': { 'index': 'int' } }
 
+
+##
+# @PandaPluginInfo:
+#
+# Structure holding the information of a PANDA plugin
+##
+{ 'struct': 'PandaPluginInfo', 'data': {'index': 'int', 'name': 'str', 'address': 'int'} }
+
 ##
 # @list_plugins:
 #
@@ -6092,7 +6110,7 @@
 # 
 # BDG 20120821
 ##
-{ 'command': 'list_plugins' }
+{ 'command': 'list_plugins', 'returns': ['PandaPluginInfo']}
 
 ##
 # @plugin_cmd:

--- a/qemu-timer.c
+++ b/qemu-timer.c
@@ -591,7 +591,7 @@ int64_t timerlistgroup_deadline_ns(QEMUTimerListGroup *tlg)
     bool play = replay_mode == REPLAY_MODE_PLAY;
 
 #ifdef CONFIG_SOFTMMU
-    if (rr_in_replay()) return RR_REPLAY_DEADLINE;
+    if (rr_in_replay() || rr_replay_requested) return RR_REPLAY_DEADLINE;
 #endif
 
     for (type = 0; type < QEMU_CLOCK_MAX; type++) {


### PR DESCRIPTION
Hey!

This PR exposes the Panda features to the HMP and QMP. In detail, the following functionalities can now be called from the monitor protocols:
* load_plugin
* unload_plugin
* list_plugins
* begin_record
* end_record
* begin_replay
* end_replay

For realizing begin_replay, I migrated functionality from PANDA1 to PANDA2, mainly extra checks for rr_replay_requested.
Additionally, I changed qmp/hmp_load_plugin(), so that a) it is now possible to give arguments for the plugin to be loaded, and b) file_name is not a neccessary argument anymore - when a plugin_name is specified (and no file_name), panda will try to automatically resolve the shared-library via panda_plugin_path(). However, if a file_name is specified, PANDA will try to load the specified file.

Except that, this PR also contains a minor bugfix in panda/src/plog.c: panda_log_read_entry() asserted that in_read_mode is defined, rather than calling in_read_mode().

//Edit: The CI-build for this PR failed and I can't explain why.
```
[...]
LINK    tests/test-char
main-loop.o: In function `main_loop_wait':
/home/travis/build/panda-re/panda/main-loop.c:505: undefined reference to `rr_replay_requested'
/home/travis/build/panda-re/panda/main-loop.c:531: undefined reference to `rr_replay_requested'
collect2: error: ld returned 1 exit status
make: *** [tests/test-char] Error 1
```
main-loop.c includes panda/rr/rr_log_all.h which provides the declaration for rr_replay_requested, which in turn is defined in panda/src/rr/rr_log.c.
PANDA builds for me with the included changes on Debian Stretch (gcc 5.4.1), Arch Linux (gcc 6.3.1) and even a freshly installed vagrant image of Ubuntu Trusty/14.04 (gcc 4.8.2) as used by your travis-ci.
Any ideas?