### PR TITLE
Add support for kernel >= 3.3 to kernelinfo module.

### DIFF
--- a/panda/plugins/osi_linux/utils/kernelinfo/README.md
+++ b/panda/plugins/osi_linux/utils/kernelinfo/README.md
@@ -26,3 +26,10 @@ svn export https://github.com/panda-re/panda/trunk/panda/plugins/osi_linux/utils
 
 To compile the module, you will need to have installed the appropriate
 linux-headers package.
+
+## Kernels from v3.3-rc1 onwards
+
+As of [v3.3-rc1](https://github.com/torvalds/linux/releases/tag/v3.3-rc1), the structures `mnt_parent` and `mnt_mountpoint` were moved from `struct vfsmount` to `struct mount`. `struct mount` is defined in `/fs/mount.h` of the kernel source which is not included in the `linux-headers` package. Consequently, [`mount.h` from kernel 4.12](https://github.com/torvalds/linux/blob/6f7da290413ba713f0cdd9ff1a2a9bb129ef4f6c/fs/mount.h#L33) was added to this folder.
+
+### Here be dragons! `__randomize_layout`
+As of [v4.13-rc2](https://github.com/torvalds/linux/releases/tag/v4.13-rc2), `struct mount` (in `mount.h`) includes [the `__randomize_layout` annotation](https://lwn.net/Articles/723997/). We don't *think* this breaks anything, but it might be the case that the offsets are not transferrable between different builds of the same kernel.

--- a/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo.c
+++ b/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo.c
@@ -19,6 +19,11 @@
 #include <linux/fdtable.h>
 #include <linux/dcache.h>
 #include <linux/mount.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,0)
+#include "mount.h"
+#endif
 
 /*
  * This function is used because to print offsets of members
@@ -76,6 +81,13 @@ int init_module(void)
 	struct thread_info *ti_p;
 	struct files_struct *fss_p;
 	struct vfsmount *vfsmnt_p;
+
+// Put it here because ISO C90
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,0)
+	struct mount mountstruct;
+	struct mount *mnt_p;
+	mnt_p = &mountstruct;
+#endif
 
 	ts_p = &init_task;
 	cs_p = &credstruct;
@@ -135,9 +147,14 @@ int init_module(void)
 	PRINT_OFFSET(fs_p,		f_path.dentry,	"fs");
 	PRINT_OFFSET(fs_p,		f_path.mnt,		"fs");
     PRINT_OFFSET(fs_p,      f_pos,          "fs");
+	PRINT_OFFSET(vfsmnt_p,	mnt_root,		"fs");	/* XXX: We don't use this anywhere. Marked for removal. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,0)
+	PRINT_OFFSET(mnt_p,		mnt_parent,		"fs");
+	PRINT_OFFSET(mnt_p,		mnt_mountpoint, "fs");
+#else
 	PRINT_OFFSET(vfsmnt_p,	mnt_parent,		"fs");
 	PRINT_OFFSET(vfsmnt_p,	mnt_mountpoint, "fs");
-	PRINT_OFFSET(vfsmnt_p,	mnt_root,		"fs");	/* XXX: We don't use this anywhere. Marked for removal. */
+#endif
 
 	/* used in reading FDs */
 	PRINT_OFFSET(fss_p,	fdt,			"fs");

--- a/panda/plugins/osi_linux/utils/kernelinfo/mount.h
+++ b/panda/plugins/osi_linux/utils/kernelinfo/mount.h
@@ -1,0 +1,146 @@
+#include <linux/mount.h>
+#include <linux/seq_file.h>
+#include <linux/poll.h>
+#include <linux/ns_common.h>
+#include <linux/fs_pin.h>
+
+struct mnt_namespace {
+	atomic_t		count;
+	struct ns_common	ns;
+	struct mount *	root;
+	struct list_head	list;
+	struct user_namespace	*user_ns;
+	struct ucounts		*ucounts;
+	u64			seq;	/* Sequence number to prevent loops */
+	wait_queue_head_t poll;
+	u64 event;
+	unsigned int		mounts; /* # of mounts in the namespace */
+	unsigned int		pending_mounts;
+};
+
+struct mnt_pcp {
+	int mnt_count;
+	int mnt_writers;
+};
+
+struct mountpoint {
+	struct hlist_node m_hash;
+	struct dentry *m_dentry;
+	struct hlist_head m_list;
+	int m_count;
+};
+
+struct mount {
+	struct hlist_node mnt_hash;
+	struct mount *mnt_parent;
+	struct dentry *mnt_mountpoint;
+	struct vfsmount mnt;
+	union {
+		struct rcu_head mnt_rcu;
+		struct llist_node mnt_llist;
+	};
+#ifdef CONFIG_SMP
+	struct mnt_pcp __percpu *mnt_pcp;
+#else
+	int mnt_count;
+	int mnt_writers;
+#endif
+	struct list_head mnt_mounts;	/* list of children, anchored here */
+	struct list_head mnt_child;	/* and going through their mnt_child */
+	struct list_head mnt_instance;	/* mount instance on sb->s_mounts */
+	const char *mnt_devname;	/* Name of device e.g. /dev/dsk/hda1 */
+	struct list_head mnt_list;
+	struct list_head mnt_expire;	/* link in fs-specific expiry list */
+	struct list_head mnt_share;	/* circular list of shared mounts */
+	struct list_head mnt_slave_list;/* list of slave mounts */
+	struct list_head mnt_slave;	/* slave list entry */
+	struct mount *mnt_master;	/* slave is on master->mnt_slave_list */
+	struct mnt_namespace *mnt_ns;	/* containing namespace */
+	struct mountpoint *mnt_mp;	/* where is it mounted */
+	struct hlist_node mnt_mp_list;	/* list mounts with the same mountpoint */
+#ifdef CONFIG_FSNOTIFY
+	struct fsnotify_mark_connector __rcu *mnt_fsnotify_marks;
+	__u32 mnt_fsnotify_mask;
+#endif
+	int mnt_id;			/* mount identifier */
+	int mnt_group_id;		/* peer group identifier */
+	int mnt_expiry_mark;		/* true if marked for expiry */
+	struct hlist_head mnt_pins;
+	struct fs_pin mnt_umount;
+	struct dentry *mnt_ex_mountpoint;
+};
+
+#define MNT_NS_INTERNAL ERR_PTR(-EINVAL) /* distinct from any mnt_namespace */
+
+static inline struct mount *real_mount(struct vfsmount *mnt)
+{
+	return container_of(mnt, struct mount, mnt);
+}
+
+static inline int mnt_has_parent(struct mount *mnt)
+{
+	return mnt != mnt->mnt_parent;
+}
+
+static inline int is_mounted(struct vfsmount *mnt)
+{
+	/* neither detached nor internal? */
+	return !IS_ERR_OR_NULL(real_mount(mnt)->mnt_ns);
+}
+
+extern struct mount *__lookup_mnt(struct vfsmount *, struct dentry *);
+
+extern int __legitimize_mnt(struct vfsmount *, unsigned);
+extern bool legitimize_mnt(struct vfsmount *, unsigned);
+
+static inline bool __path_is_mountpoint(const struct path *path)
+{
+	struct mount *m = __lookup_mnt(path->mnt, path->dentry);
+	return m && likely(!(m->mnt.mnt_flags & MNT_SYNC_UMOUNT));
+}
+
+extern void __detach_mounts(struct dentry *dentry);
+
+static inline void detach_mounts(struct dentry *dentry)
+{
+	if (!d_mountpoint(dentry))
+		return;
+	__detach_mounts(dentry);
+}
+
+static inline void get_mnt_ns(struct mnt_namespace *ns)
+{
+	atomic_inc(&ns->count);
+}
+
+extern seqlock_t mount_lock;
+
+static inline void lock_mount_hash(void)
+{
+	write_seqlock(&mount_lock);
+}
+
+static inline void unlock_mount_hash(void)
+{
+	write_sequnlock(&mount_lock);
+}
+
+struct proc_mounts {
+	struct mnt_namespace *ns;
+	struct path root;
+	int (*show)(struct seq_file *, struct vfsmount *);
+	void *cached_mount;
+	u64 cached_event;
+	loff_t cached_index;
+};
+
+extern const struct seq_operations mounts_op;
+
+extern bool __is_local_mountpoint(struct dentry *dentry);
+static inline bool is_local_mountpoint(struct dentry *dentry)
+{
+	if (!d_mountpoint(dentry))
+		return false;
+
+	return __is_local_mountpoint(dentry);
+}


### PR DESCRIPTION
As discussed in [issue#194](https://github.com/panda-re/panda/issues/194), from kernel 3.3-rc1 the `mnt_mountpoint` and `mnt_parent` members were moved from `struct vfsmount` to `struct mount`. This broke `kernelinfo`.

These commits add support for the newer kernels whilst maintaining backwards compatibility with the older kernels.

Documentation also updated accordingly.