### PR TITLE
Record VAPIC Memory Writes

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -2929,6 +2929,9 @@ static inline void cpu_physical_memory_write_rom_internal(AddressSpace *as,
             ptr = qemu_map_ram_ptr(mr->ram_block, addr1);
             switch (type) {
             case WRITE_DATA:
+                if (rr_in_record() && (rr_record_in_progress || rr_record_in_main_loop_wait)) {
+                    rr_device_mem_rw_call_record(addr1, buf, l, 1);
+                }
                 memcpy(ptr, buf, l);
                 invalidate_and_set_dirty(mr, addr1, l);
                 break;

--- a/panda/scripts/diverge.py
+++ b/panda/scripts/diverge.py
@@ -116,7 +116,7 @@ class RRInstance(object):
 
     @cached_property
     def arch(self):
-        rr_ps = check_output(['rr', 'ps', self.rr_replay])
+        rr_ps = check_output([cli_args.rr, 'ps', self.rr_replay])
         qemu_regex = r"qemu-system-({})".format("|".join(SUPPORTED_ARCHS.keys()))
         re_result = re.search(qemu_regex, rr_ps)
         if not re_result: raise RuntimeError("Unsupported architecture!")


### PR DESCRIPTION
We have a fix for #225. It appears that PANDA was not recording changes to the guest memory where the VAPIC was mapped.

We also have a fix for the diverge.py script that we used to discover this bug.