### PR TITLE
Taint2: Added QuerySet, Removed C Incompatible Code

### DIFF
--- a/panda/plugins/taint2/USAGE.md
+++ b/panda/plugins/taint2/USAGE.md
@@ -67,10 +67,11 @@ Description: Called whenever the state of taint changes; i.e. when taint is prop
     uint32_t taint2_query_reg(int reg_num, int offset);
     uint32_t taint2_query_llvm(int reg_num, int offset);
 
-    // query set fns return taint set
-    LabelSetP taint2_query_set(Addr a);
-    LabelSetP taint2_query_set_ram(uint64_t pa);
-    LabelSetP taint2_query_set_reg(int reg_num, int offset);
+    // query set fns writes taint set contents to the specified array. the
+    // size of the array must be >= the cardianlity of the taint set.
+    void taint2_query_set(Addr a, uint32_t *out);
+    void taint2_query_set_ram(uint64_t pa, uint32_t *out);
+    void taint2_query_set_reg(int reg_num, int offset, uint32_t *out);
 
     // returns taint compute number associated with addr
     uint32_t taint2_query_tcn(Addr a);

--- a/panda/plugins/taint2/USAGE.md
+++ b/panda/plugins/taint2/USAGE.md
@@ -67,6 +67,11 @@ Description: Called whenever the state of taint changes; i.e. when taint is prop
     uint32_t taint2_query_reg(int reg_num, int offset);
     uint32_t taint2_query_llvm(int reg_num, int offset);
 
+    // query set fns return taint set
+    LabelSetP taint2_query_set(Addr a);
+    LabelSetP taint2_query_set_ram(uint64_t pa);
+    LabelSetP taint2_query_set_reg(int reg_num, int offset);
+
     // returns taint compute number associated with addr
     uint32_t taint2_query_tcn(Addr a);
     uint32_t taint2_query_tcn_ram(uint64_t pa);

--- a/panda/plugins/taint2/taint2_int_fns.h
+++ b/panda/plugins/taint2/taint2_int_fns.h
@@ -25,6 +25,11 @@ uint32_t taint2_query(Addr a);
 uint32_t taint2_query_ram(uint64_t pa);
 uint32_t taint2_query_reg(int reg_num, int offset);
 
+// query set fns return taint set
+LabelSetP taint2_query_set(Addr a);
+LabelSetP taint2_query_set_ram(uint64_t pa);
+LabelSetP taint2_query_set_reg(int reg_num, int offset);
+
 // returns taint compute number associated with addr
 uint32_t taint2_query_tcn(Addr a);
 uint32_t taint2_query_tcn_ram(uint64_t pa);

--- a/panda/plugins/taint2/taint2_int_fns.h
+++ b/panda/plugins/taint2/taint2_int_fns.h
@@ -25,10 +25,11 @@ uint32_t taint2_query(Addr a);
 uint32_t taint2_query_ram(uint64_t pa);
 uint32_t taint2_query_reg(int reg_num, int offset);
 
-// query set fns return taint set
-LabelSetP taint2_query_set(Addr a);
-LabelSetP taint2_query_set_ram(uint64_t pa);
-LabelSetP taint2_query_set_reg(int reg_num, int offset);
+// query set fns writes taint set contents to the specified array. the size of
+// the array must be >= the cardianlity of the taint set.
+void taint2_query_set(Addr a, uint32_t *out);
+void taint2_query_set_ram(uint64_t pa, uint32_t *out);
+void taint2_query_set_reg(int reg_num, int offset, uint32_t *out);
 
 // returns taint compute number associated with addr
 uint32_t taint2_query_tcn(Addr a);
@@ -45,9 +46,6 @@ void taint2_delete_ram(uint64_t pa);
 // delete taint from this register
 void taint2_delete_reg(int reg_num, int offset);
 
-// spit labelset.
-void taint2_labelset_spit(LabelSetP ls) ; 
-
 // addr is an opaque.  it should be &a if a is known to be an Addr
 void taint2_labelset_addr_iter(Addr addr, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 
@@ -59,9 +57,6 @@ void taint2_labelset_ram_iter(uint64_t pa, int (*app)(uint32_t el, void *stuff1)
 // you should be able to use R_EAX, etc as reg_num
 // offset is byte offset withing that reg.
 void taint2_labelset_reg_iter(int reg_num, int offset, int (*app)(uint32_t el, void *stuff1), void *stuff2);
-
-// ditto, but someone handed you the ls, e.g. a callback like tainted branch
-void taint2_labelset_iter(LabelSetP ls, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 
 // just tells how big that labels_applied set will be
 uint32_t taint2_num_labels_applied(void);
@@ -80,3 +75,4 @@ Panda__TaintQuery *taint2_query_pandalog (Addr addr, uint32_t offset);
 void pandalog_taint_query_free(Panda__TaintQuery *tq);
 
 #endif
+

--- a/panda/plugins/taint2/taint_api.cpp
+++ b/panda/plugins/taint2/taint_api.cpp
@@ -181,16 +181,34 @@ uint32_t taint2_query_reg(int reg_num, int offset) {
     return ls ? ls->size() : 0;
 }
 
-LabelSetP taint2_query_set(Addr a) {
-	return tp_labelset_get(a);
+extern "C" void taint2_query_set(Addr a, uint32_t *out) {
+	auto set = tp_labelset_get(a);
+	if (set == nullptr || set->empty()) return;
+
+	auto it = set->begin();
+	for (size_t i = 0; it != set->end(); ++i, ++it) {
+		out[i] = *it;
+	}
 }
 
-LabelSetP taint2_query_set_ram(uint64_t pa) {
-	return tp_labelset_get(make_maddr(pa));
+extern "C" void taint2_query_set_ram(uint64_t pa, uint32_t *out) {
+	auto set = tp_labelset_get(make_maddr(pa));
+	if (set == nullptr || set->empty()) return;
+
+	auto it = set->begin();
+	for (size_t i = 0; it != set->end(); ++i, ++it) {
+		out[i] = *it;
+	}
 }
 
-LabelSetP taint2_query_set_reg(int reg_num, int offset) {
-	return tp_labelset_get(make_greg(reg_num, offset));
+extern "C" void taint2_query_set_reg(int reg_num, int offset, uint32_t *out) {
+	auto set = tp_labelset_get(make_greg(reg_num, offset));
+	if (set == nullptr || set->empty()) return;
+
+	auto it = set->begin();
+	for (size_t i = 0; it != set->end(); ++i, ++it) {
+		out[i] = *it;
+	}
 }
 
 uint32_t taint2_query_tcn(Addr a) {
@@ -225,17 +243,6 @@ void taint2_delete_ram(uint64_t pa) {
 void taint2_delete_reg(int reg_num, int offset) {
     Addr a = make_greg(reg_num, offset);
     tp_delete(a);
-}
-
-void taint2_labelset_spit(LabelSetP ls) {
-    for (uint32_t l : *ls) {
-        printf("%u ", l);
-    }
-    printf("\n");
-}
-
-void taint2_labelset_iter(LabelSetP ls,  int (*app)(uint32_t el, void *stuff1), void *stuff2) {
-    tp_ls_iter(ls, app, stuff2);
 }
 
 void taint2_labelset_addr_iter(Addr a, int (*app)(uint32_t el, void *stuff1), void *stuff2) {
@@ -330,3 +337,4 @@ extern bool taintEnabled;
 int taint2_enabled() {
     return taintEnabled;
 }
+

--- a/panda/plugins/taint2/taint_api.cpp
+++ b/panda/plugins/taint2/taint_api.cpp
@@ -181,6 +181,18 @@ uint32_t taint2_query_reg(int reg_num, int offset) {
     return ls ? ls->size() : 0;
 }
 
+LabelSetP taint2_query_set(Addr a) {
+	return tp_labelset_get(a);
+}
+
+LabelSetP taint2_query_set_ram(uint64_t pa) {
+	return tp_labelset_get(make_maddr(pa));
+}
+
+LabelSetP taint2_query_set_reg(int reg_num, int offset) {
+	return tp_labelset_get(make_greg(reg_num, offset));
+}
+
 uint32_t taint2_query_tcn(Addr a) {
     return tp_query_full(a).tcn;
 }

--- a/panda/plugins/taint2/taint_api.h
+++ b/panda/plugins/taint2/taint_api.h
@@ -23,6 +23,9 @@ uint32_t taint2_query_ram(uint64_t pa);
 uint32_t taint2_query_reg(int reg_num, int offset);
 uint32_t taint2_query_llvm(int reg_num, int offset);
 
+LabelSetP taint2_query_set(Addr a);
+LabelSetP taint2_query_set_ram(uint64_t pa);
+LabelSetP taint2_query_set_reg(int reg_num, int offset);
 
 uint32_t taint2_query_tcn(Addr a);
 uint32_t taint2_query_tcn_ram(uint64_t pa);

--- a/panda/plugins/taint2/taint_api.h
+++ b/panda/plugins/taint2/taint_api.h
@@ -23,9 +23,9 @@ uint32_t taint2_query_ram(uint64_t pa);
 uint32_t taint2_query_reg(int reg_num, int offset);
 uint32_t taint2_query_llvm(int reg_num, int offset);
 
-LabelSetP taint2_query_set(Addr a);
-LabelSetP taint2_query_set_ram(uint64_t pa);
-LabelSetP taint2_query_set_reg(int reg_num, int offset);
+void taint2_query_set(Addr a, uint32_t *out);
+void taint2_query_set_ram(uint64_t pa, uint32_t *out);
+void taint2_query_set_reg(int reg_num, int offset, uint32_t *out);
 
 uint32_t taint2_query_tcn(Addr a);
 uint32_t taint2_query_tcn_ram(uint64_t pa);
@@ -34,15 +34,13 @@ uint32_t taint2_query_tcn_llvm(int reg_num, int offset);
 
 uint64_t taint2_query_cb_mask(Addr a, uint8_t size);
 
-void taint2_labelset_spit(LabelSetP ls);
-
 void taint2_labelset_addr_iter(Addr addr, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 void taint2_labelset_ram_iter(uint64_t pa, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 void taint2_labelset_reg_iter(int reg_num, int offset, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 void taint2_labelset_llvm_iter(int reg_num, int offset, int (*app)(uint32_t el, void *stuff1), void *stuff2);
-void taint2_labelset_iter(LabelSetP ls,  int (*app)(uint32_t el, void *stuff1), void *stuff2) ;
 
 uint32_t taint2_num_labels_applied(void);
 
 void taint2_track_taint_state(void);
 }
+


### PR DESCRIPTION
- Added query_set functions for the taint2 plugin which allow other plugins to get the label set containing all of the labels at some tainted RAM address or register. 
- Removed mentions of the LabelSetP data structure in the taint2_api since LabelSetP is incompatible with C code.