### PR TITLE
Bunch of small tweaks to make the doc more readable and Markdown Checkers complain less

### DIFF
--- a/panda/docs/dynslice.md
+++ b/panda/docs/dynslice.md
@@ -19,16 +19,18 @@ Given this, it is a natural fit to add to PANDA.
 The basic algorithm is quite simple, and can be expressed in a few lines
 of pseudocode. Given an execution trace:
 
-    ; initialize a working set containing the data whose computation we
-    ; want to understand
+```python
+    # initialize a working set containing the data whose computation we
+    # want to understand
     work = { initial slice variables }
 
-    ; walk backward through the trace
+    # walk backward through the trace
     for insn in reversed(trace):
         if work ∩ defines(insn) != ∅:
             mark(insn)
             work = work ∖ defines(insn)
             work = work ∪ uses(insn)
+```
 
 The `defines` and `uses` functions above just get the variables used or
 defined by a given instruction. For example, for the LLVM instruction
@@ -61,10 +63,10 @@ simplifying program analyses. It has three main benefits:
     simpler and fewer in number than native code, meaning that analyses
     which need to model each instruction (like taint and dynamic
     slicing) are vastly easier to write.
-2. Since the LLVM is generated from TCG operations, and QEMU already
+1. Since the LLVM is generated from TCG operations, and QEMU already
    lifts native code to TCG for every architecture it supports, analyses
    on LLVM automatically work for every architecture QEMU supports.
-3. Unlike analyses that work only on TCG, however, we can also analyze
+1. Unlike analyses that work only on TCG, however, we can also analyze
    functions written in C by compiling them to LLVM bitcode with
    `clang`. This is critical, since significant portions of QEMU's guest
    emulation (for example, floating point operations) are implemented as
@@ -81,9 +83,9 @@ Execution Tracing in PANDA with `llvm_trace`
 To capture a useful execution trace, we want three things:
 
 1. A list of basic blocks executed in the guest.
-2. The corresponding code for each basic block.
-3. Dynamic information, such as the address of memory loads and stores
-   and the 
+1. The corresponding code for each basic block.
+1. Dynamic information, such as the address of memory loads and stores
+   and the
 
 This is precisely what the `llvm_trace` plugin produces. When enabled,
 it runs guest code in LLVM mode, where each basic block of native code
@@ -112,8 +114,10 @@ log is a mere 2.7G when compressed with `gzip`.
 
 To actually produce a trace, run:
 
-    $ cd <arch>-softmmu
-    $ ./qemu-system-<arch> -replay <replay> -panda 'llvm_trace:tubt=1,base=<output_dir>'
+```sh
+cd <arch>-softmmu
+./qemu-system-<arch> -replay <replay> -panda 'llvm_trace:tubt=1,base=<output_dir>'
+```
 
 Which will produce `llvm-mod.bc` and `tubtf.log` in the `<output_dir>`
 directory.
@@ -124,8 +128,10 @@ Using PANDA's Dynamic Slicer
 Because dynamic slicing operates on a trace in reverse, we first need to
 reverse the logfile. This is done using the `logreverse_mmap` tool:
 
-    $ cd <arch>-softmmu/panda_tools/
-    $ ./logreverse_mmap tubtf.log
+```sh
+cd <arch>-softmmu/panda_tools/
+./logreverse_mmap tubtf.log
+```
 
 Note that since it reverses the file in-place, you may want to make a
 backup of the original somewhere.
@@ -152,7 +158,9 @@ for slicing conditions:
 So if we want to track four bytes at physical address `0x12000`, we could
 do:
 
-    $ ./dynslice llvm-mod.bc tubtf.log MEM_12000 MEM_12001 MEM_12002 MEM_1203
+```sh
+./dynslice llvm-mod.bc tubtf.log MEM_12000 MEM_12001 MEM_12002 MEM_1203
+```
 
 Both the `N` in `REG_[N]` and the `PADDR` in `MEM_[PADDR]` are
 hexadecimal numbers.
@@ -173,7 +181,9 @@ virtual address at different points in the trace). So to see, for
 example, the marked instructions in `tcg-llvm-tb-31408-74b92bec`, we can
 do:
 
-    $ ./slice_viewer llvm-mod.bc slice_report.bin tcg-llvm-tb-31408-74b92bec
+```sh
+./slice_viewer llvm-mod.bc slice_report.bin tcg-llvm-tb-31408-74b92bec
+```
 
 And we'll get the output below:
 

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -228,9 +228,11 @@ These functions don't really form an API to QEMU or PANDA, but they are useful
 for controlling PANDA or interacting with QEMU.
 
 #### QEMU translation control
+
 ```C
 void panda_do_flush_tb(void);
 ```
+
 This function requests that the translation block cache be flushed as soon as
 possible. If running with translation block chaining turned off (e.g. when in
 LLVM mode or replay mode), this will happen when the current translation block
@@ -612,12 +614,15 @@ consider that example from above.
 The `llvm_trace` plugin has two arguments, `base` and `foo` with values `/tmp`
 and `6`.  In `init_plugin` for `llvm_trace`, include the following code to
 retrieve just the arguments for the `llvm_trace` plugin and then to parse the individual arguments.
+
 ```C
 panda_arg_list *args = panda_get_args("llvm_trace");
 uint32_t foo = panda_parse_uint32(args, "foo", 0);
 char *base = panda_parse_string(args, "base", NULL);
 ```
+
 Here is the complete list of PANDA arg parsing functions.
+
 ```C
 target_ulong panda_parse_ulong(panda_arg_list *args, const char *argname, target_ulong defval);
 uint32_t panda_parse_uint32(panda_arg_list *args, const char *argname, uint32_t defval);
@@ -626,11 +631,14 @@ double panda_parse_double(panda_arg_list *args, const char *argname, double defv
 bool panda_parse_bool(panda_arg_list *args, const char *argname);
 const char *panda_parse_string(panda_arg_list *args, const char *argname, const char *defval);
 ```
+
 Note that calling `panda_get_args` allocates memory to store the list, which
 should be freed after use with `panda_free_args`.
+
 ```C
 void panda_free_args(panda_arg_list *args);
 ```
+
 Frees an argument list created with `panda_get_args`.
 
 
@@ -663,6 +671,7 @@ To export an API for use in another plugin:
 1. Create a file named `<plugin>_int_fns.h` in the plugin's directory and list
    each function's prototype, along with any data types it requires.
 2. Create a file named `<plugin>_int.h` in the plugin's directory looks like:
+
 ```C
 typedef void YourCustomType;
 typedef void YourOtherCustomType;

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -63,8 +63,9 @@ void get_prog_point(CPUState *env, prog_point *p);
 ```
 
 There are also functions available for getting callstack information in [pandalog format](docs/pandalog.md):
+
 ```C
-// Create pandalog message for callstack info 
+// Create pandalog message for callstack info
 Panda__CallStack *pandalog_callstack_create(void);
 
 ```C

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -43,8 +43,8 @@ typedef void (* on_ret_t)(CPUState *env, target_ulong func)
 
 Description: Called every time a function call returns in guest (e.g., at the `ret` instruction). Arguments are the CPU state pointer `env` and the virtual address of the function we're returning from. This can be used to match up the return with the appropriate call, but does not indicate the level of nesting in the case of recursive calls. If you want to match returns with calls in this case, you will need to keep a counter inside your plugin.
 
-
 `callstack_instr` also provides the following API functions that can be called from other plugins:
+
 ```C
 // Get up to n callers from the given address space at this moment
 // Callers are returned in callers[], most recent first
@@ -61,14 +61,17 @@ int get_functions(target_ulong *functions, int n, CPUState *env);
 // right now to have a "utilities" library, this will have to do
 void get_prog_point(CPUState *env, prog_point *p);
 ```
+
 There are also functions available for getting callstack information in [pandalog format](docs/pandalog.md):
+
 ```C
-// Create pandalog message for callstack info 
+// Create pandalog message for callstack info
 Panda__CallStack *pandalog_callstack_create(void);
 
 // Free a Panda__CallStack struct
 void pandalog_callstack_free(Panda__CallStack *cs);
 ```
+
 Example
 -------
 

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -25,42 +25,50 @@ APIs and Callbacks
 
 Name: **on_call**
 
-Signature: `typedef void (* on_call_t)(CPUState *env, target_ulong func)`
+Signature:
+
+```C
+typedef void (* on_call_t)(CPUState *env, target_ulong func)
+```
 
 Description: Called every time a function call occurs in the guest. Arguments are the CPU state pointer `env` and the virtual address of the function that is being called.
 
 Name: **on_ret**
 
-Signature: `typedef void (* on_ret_t)(CPUState *env, target_ulong func)`
+Signature:
+
+```C
+typedef void (* on_ret_t)(CPUState *env, target_ulong func)
+```
 
 Description: Called every time a function call returns in guest (e.g., at the `ret` instruction). Arguments are the CPU state pointer `env` and the virtual address of the function we're returning from. This can be used to match up the return with the appropriate call, but does not indicate the level of nesting in the case of recursive calls. If you want to match returns with calls in this case, you will need to keep a counter inside your plugin.
 
 
 `callstack_instr` also provides the following API functions that can be called from other plugins:
+```C
+// Get up to n callers from the given address space at this moment
+// Callers are returned in callers[], most recent first
+// Return value is the number of callers actually retrieved
+int get_callers(target_ulong *callers, int n, CPUState *env);
 
-    // Get up to n callers from the given address space at this moment
-    // Callers are returned in callers[], most recent first
-    // Return value is the number of callers actually retrieved
-    int get_callers(target_ulong *callers, int n, CPUState *env);
+// Get up to n functions from the given address space at this moment
+// Functions are returned in functions[], most recent first
+// Return value is the number of callers actually retrieved
+int get_functions(target_ulong *functions, int n, CPUState *env);
 
-    // Get up to n functions from the given address space at this moment
-    // Functions are returned in functions[], most recent first
-    // Return value is the number of callers actually retrieved
-    int get_functions(target_ulong *functions, int n, CPUState *env);
-
-    // Get the current program point: (Caller, PC, ASID)
-    // This isn't quite the right place for it, but since it's awkward
-    // right now to have a "utilities" library, this will have to do
-    void get_prog_point(CPUState *env, prog_point *p);
-
+// Get the current program point: (Caller, PC, ASID)
+// This isn't quite the right place for it, but since it's awkward
+// right now to have a "utilities" library, this will have to do
+void get_prog_point(CPUState *env, prog_point *p);
+```
 There are also functions available for getting callstack information in [pandalog format](docs/pandalog.md):
+```C
+// Create pandalog message for callstack info 
+Panda__CallStack *pandalog_callstack_create(void);
 
-    // Create pandalog message for callstack info 
-    Panda__CallStack *pandalog_callstack_create(void);
-
-    // Free a Panda__CallStack struct
-    void pandalog_callstack_free(Panda__CallStack *cs);
-
+// Free a Panda__CallStack struct
+void pandalog_callstack_free(Panda__CallStack *cs);
+```
 Example
 -------
 

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -63,6 +63,9 @@ void get_prog_point(CPUState *env, prog_point *p);
 ```
 
 There are also functions available for getting callstack information in [pandalog format](docs/pandalog.md):
+```C
+// Create pandalog message for callstack info 
+Panda__CallStack *pandalog_callstack_create(void);
 
 ```C
 // Create pandalog message for callstack info

--- a/panda/plugins/callstack_instr/callstack_instr_int_fns.h
+++ b/panda/plugins/callstack_instr/callstack_instr_int_fns.h
@@ -17,7 +17,7 @@ int get_functions(target_ulong *functions, int n, CPUState *cpu);
 // right now to have a "utilities" library, this will have to do
 void get_prog_point(CPUState *cpu, prog_point *p);
 
-// create pandalog message for callstack info 
+// create pandalog message for callstack info
 Panda__CallStack *pandalog_callstack_create(void);
 
 // free that data structure

--- a/panda/plugins/cppskeleton/USAGE.md
+++ b/panda/plugins/cppskeleton/USAGE.md
@@ -15,4 +15,3 @@ APIs and Callbacks
 
 Example
 -------
-

--- a/panda/plugins/cskeleton/USAGE.md
+++ b/panda/plugins/cskeleton/USAGE.md
@@ -15,4 +15,3 @@ APIs and Callbacks
 
 Example
 -------
-

--- a/panda/plugins/osi/USAGE.md
+++ b/panda/plugins/osi/USAGE.md
@@ -35,43 +35,71 @@ To implement OS-specific introspection support, an OSI provider should register 
 
 Name: **on_get_processes**
 
-Signature: `typedef void (*on_get_processes_t)(CPUState *, OsiProcs **)`
+Signature:
+
+```C
+typedef void (*on_get_processes_t)(CPUState *, OsiProcs **)
+```
 
 Description: Called to get the process list from the guest OS. The implementation should allocate memory and fill in the pointer to an `OsiProcs` struct. The returned list can be freed with `on_free_osiprocs`.
 
 Name: **on_get_current_process**
 
-Signature: `typedef void (*on_get_current_process_t)(CPUState *, OsiProc **)`
+Signature:
+
+```C
+typedef void (*on_get_current_process_t)(CPUState *, OsiProc **)
+```
 
 Description: Called to get the currently running process in the guest OS. The implementation should allocate memory and fill in the pointer to an `OsiProc` struct. The returned `OsiProc` can be freed with `on_free_osiproc`.
 
 Name: **on_get_modules**
 
-Signature: `typedef void (*on_get_modules_t)(CPUState *, OsiModules **)`
+Signature:
+
+```C
+typedef void (*on_get_modules_t)(CPUState *, OsiModules **)
+```
 
 Description: Called to get the list of kernel modules loaded in the guest. The implementation should allocate memory and fill in the pointer to an `OsiModules` struct. The returned list can be freed with `on_free_osimodules`.
 
 Name: **on_get_libraries**
 
-Signature: `typedef void (*on_get_libraries_t)(CPUState *, OsiProc *, OsiModules**)`
+Signature:
+
+```C
+typedef void (*on_get_libraries_t)(CPUState *, OsiProc *, OsiModules**)
+```
 
 Description: Called to get the list of shared libraries loaded for some particular process in the guest. The process should be an `OsiProc` previously returned by `on_get_current_process` or `on_get_processes`. The implementation should allocate memory and fill in the pointer to an `OsiModules` struct. The returned list can be freed with `on_free_osimodules`.
 
 Name: **on_free_osiproc**
 
-Signature: `typedef void (*on_free_osiproc_t)(OsiProc *p)`
+Signature:
+
+```C
+typedef void (*on_free_osiproc_t)(OsiProc *p)`
+```
 
 Description: Frees an `OsiProc` struct. You only need to implement this if you use a custom memory allocator (instead of the default malloc/free) in your plugin.
 
 Name: **on_free_osiprocs**
 
-Signature: `typedef void (*on_free_osiprocs_t)(OsiProcs *ps)`
+Signature:
+
+```C
+typedef void (*on_free_osiprocs_t)(OsiProcs *ps)
+```
 
 Description: Frees an `OsiProcs` struct. You only need to implement this if you use a custom memory allocator (instead of the default malloc/free) in your plugin.
 
 Name: **on_free_osimodules**
 
-Signature: `typedef void (*on_free_osimodules_t)(OsiModules *ms)`
+Signature:
+
+```C
+typedef void (*on_free_osimodules_t)(OsiModules *ms)
+```
 
 Description: Frees an `OsiModules` structure. You only need to implement this if you use a custom memory allocator (instead of the default malloc/free) in your plugin.
 
@@ -81,13 +109,21 @@ In addition, there are two callbacks intended to be used by `osi` *users*, rathe
 
 Name: **on_new_process**
 
-Signature: `typedef void (*on_new_process_t)(CPUState *, OsiProc *)`
+Signature:
+
+```C
+typedef void (*on_new_process_t)(CPUState *, OsiProc *)
+```
 
 Description: Called whenever a new process is created in the guest. Passes in an `OsiProc` identifying the newly created process.
 
 Name: **on_finished_process**
 
-Signature: `typedef void (*on_finished_process_t)(CPUState *, OsiProc *)`
+Signature:
+
+```C
+typedef void (*on_finished_process_t)(CPUState *, OsiProc *)
+```
 
 Description: Called whenever a process exits in the guest. Passes in an `OsiProc` identifying the process that just exited.
 

--- a/panda/plugins/osi/USAGE.md
+++ b/panda/plugins/osi/USAGE.md
@@ -93,6 +93,7 @@ Description: Called whenever a process exits in the guest. Passes in an `OsiProc
 
 Data structures used by OSI:
 
+```C
     // Represents a page of memory
     typedef struct osi_page_struct {
         target_ulong start;
@@ -129,7 +130,7 @@ Data structures used by OSI:
         uint32_t num;
         OsiModule *module;
     } OsiModules;
-
+```
 
 Example
 -------

--- a/panda/plugins/osi_linux/USAGE.md
+++ b/panda/plugins/osi_linux/USAGE.md
@@ -19,7 +19,7 @@ Because the offsets of fields in Linux kernel data structures change frequently 
 
     [... omitted ...]
 
-    [debian_wheezy_i386_desktop] 
+    [debian_wheezy_i386_desktop]
     name = #1 SMP Debian 3.2.51-1 i686
     task.size = 1060
     #task.init_addr = 0xC13E0FE0
@@ -36,7 +36,9 @@ Of course, generating this file by hand would be extremely painful. So instead w
 
 To do so, you will need the kernel headers and a compiler installed in the guest. On a Debian guest, you can do:
 
-    # apt-get install build-essential linux-headers-`uname -r`
+```sh
+    apt-get install build-essential linux-headers-`uname -r`
+```
 
 Then copy the `panda_plugins/osi_linux/utils/kernelinfo` directory into the guest (e.g., using `scp` from inside the guest or simply by cloning the PANDA repository), and run `make` to build `kernelinfo.ko`. Finally, insert the kernel module and run `dmesg` to get the values. Note that although `insmod` will return an "Operation not permitted" error, it will still print the right information to the log:
 
@@ -94,18 +96,21 @@ APIs and Callbacks
 
 In addition to providing the standard APIs used by OSI, `osi_linux` also provides two Linux-specific API calls that resolve file descriptors to filenames and tell you the current file position:
 
+```C
     // returns fd for a filename or a NULL if failed
     char *osi_linux_fd_to_filename(CPUState *env, OsiProc *p, int fd);
 
-    // returns pos in a file 
+    // returns pos in a file
     unsigned long long  osi_linux_fd_to_pos(CPUState *env, OsiProc *p, int fd);
-
+```
 
 Example
 -------
 
 Assuming you have a `kernelinfo.conf` in the current directory with a configuration named `my_kernel_info`, you can run the OSI test plugin on a Linux replay as follows:
 
+```bash
     $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
         -panda osi -panda osi_linux:kconf_file=kernelinfo.conf,kconf_group=my_kernel_info \
         -panda osi_test
+```

--- a/panda/plugins/osi_test/USAGE.md
+++ b/panda/plugins/osi_test/USAGE.md
@@ -1,8 +1,7 @@
-Plugin: osi_test
-===========
+# Plugin: osi_test
 
-Summary
--------
+## Summary
+
 This plugin is meant to test the functionality of the [PANDA OS introspection framework](../osi).
 
 By default, the `osi_test` plugin invokes the OSI code every time that the Page Directory register is written to.
@@ -10,6 +9,7 @@ By default, the `osi_test` plugin invokes the OSI code every time that the Page 
 Invocation frequency can be increased by commenting out the definition of the `INVOKE_FREQ_PGD` macro in the code. Then, OSI code will be invoked before the execution of each basic block. Be warned that this may be too frequent and even small traces will take a long time to be replayed.
 
 ### Output Normalizer
+
 The [osi_test_normalize.py](osi_test_normalize.py) script can be used to make regression testing easier.  The script will strip out any cruft coming from debug printing and print process and library lists in a normalized format.
 
 ### Example Output
@@ -39,25 +39,23 @@ The [osi_test_normalize.py](osi_test_normalize.py) script can be used to make re
       dwm.exe               1136    832
     [...]
 
-Arguments
----------
+## Arguments
 
 None.
 
-Dependencies
-------------
+## Dependencies
 
 Depends on the `osi` plugin to access the introspection API, and also a particular introspection provider (e.g., `osi_linux` or `win7x86intro`).
 
-APIs and Callbacks
-------------------
+## APIs and Callbacks
 
 None.
 
-Example
--------
+## Example
 
 Running `osi_test` on an Windows 7 32-bit replay:
 
+```sh
     $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
         -panda osi -panda win7x86intro -panda osi_test
+```

--- a/panda/plugins/pri/USAGE.md
+++ b/panda/plugins/pri/USAGE.md
@@ -129,9 +129,6 @@ There are three API functions provided to clients that allow them to iterate thr
     char *pri_get_vma_symbol (CPUState *env, target_ulong pc, target_ulong vma);
 
     // iterate through the live vars at the current state of execution
-    void pri_all_livevar_iter (CPUState *env, target_ulong pc, void (*f)(void *var_ty, const char *var_nm, LocType loc_t, target_ulong loc));
-    // iterate through the live vars at the current state of execution
-    // iterate through the live vars at the current state of execution
     void pri_all_livevar_iter (CPUState *env, target_ulong pc, void (*f)(void *var_ty, const char *var_nm, LocType loc_t,     target_ulong loc));
 
     // iterate through the function vars at the current state of execution

--- a/panda/plugins/pri/USAGE.md
+++ b/panda/plugins/pri/USAGE.md
@@ -17,6 +17,7 @@ Expressed graphically, this arrangement looks like:
     +-------------------+  +-------------------+
 
 The key is that you can swap out the bottom layer to support a different debugging file format without needing to modify your plugin.
+
 Arguments
 ---------
 
@@ -24,16 +25,22 @@ None.
 
 Dependencies
 ------------
-Depends on a debugging file format specific plugin.  
-Without this, pri will return no useful information becuase it is just a shell for provider plugins. 
+
+Depends on a debugging file format specific plugin.
+Without this, pri will return no useful information becuase it is just a shell for provider plugins.
 
 APIs and Callbacks
 ------------------
+
 To implement debugging information process introspection support, an pri provider should register the following callbacks:
 
 Name: **on_get_pc_source_info**
 
-Signature: `typedef void (*on_get_pc_source_info_t)(CPUState *a, target_ulong pc, SrcInfo *info, int *rc)`
+Signature:
+
+```C
+typedef void (*on_get_pc_source_info_t)(CPUState *a, target_ulong pc, SrcInfo *info, int *rc)
+```
 
 Description: get source info for a pc at current execution return -1 if pc is in
 external libraries that do not have symbol information.  Return 1 if pc is in
@@ -41,7 +48,11 @@ the plt for an external function.
 
 Name: **on_get_vma_symbol**
 
-Signature: `typedef void (*on_get_vma_symbol)(CPUState *env, target_ulong pc, target_ulong vma, char **symbol_name)`
+Signature:
+
+```C
+typedef void (*on_get_vma_symbol)(CPUState *env, target_ulong pc, target_ulong vma, char **symbol_name)
+```
 
 Description: get dwarf symbol info for a Virtual Memory Address while execution is at pc. Sets `symbol_name` to  `NULL` if pc is in external libraries that do not have symbol information.
 
@@ -53,13 +64,21 @@ Description: iterate through all live vars and apply function f on them.
 
 Name: **on_global_livevar_iter**
 
-Signature: `typedef void (*on_global_livevar_iter_t)(CPUState *a, target_ulong pc, liveVarCB f)`
+Signature:
+
+```C
+typedef void (*on_global_livevar_iter_t)(CPUState *a, target_ulong pc, liveVarCB f)
+```
 
 Description: iterate through global live vars and apply function f on them.
 
 Name: **on_funct_livevar_iter**
 
-Signature: `typedef void (*on_funct_livevar_iter_t)(CPUState *a, target_ulong pc, liveVarCB f)`
+Signature:
+
+```C
+typedef void (*on_funct_livevar_iter_t)(CPUState *a, target_ulong pc, liveVarCB f)
+```
 
 Description: iterate through live vars local to the current function and apply function f on them.
 
@@ -69,19 +88,31 @@ In addition, there are two callbacks intended to be used by `pri` *users*, rathe
 
 Name: **on_before_line_change**
 
-Signature: `typedef void (*on_before_line_change_t)(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name, unsigned long long lno)`
+Signature:
+
+```C
+typedef void (*on_before_line_change_t)(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name, unsigned long long lno)
+```
 
 Description: Called before execution starts a line in source code.
 
 Name: **on_after_line_change**
 
-Signature: `typedef void (*on_after_line_change_t)(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name, unsigned long long lno)`
+Signature:
+
+```C
+typedef void (*on_after_line_change_t)(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name, unsigned long long lno)
+```
 
 Description: Called after execution finishes a line in source code.
 
 Name: **on_fn_start**
 
-Signature: `typedef void (*on_fn_start_t)(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name)`
+Signature:
+
+```C
+typedef void (*on_fn_start_t)(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name)
+```
 
 Description: Called when execution hits the start of a function after the function's prologue.
 
@@ -91,7 +122,7 @@ There are three API functions provided to clients that allow them to iterate thr
 
     // get source info for a pc at current execution return -1 if in external libraries that do not have symbol information
     int pri_get_pc_source_info (CPUState *env, target_ulong pc, PC_Info *info);
-    
+
     // get dwarf symbol info for a Virtual Memory Address while execution is at pc. Return `NULL` if external libraries that do not have symbol information
     // do not free string returned from function
     char *pri_get_vma_symbol (CPUState *env, target_ulong pc, target_ulong vma);
@@ -104,10 +135,10 @@ There are three API functions provided to clients that allow them to iterate thr
 
     // iterate through the function vars at the current state of execution
     void pri_funct_livevar_iter (CPUState *env, target_ulong pc, void (*f)(void *var_ty, const char *var_nm, LocType loc_t, target_ulong loc));
-    
+
     // iterate through the global vars at the current state of execution
     void pri_global_livevar_iter (CPUState *env, target_ulong pc, void (*f)(void *var_ty, const char *var_nm, LocType loc_t, target_ulong loc));
-    
+
 There are three API functions provided to pri providers that allow them to run callbacks that will be available to clients through the `pri` interface.
     // run a line change callback
     void pri_runcb_on_before_line_change(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name, unsigned long long lno);
@@ -118,13 +149,13 @@ There are three API functions provided to pri providers that allow them to run c
 ---------------
 
 Data Structures used by `pri`:
-    
+
     // A location is one of three types: Register, Memory, or a Constant (variable is not stored anywhere in memory or registers)
     // but we know it's value at compile time.
     // LocErr means that the variables location was too difficult to be determine (future support may remediate this).
     //     -> ie a variable's location is represented by two different registers (DW_OP_bit_piece)
     typedef enum { LocReg, LocMem, LocConst, LocErr } LocType;
-    
+
     // the live_var_iter functions take in this callback and apply it to all vars that are live at the current program state
     typedef void (*liveVarCB)(void *var_ty, const char *var_nm, LocType loc_t, target_ulong loc);
 
@@ -134,25 +165,25 @@ Example
 This is an example of a use of `pri`.  Note that for this to be useful it needs to include a provider plugin to support the `pri` callbacks for a specific debuggin format: DWARF, pdb, etc
 
     extern "C" {
-    
-    // usual panda includes . . .    
-    
+
+    // usual panda includes . . .
+
     // pri specific includes
     #include "../pri/pri_types.h"
     #include "../pri/pri_ext.h"
     #include "../pri/pri.h"
     // pri provider include
     #include "../dwarfp/dwarfp_ext.h"
-        
+
         bool init_plugin(void *);
         void uninit_plugin(void *);
-        
+
     }
-    
+
     // pri is only supported 32 bit linux
     #if defined(TARGET_I386) && !defined(TARGET_X86_64)
     void pfun(void *var_ty, const char *var_nm, LocType loc_t, target_ulong loc){
-        
+
         switch (loc_t){
             case LocReg:
                 printf("VAR REG %s in 0x%x\n", var_nm, loc);
@@ -177,9 +208,9 @@ This is an example of a use of `pri`.  Note that for this to be useful it needs 
         pri_funct_livevar_iter(env, pc, pfun);
     }
     #endif
-    
+
     bool init_plugin(void *self) {
-    
+
     #if defined(TARGET_I386) && !defined(TARGET_X86_64)
         printf("Initializing plugin dwarf_simple\n");
         //panda_arg_list *args = panda_get_args("dwarf_taint");
@@ -187,7 +218,7 @@ This is an example of a use of `pri`.  Note that for this to be useful it needs 
         assert(init_pri_api());
         panda_require("dwarfp");
         assert(init_dwarfp_api());
-        
+
         //PPP_REG_CB("pri", on_line_change, on_line_change);
         PPP_REG_CB("pri", on_fn_start, on_fn_start);
     #endif

--- a/panda/plugins/pri/USAGE.md
+++ b/panda/plugins/pri/USAGE.md
@@ -120,6 +120,7 @@ Description: Called when execution hits the start of a function after the functi
 
 There are three API functions provided to clients that allow them to iterate through live variables at the current state of execution.
 
+```C
     // get source info for a pc at current execution return -1 if in external libraries that do not have symbol information
     int pri_get_pc_source_info (CPUState *env, target_ulong pc, PC_Info *info);
 
@@ -138,18 +139,23 @@ There are three API functions provided to clients that allow them to iterate thr
 
     // iterate through the global vars at the current state of execution
     void pri_global_livevar_iter (CPUState *env, target_ulong pc, void (*f)(void *var_ty, const char *var_nm, LocType loc_t, target_ulong loc));
+```
 
 There are three API functions provided to pri providers that allow them to run callbacks that will be available to clients through the `pri` interface.
+
+```C
     // run a line change callback
     void pri_runcb_on_before_line_change(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name, unsigned long long lno);
     void pri_runcb_on_after_line_change(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name, unsigned long long lno);
     // run a callback signaling the beginning of a function AFTER the function prologue
     void pri_runcb_on_fn_start(CPUState *env, target_ulong pc, const char *file_name, const char *funct_name);
+```
 
 ---------------
 
 Data Structures used by `pri`:
 
+```C
     // A location is one of three types: Register, Memory, or a Constant (variable is not stored anywhere in memory or registers)
     // but we know it's value at compile time.
     // LocErr means that the variables location was too difficult to be determine (future support may remediate this).
@@ -158,72 +164,74 @@ Data Structures used by `pri`:
 
     // the live_var_iter functions take in this callback and apply it to all vars that are live at the current program state
     typedef void (*liveVarCB)(void *var_ty, const char *var_nm, LocType loc_t, target_ulong loc);
-
+```
 
 Example
 -------
+
 This is an example of a use of `pri`.  Note that for this to be useful it needs to include a provider plugin to support the `pri` callbacks for a specific debuggin format: DWARF, pdb, etc
 
-    extern "C" {
+```C
+extern "C" {
 
-    // usual panda includes . . .
+// usual panda includes . . .
 
-    // pri specific includes
-    #include "../pri/pri_types.h"
-    #include "../pri/pri_ext.h"
-    #include "../pri/pri.h"
-    // pri provider include
-    #include "../dwarfp/dwarfp_ext.h"
+// pri specific includes
+#include "../pri/pri_types.h"
+#include "../pri/pri_ext.h"
+#include "../pri/pri.h"
+// pri provider include
+#include "../dwarfp/dwarfp_ext.h"
 
-        bool init_plugin(void *);
-        void uninit_plugin(void *);
+    bool init_plugin(void *);
+    void uninit_plugin(void *);
 
+}
+
+// pri is only supported 32 bit linux
+#if defined(TARGET_I386) && !defined(TARGET_X86_64)
+void pfun(void *var_ty, const char *var_nm, LocType loc_t,target_ulong loc){
+
+    switch (loc_t){
+        case LocReg:
+            printf("VAR REG %s in 0x%x\n", var_nm, loc);
+            break;
+        case LocMem:
+            printf("VAR MEM %s @ 0x%x\n", var_nm, loc);
+            break;
+        case LocConst:
+            printf("VAR CONST %s as 0x%x\n", var_nm, loc);
+            break;
+        case LocErr:
+            printf("VAR does not have a location we coulddetermine. Most likely because the var is splitamong multiple locations\n");
+            break;
     }
+}
+void on_line_change(CPUState *env, target_ulong pc, const char*file_Name, const char *funct_name, unsigned long long lno){
+    printf("[%s] %s(), ln: %4lld, pc @ 0x%x\n",file_Name,funct_name,lno,pc);
+    //pri_funct_livevar_iter(env, pc, pfun);
+}
+void on_fn_start(CPUState *env, target_ulong pc, const char*file_Name, const char *funct_name, unsigned long long lno){
+    printf("fn-start: %s() [%s], ln: %4lld, pc @ 0x%x\n"funct_name,file_Name,lno,pc);
+    pri_funct_livevar_iter(env, pc, pfun);
+}
+#endif
 
-    // pri is only supported 32 bit linux
-    #if defined(TARGET_I386) && !defined(TARGET_X86_64)
-    void pfun(void *var_ty, const char *var_nm, LocType loc_t, target_ulong loc){
+bool init_plugin(void *self) {
 
-        switch (loc_t){
-            case LocReg:
-                printf("VAR REG %s in 0x%x\n", var_nm, loc);
-                break;
-            case LocMem:
-                printf("VAR MEM %s @ 0x%x\n", var_nm, loc);
-                break;
-            case LocConst:
-                printf("VAR CONST %s as 0x%x\n", var_nm, loc);
-                break;
-            case LocErr:
-                printf("VAR does not have a location we could determine. Most likely because the var is split among multiple locations\n");
-                break;
-        }
-    }
-    void on_line_change(CPUState *env, target_ulong pc, const char *file_Name, const char *funct_name, unsigned long long lno){
-        printf("[%s] %s(), ln: %4lld, pc @ 0x%x\n",file_Name, funct_name,lno,pc);
-        //pri_funct_livevar_iter(env, pc, pfun);
-    }
-    void on_fn_start(CPUState *env, target_ulong pc, const char *file_Name, const char *funct_name, unsigned long long lno){
-        printf("fn-start: %s() [%s], ln: %4lld, pc @ 0x%x\n",funct_name,file_Name,lno,pc);
-        pri_funct_livevar_iter(env, pc, pfun);
-    }
-    #endif
+#if defined(TARGET_I386) && !defined(TARGET_X86_64)
+    printf("Initializing plugin dwarf_simple\n");
+    //panda_arg_list *args = panda_get_args("dwarf_taint");
+    panda_require("pri");
+    assert(init_pri_api());
+    panda_require("dwarfp");
+    assert(init_dwarfp_api());
 
-    bool init_plugin(void *self) {
-
-    #if defined(TARGET_I386) && !defined(TARGET_X86_64)
-        printf("Initializing plugin dwarf_simple\n");
-        //panda_arg_list *args = panda_get_args("dwarf_taint");
-        panda_require("pri");
-        assert(init_pri_api());
-        panda_require("dwarfp");
-        assert(init_dwarfp_api());
-
-        //PPP_REG_CB("pri", on_line_change, on_line_change);
-        PPP_REG_CB("pri", on_fn_start, on_fn_start);
-    #endif
-        return true;
-    }
-    void uninit_plugin(void *self) {
-    }
-
+    //PPP_REG_CB("pri", on_line_change, on_line_change);
+    PPP_REG_CB("pri", on_fn_start, on_fn_start);
+#endif
+    return true;
+}
+void uninit_plugin(void *self) {
+}
+```

--- a/panda/plugins/scissors/USAGE.md
+++ b/panda/plugins/scissors/USAGE.md
@@ -30,9 +30,10 @@ Example
 
 Snipping from instruction 12345 to 8675309 into `foo_reduced`:
 
-
-    $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
-        -panda scissors:name=foo_reduced,start=12345,end=8675309
+```sh
+$PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
+    -panda scissors:name=foo_reduced,start=12345,end=8675309
+```
 
 Bugs
 ----

--- a/panda/plugins/stringsearch/USAGE.md
+++ b/panda/plugins/stringsearch/USAGE.md
@@ -21,7 +21,6 @@ When a match is found, it is saved into `${NAME}_string_matches.txt` in a file l
     188b2992 1c9196fc 23d7f60a 3eb5b3c0  3
     1fd615c5 1fd621d8 23d80d9e 3eb5b3c0  8
 
-
 Arguments
 ---------
 
@@ -43,9 +42,11 @@ Name: **on_ssm**
 
 Signature:
 
-    typedef void (* on_ssm_t)(CPUState *env, target_ulong pc, target_ulong addr,
-                  uint8_t *matched_string, uint32_t matched_string_length, 
-                  bool is_write)
+```C
+typedef void (* on_ssm_t)(CPUState *env, target_ulong pc, target_ulong addr,
+                uint8_t *matched_string, uint32_t matched_string_length,
+                bool is_write)
+```
 
 Description: Called whenever a string match is observed. The callback is passed the CPU state, the value of the program counter when the match occurred, the actual string data that was matched (in case multiple search strings were used), the number of bytes in the matched string, and a flag indicating whether the match was seen during a read or a write.
 
@@ -58,7 +59,9 @@ To search for JPEG files being read or written in memory, create a file named `j
 
 Then run PANDA with stringsearch:
 
+```sh
     $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
         -panda callstack_instr -panda stringsearch:name=jpeg
+```
 
 Output will be placed in `jpeg_string_matches.txt` as well as being printed to the screen.

--- a/panda/plugins/syscalls2/USAGE.md
+++ b/panda/plugins/syscalls2/USAGE.md
@@ -31,25 +31,41 @@ In addition to the OS-specific system calls, there are four callbacks defined th
 
 Name: **on_unknown_sys_enter**
 
-Signature: `typedef void (*on_unknown_sys_enter_t)(CPUState *env, target_ulong pc, target_ulong callno)`
+Signature:
+
+```C
+typedef void (*on_unknown_sys_enter_t)(CPUState *env, target_ulong pc, target_ulong callno)
+```
 
 Description: Called when an unknown system call (i.e., one that does not have a callback already defined for it) is invoked in the guest. The system call number will be available in the `callno` parameter.
 
 Name: **on_unknown_sys_return**
 
-Signature: `typedef void (*on_unknown_sys_return_t)(CPUState *env, target_ulong pc, target_ulong callno)`
+Signature:
+
+```C
+typedef void (*on_unknown_sys_return_t)(CPUState *env, target_ulong pc, target_ulong callno)
+```
 
 Description: Called when an unknown system call (i.e., one that does not have a callback already defined for it) returns in the guest. The system call number will be available in the `callno` parameter.
 
 Name: **on_all_sys_enter**
 
-Signature: `typedef void (*on_all_sys_enter_t)(CPUState *env, target_ulong pc, target_ulong callno)`
+Signature:
+
+```C
+typedef void (*on_all_sys_enter_t)(CPUState *env, target_ulong pc, target_ulong callno)
+```
 
 Description: Called for every system call invoked in the guest. The call number is available in the `callno` parameter.
 
 Name: **on_all_sys_return**
 
-Signature: `typedef void (*on_all_sys_return_t)(CPUState *env, target_ulong pc, target_ulong callno)`
+Signature:
+
+```C
+typedef void (*on_all_sys_return_t)(CPUState *env, target_ulong pc, target_ulong callno)
+```
 
 Description: Called whenever any system call returns in the guest. The call number is available in the `callno` parameter.
 
@@ -95,7 +111,9 @@ bool init_plugin(void *self) {
 
 And then invoke it as:
 
-    $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
-        -panda syscalls2:profile=windows7_x86 -panda filereadmon
+```sh
+$PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
+    -panda syscalls2:profile=windows7_x86 -panda filereadmon
+```
 
 If you'd like more examples, you can have a look at `win7proc` and `file_taint`, which both use `syscalls2` extensively.


### PR DESCRIPTION
While reading the doc I wrapped various code snippets in their appropriate code blocks for syntax highlighting which (imo) significantly increases readability.
Also fixed a bunch of things to conform to the Markdown standard so my IDE would stop complaining.