### PR TITLE
updating README.md to reflect realities of osi

### DIFF
--- a/panda/plugins/osi/USAGE.md
+++ b/panda/plugins/osi/USAGE.md
@@ -130,7 +130,7 @@ Description: Called whenever a process exits in the guest. Passes in an `OsiProc
 Data structures used by OSI:
 
 ```C
-    // Represents a page of memory
+    // Represents a page of memory (TODO in osi_linux)
     typedef struct osi_page_struct {
         target_ulong start;
         target_ulong len;
@@ -141,7 +141,7 @@ Data structures used by OSI:
         target_ulong offset;
         char *name;
         target_ulong asid;
-        OsiPage *pages;
+        OsiPage *pages;     // TODO in osi_linux
         target_ulong pid;
         target_ulong ppid;
     } OsiProc;


### PR DESCRIPTION
At the moment pages are not implemented in the osi or osi_linux plugins. https://github.com/panda-re/panda/blob/b5dbe2b8b8dc4aa217c9bd1557444ec61ad23fc0/panda/plugins/osi_linux/osi_linux.cpp#L130 It would be helpful that the readme mention something about it. It could be either here or in osi_linux, but I think it would be helpful for it to be mentioned somewhere. This commit accomplishes that. Thanks.