### PR TITLE
Allow launching panda through path

### DIFF
--- a/panda/llvm/helper_runtime.cpp
+++ b/panda/llvm/helper_runtime.cpp
@@ -151,7 +151,9 @@ void PandaHelperCallVisitor::visitCallInst(CallInst &I) {
 
 } // namespace llvm
 
-extern const char **gargv;
+// resolved full path to the current executable
+extern const char *qemu_file;
+
 /*
  * Start the process of including the execution of QEMU helper functions in the
  * LLVM JIT.
@@ -170,7 +172,7 @@ void init_llvm_helpers() {
     llvm::LLVMContext &ctx = mod->getContext();
 
     // Read helper module, link into JIT, verify
-    char *exe = strdup(gargv[0]);
+    char *exe = strdup(qemu_file);
     std::string bitcode(dirname(exe));
     free(exe);
     bitcode.append("/llvm-helpers.bc");

--- a/panda/plugins/memsavep/USAGE.md
+++ b/panda/plugins/memsavep/USAGE.md
@@ -11,7 +11,7 @@ Once the given point in the replay has been reached and the memory has been dump
 Arguments
 ---------
 
-`memsavep` accepts two arguments: a given point in the program, expressed with either `percent` or `instr_count`, and a filename
+`memsavep` accepts two arguments: a given point in the program, expressed with either `percent` or `instrcount`, and a filename
 
 * `percent`: double, defaults to 200 (do not dump at percent). The percentage of the replay at which we should dump memory.
 * `instrcount`: uint64, defaults to 0 (do not dump at instrcount). The instruction count of the replay at which we should dump memory.
@@ -38,4 +38,4 @@ To dump memory at 66.2% to `mymem.dd`:
 To dump memory when an instruction count of 3314667015 is reached: 
 
     $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
-        -panda memsavep:instr_count=3314667015,file=mymem.dd
+        -panda memsavep:instrcount=3314667015,file=mymem.dd

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -136,7 +136,7 @@ int vmi_pgd_changed(CPUState *cpu, target_ulong oldval, target_ulong newval) {
 }
 #endif
 
-extern char **gargv;
+extern const char *qemu_file;
 
 bool init_plugin(void *self) {
 #ifdef OSI_PROC_EVENTS
@@ -147,7 +147,7 @@ bool init_plugin(void *self) {
     assert (!(panda_os_type == OST_UNKNOWN));
     if (panda_os_type == OST_LINUX) {
         // sadly, all of this is to find kernelinfo.conf file
-        gchar *progname = gargv[0];
+        const gchar *progname = qemu_file;
         gchar *progname_path;
         gchar *progdir;
 

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -59,7 +59,7 @@ PPP_CB_BOILERPLATE(on_ptr_store);
 
 }
 
-extern char **gargv;
+extern const char *qemu_file;
 
 // Helper methods for doing structure computations.
 #define cpu_off(member) (uint64_t)(&((CPUArchState *)0)->member)
@@ -123,7 +123,7 @@ static void taint_storeEip_run(FastShad *shad, uint64_t src, uint64_t size) {
 extern "C" { extern TCGLLVMContext *tcg_llvm_ctx; }
 bool PandaTaintFunctionPass::doInitialization(Module &M) {
     // Add taint functions to module
-    char *exe = strdup(gargv[0]);
+    char *exe = strdup(qemu_file);
     std::string bitcode(dirname(exe));
     free(exe);
     bitcode.append("/panda/plugins/panda_taint2_ops.bc");


### PR DESCRIPTION
addresses #209 
In vl.c, `qemu_file` is now set by trying the readlink method first (linux only), and the old realpath method as fallback. Some plugins are also updated to refer directly to `qemu_file` instead of `gargv[0]`.