### PR TITLE
Simplified processing of -os option parsing.

### DIFF
--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -660,7 +660,7 @@ dynamically loaded. Thus, even if Plugin A has a function intended to be called
 by another plugin, it is painful to obtain access to that function from Plugin B
 (hint: `dlsym` is involved). Further, the code necessary to iterate over a
 sequence of callbacks is annoying and formulaic.Software engineering to the
-rescue! `panda_plugin_plugin.h` provides a number of convenient macros that
+rescue! `panda/plugin_plugin.h` provides a number of convenient macros that
 simplify arranging for these two types of plugin interaction. Here is how to use
 them.
 
@@ -740,9 +740,9 @@ following.
 
 5. In the same file you edited in 3, in the `extern "C" {` portion near the top
    of the file, add `PPP_PROT_REG_CB(foo);`. For more information on this, see
-   `panda_plugin_plugin.h`.
+   `panda/plugin_plugin.h`.
 
-6. Remember to `#include "panda_plugin_plugin.h"` at the top of the edited
+6. Remember to `#include "panda/plugin_plugin.h"` at the top of the edited
    source file.
 
 In order to register a callback with Plugin A that is defined in Plugin B, all

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -83,7 +83,7 @@ Example
 
 ```C
 #include "../callstack_instr/callstack_instr_ext.h"
-#include "panda_plugin_plugin.h"
+#include "panda/plugin_plugin.h"
 
 // ...
 

--- a/panda/plugins/syscalls2/USAGE.md
+++ b/panda/plugins/syscalls2/USAGE.md
@@ -113,7 +113,7 @@ And then invoke it as:
 
 ```sh
 $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
-    -panda syscalls2:profile=windows7_x86 -panda filereadmon
+    -os windows-32-7 -panda syscalls2:profile=windows7_x86 -panda filereadmon
 ```
 
 If you'd like more examples, you can have a look at `win7proc` and `file_taint`, which both use `syscalls2` extensively.

--- a/panda/plugins/syscalls2/USAGE.md
+++ b/panda/plugins/syscalls2/USAGE.md
@@ -77,7 +77,7 @@ In general one uses `syscalls2` with another plugin that registers callbacks for
 ```C
 #include "../syscalls2/gen_syscalls_ext_typedefs.h"
 #include "../syscalls2/syscalls_common.h"
-#include "panda_plugin_plugin.h"
+#include "panda/plugin_plugin.h"
 
 void my_NtReadFile_enter(
         CPUState* env,

--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -506,7 +506,7 @@ bool init_plugin(void *self) {
 #if defined(TARGET_I386) || defined(TARGET_ARM)
 
     if(panda_os_type == OST_UNKNOWN){
-        std::cerr << "syscalls2: ERROR No OS profile specified. You can choose one with the -os switch, eg: '-os linux' or '-os  windows-32-7' " << std::endl;
+        std::cerr << "syscalls2: ERROR No OS profile specified. You can choose one with the -os switch, eg: '-os linux-32-debian-3.2.81-486' or '-os  windows-32-7' " << std::endl;
         return false;
     }
 


### PR DESCRIPTION
Instead of splitting the option and then checking the individual components, now the options is first as a whole to be valid. Then the individual components are parsed.

Also fixed some minor documentation errors.