### PR TITLE
fix callstack_instr 64bit init + build fixes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -640,7 +640,7 @@ TAGS:
 
 cscope:
 	rm -f "$(SRC_PATH)"/cscope.*
-	find "$(SRC_PATH)/" -name "*.[chsS]" -print | sed 's,^\./,,' > "$(SRC_PATH)/cscope.files"
+	find "$(SRC_PATH)/" \( -name "*.[chsS]" -o -name '*.cpp' \) -print | sed 's,^\./,,' > "$(SRC_PATH)/cscope.files"
 	cscope -b -i"$(SRC_PATH)/cscope.files"
 
 # opengl shader programs

--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,7 @@ fi
     --disable-vhost-net \
     --target-list=x86_64-softmmu,i386-softmmu,arm-softmmu,ppc-softmmu \
     --prefix="$(pwd)/install" \
+    --python=python2 \
     $LLVM_BIT \
     "$@"
 

--- a/configure
+++ b/configure
@@ -5573,8 +5573,9 @@ if test "$virglrenderer" = "yes" ; then
 fi
 
 if test "$llvm" = "yes" ; then
+    FILTERFLAGS="-pedantic"
   if test "$debug" = "yes" ; then
-     FILTERFLAGS="-O2 -O1 -O3 -fomit-frame-pointer"
+     FILTERFLAGS="$FILTERFLAGS -O2 -O1 -O3 -fomit-frame-pointer"
   fi
 
   echo "CLANG_CXXFLAGS:=$clang_cxxflags" >> $config_host_mak

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -370,15 +370,18 @@ void get_prog_point(CPUState* cpu, prog_point *p) {
 bool init_plugin(void *self) {
 #if defined(TARGET_I386)
     if (cs_open(CS_ARCH_X86, CS_MODE_32, &cs_handle_32) != CS_ERR_OK)
+        return false;
 #if defined(TARGET_X86_64)
     if (cs_open(CS_ARCH_X86, CS_MODE_64, &cs_handle_64) != CS_ERR_OK)
+        return false;
 #endif
 #elif defined(TARGET_ARM)
     if (cs_open(CS_ARCH_ARM, CS_MODE_ARM, &cs_handle_32) != CS_ERR_OK)
+        return false;
 #elif defined(TARGET_PPC)
     if (cs_open(CS_ARCH_PPC, CS_MODE_32, &cs_handle_32) != CS_ERR_OK)
-#endif
         return false;
+#endif
 
     // Need details in capstone to have instruction groupings
     cs_option(cs_handle_32, CS_OPT_DETAIL, CS_OPT_ON);

--- a/panda/plugins/callstack_instr/prog_point.h
+++ b/panda/plugins/callstack_instr/prog_point.h
@@ -31,7 +31,6 @@ struct prog_point {
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
 
-#include <functional>
 struct hash_prog_point{
     size_t operator()(const prog_point &p) const
     {


### PR DESCRIPTION
Hi,

Here's a pull request with a few build fixes + a fix on callstack_instr.

The patch in callstack_instr fixes the bug that capstone's 64bit cs_open is only done if the 32bit init fails.

```
if (cs_open(CS_ARCH_X86, CS_MODE_32, &cs_handle_32) != CS_ERR_OK)
    if (cs_open(CS_ARCH_X86, CS_MODE_64, &cs_handle_64) != CS_ERR_OK)
```

Cheers,
Pierre