### PR TITLE
makefile changes to make Panda build on gcc-6.2

### DIFF
--- a/panda/Makefile.panda.target
+++ b/panda/Makefile.panda.target
@@ -157,7 +157,7 @@ llvm-$(TARGET_ARM) += fpu/softfloat.bc2
 llvm-$(TARGET_ARM) += $(addprefix target/arm/,$(ARM_HELPERS))
 llvmmorph-$(TARGET_ARM) += llvm-helpers.bc
 
-CLANG_FILTER = -Wold-style-declaration -fstack-protector-strong -Wno-error=cpp -g -O0 -O1 -O3 -mcx16
+CLANG_FILTER = -Wold-style-declaration -fstack-protector-strong -Wno-error=cpp -g -O0 -O1 -O3 -mcx16 -Wno-shift-negative-value
 QEMU_BC2FLAGS:=$(filter-out $(CLANG_FILTER),$(QEMU_CFLAGS) $(CFLAGS)) -O2 -I../target/$(TARGET_BASE_ARCH)
 %.bc2: %.c $(GENERATED_HEADERS)
 	$(call quiet-command,\
@@ -169,7 +169,7 @@ llvm-helpers.bc1: $(llvm-y)
 
 # Make explicit the fact that we need the tool present to do the morphing
 
-panda/tools/helper_call_modifier.o-cflags += $(LLVM_CXXFLAGS)
+panda/tools/helper_call_modifier.o-cflags += $(LLVM_CXXFLAGS) -Wno-misleading-indentation
 
 panda/tools:
 	$(call quiet-command,mkdir -p panda/tools,)

--- a/panda/plugins/taint2/Makefile
+++ b/panda/plugins/taint2/Makefile
@@ -15,6 +15,8 @@ TAINT_OP_CFLAGS+= $(CLANG_CXXFLAGS) $(DBGFLAGS)
 
 TAINT_OP_FILTER = -g -Wold-style-declaration -std=c11 -fpermissive
 TAINT_OP_FILTER+= -fstack-protector-strong -Wno-error=cpp -mcx16
+TAINT_OP_FILTER+= -Wno-shift-negative-value
+
 
 $(PLUGIN_TARGET_DIR)/panda_taint2.so: \
     $(PLUGIN_OBJ_DIR)/shad_dir_32.o \


### PR DESCRIPTION
Hi. I've started building panda with gcc-6.2 on ubuntu 16.10, patching clang and compiling llvm3.3 from sources, as from documentation. It seems to work well enough (I had been using an ubuntu 14.04 container, which was cumbersome).
This commit disables some newer compiler flags that cause problems with llvm3.3 headers or clang3.3. It should still build on ubuntu 14.04.