### PR TITLE
Pandalog off by one

### DIFF
--- a/panda/src/plog.c
+++ b/panda/src/plog.c
@@ -286,7 +286,6 @@ void pandalog_write_entry(Panda__LogEntry *entry) {
         >= thePandalog->chunk.buf + ((int)(floor(thePandalog->chunk.size)))) {
         uint32_t offset = thePandalog->chunk.buf_p - thePandalog->chunk.buf;
         uint32_t new_size = offset * 2;
-        printf ("reallocing chunk.buf to %d bytes\n", new_size);
         thePandalog->chunk.buf = (unsigned char *) realloc(thePandalog->chunk.buf, new_size);
         thePandalog->chunk.buf_p = thePandalog->chunk.buf + offset;
         assert (thePandalog->chunk.buf != NULL);

--- a/panda/src/plog.c
+++ b/panda/src/plog.c
@@ -481,35 +481,51 @@ void unmarshall_chunk(uint32_t chunk_num) {
     chunk->ind_entry = 0;  // a guess
 }
 
+// Reads an entry from the pandalog in fwd or bwd direction, updating chunk and index 
+// Returns NULL if all entries have been read 
 Panda__LogEntry *pandalog_read_entry(void) {
     assert (in_read_mode());
     PandalogChunk *plc = &(thePandalog->chunk);
-    uint8_t done = 0;
     uint8_t new_chunk = 0;
     uint32_t new_chunk_num;
+	Panda__LogEntry *returnEntry = plc->entry[plc->ind_entry];
+
     if (thePandalog->mode == PL_MODE_READ_FWD) {
-        if (plc->ind_entry == plc->num_entries-1) {
-            if (thePandalog->chunk_num == thePandalog->dir.max_chunks - 1) done = 1;
-            else {
+		if (plc->ind_entry > plc->num_entries-1){
+			return NULL;
+		} 
+		else if (plc->ind_entry == plc->num_entries-1) {
+			if (thePandalog->chunk_num == thePandalog->dir.max_chunks - 1) {
+				// if this is the last entry of the last chunk, return it and force next read to NULL 
+				plc->ind_entry++;
+				return returnEntry;
+			}   
+   			else {
+				// read the next chunk
                 new_chunk_num = thePandalog->chunk_num + 1;
                 new_chunk = 1;
             }
         }
         else plc->ind_entry ++;
     }
-    if (thePandalog->mode == PL_MODE_READ_BWD) {
-        if (plc->ind_entry == 0) {
-            if (thePandalog->chunk_num == 0) done = 1;
+    
+	if (thePandalog->mode == PL_MODE_READ_BWD) {
+		if (plc->ind_entry == -1){
+			return NULL;
+		}
+		else if (plc->ind_entry == 0) {
+			// if this is the first entry of the first chunk, return it and force next read to NULL
+			if (thePandalog->chunk_num == 0) {
+				plc->ind_entry--;
+				return returnEntry;
+			}
             else {
+				// read the next chunk
                 new_chunk_num = thePandalog->chunk_num - 1;
                 new_chunk = 1;
             }
         }
         else plc->ind_entry --;
-    }
-    if (done) {
-        // no more entries to read -- last chunk complete
-        return NULL;
     }
     if (new_chunk) {
         thePandalog->chunk_num = new_chunk_num;
@@ -517,11 +533,13 @@ Panda__LogEntry *pandalog_read_entry(void) {
         // can't use plc anymore
         plc = &(thePandalog->chunk);
         if (thePandalog->mode == PL_MODE_READ_FWD)
+			//reset ind_entry
             plc->ind_entry = 0;
         else
             plc->ind_entry = thePandalog->dir.num_entries[new_chunk_num]-1;
     }
-    return plc->entry[plc->ind_entry];
+
+	return returnEntry;
 }
 
 // binary search to find chunk for this instr
@@ -576,13 +594,15 @@ void pandalog_seek(uint64_t instr) {
     unmarshall_chunk(c);
     // figure out ind
     uint32_t ind = find_ind(instr, 0, thePandalog->dir.num_entries[c]-1);
-    if (thePandalog->mode == PL_MODE_READ_BWD) {
+	// if mode is BWD and we are not seeking from last instruction of chunk (-1)
+    if (thePandalog->mode == PL_MODE_READ_BWD && instr != -1) {
         // need *last* entry with that instr for backward mode
         uint32_t i;
-        //        uint8_t found_entry = 0;
         for (i=ind; i<thePandalog->dir.num_entries[c]; i++) {
             Panda__LogEntry *ple = thePandalog->chunk.entry[i];
-            if (ple->instr != instr || instr > ple->instr) {
+            if (ple->instr != instr) {
+				// we've gone past the last entry with that instr num
+				// backtrack by one and return
                 ind --;
                 break;
             }

--- a/panda/src/plog.c
+++ b/panda/src/plog.c
@@ -488,13 +488,15 @@ Panda__LogEntry *pandalog_read_entry(void) {
     PandalogChunk *plc = &(thePandalog->chunk);
     uint8_t new_chunk = 0;
     uint32_t new_chunk_num;
-    Panda__LogEntry *returnEntry = plc->entry[plc->ind_entry];
+    Panda__LogEntry *returnEntry;
 
     if (thePandalog->mode == PL_MODE_READ_FWD) {
         if (plc->ind_entry > plc->num_entries-1){
             return NULL;
         } 
-        else if (plc->ind_entry == plc->num_entries-1) {
+        
+        returnEntry = plc->entry[plc->ind_entry];
+        if (plc->ind_entry == plc->num_entries-1) {
             if (thePandalog->chunk_num == thePandalog->dir.max_chunks - 1) {
                 // if this is the last entry of the last chunk, return it and force next read to NULL 
                 plc->ind_entry++;
@@ -513,7 +515,9 @@ Panda__LogEntry *pandalog_read_entry(void) {
         if (plc->ind_entry == -1){
             return NULL;
         }
-        else if (plc->ind_entry == 0) {
+        
+        returnEntry = plc->entry[plc->ind_entry];
+        if (plc->ind_entry == 0) {
             // if this is the first entry of the first chunk, return it and force next read to NULL
             if (thePandalog->chunk_num == 0) {
                 plc->ind_entry--;

--- a/panda/src/plog.c
+++ b/panda/src/plog.c
@@ -286,6 +286,7 @@ void pandalog_write_entry(Panda__LogEntry *entry) {
         >= thePandalog->chunk.buf + ((int)(floor(thePandalog->chunk.size)))) {
         uint32_t offset = thePandalog->chunk.buf_p - thePandalog->chunk.buf;
         uint32_t new_size = offset * 2;
+        printf ("reallocing chunk.buf to %d bytes\n", new_size);
         thePandalog->chunk.buf = (unsigned char *) realloc(thePandalog->chunk.buf, new_size);
         thePandalog->chunk.buf_p = thePandalog->chunk.buf + offset;
         assert (thePandalog->chunk.buf != NULL);
@@ -488,20 +489,20 @@ Panda__LogEntry *pandalog_read_entry(void) {
     PandalogChunk *plc = &(thePandalog->chunk);
     uint8_t new_chunk = 0;
     uint32_t new_chunk_num;
-	Panda__LogEntry *returnEntry = plc->entry[plc->ind_entry];
+    Panda__LogEntry *returnEntry = plc->entry[plc->ind_entry];
 
     if (thePandalog->mode == PL_MODE_READ_FWD) {
-		if (plc->ind_entry > plc->num_entries-1){
-			return NULL;
-		} 
-		else if (plc->ind_entry == plc->num_entries-1) {
-			if (thePandalog->chunk_num == thePandalog->dir.max_chunks - 1) {
-				// if this is the last entry of the last chunk, return it and force next read to NULL 
-				plc->ind_entry++;
-				return returnEntry;
-			}   
-   			else {
-				// read the next chunk
+        if (plc->ind_entry > plc->num_entries-1){
+            return NULL;
+        } 
+        else if (plc->ind_entry == plc->num_entries-1) {
+            if (thePandalog->chunk_num == thePandalog->dir.max_chunks - 1) {
+                // if this is the last entry of the last chunk, return it and force next read to NULL 
+                plc->ind_entry++;
+                return returnEntry;
+            }   
+            else {
+                // read the next chunk
                 new_chunk_num = thePandalog->chunk_num + 1;
                 new_chunk = 1;
             }
@@ -509,18 +510,18 @@ Panda__LogEntry *pandalog_read_entry(void) {
         else plc->ind_entry ++;
     }
     
-	if (thePandalog->mode == PL_MODE_READ_BWD) {
-		if (plc->ind_entry == -1){
-			return NULL;
-		}
-		else if (plc->ind_entry == 0) {
-			// if this is the first entry of the first chunk, return it and force next read to NULL
-			if (thePandalog->chunk_num == 0) {
-				plc->ind_entry--;
-				return returnEntry;
-			}
+    if (thePandalog->mode == PL_MODE_READ_BWD) {
+        if (plc->ind_entry == -1){
+            return NULL;
+        }
+        else if (plc->ind_entry == 0) {
+            // if this is the first entry of the first chunk, return it and force next read to NULL
+            if (thePandalog->chunk_num == 0) {
+                plc->ind_entry--;
+                return returnEntry;
+            }
             else {
-				// read the next chunk
+                // read the next chunk
                 new_chunk_num = thePandalog->chunk_num - 1;
                 new_chunk = 1;
             }
@@ -533,13 +534,13 @@ Panda__LogEntry *pandalog_read_entry(void) {
         // can't use plc anymore
         plc = &(thePandalog->chunk);
         if (thePandalog->mode == PL_MODE_READ_FWD)
-			//reset ind_entry
+            //reset ind_entry
             plc->ind_entry = 0;
         else
             plc->ind_entry = thePandalog->dir.num_entries[new_chunk_num]-1;
     }
 
-	return returnEntry;
+    return returnEntry;
 }
 
 // binary search to find chunk for this instr
@@ -594,15 +595,15 @@ void pandalog_seek(uint64_t instr) {
     unmarshall_chunk(c);
     // figure out ind
     uint32_t ind = find_ind(instr, 0, thePandalog->dir.num_entries[c]-1);
-	// if mode is BWD and we are not seeking from last instruction of chunk (-1)
+    // if mode is BWD and we are not seeking from last instruction of chunk (-1)
     if (thePandalog->mode == PL_MODE_READ_BWD && instr != -1) {
         // need *last* entry with that instr for backward mode
         uint32_t i;
         for (i=ind; i<thePandalog->dir.num_entries[c]; i++) {
             Panda__LogEntry *ple = thePandalog->chunk.entry[i];
             if (ple->instr != instr) {
-				// we've gone past the last entry with that instr num
-				// backtrack by one and return
+                // we've gone past the last entry with that instr num
+                // backtrack by one and return
                 ind --;
                 break;
             }


### PR DESCRIPTION
Fixes bug in which first or last entries were not being read in fwd or bwd mode.

NULL was being returned, when instead an entry should be returned. 