### PR TITLE
Scissors fix

### DIFF
--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -745,15 +745,13 @@ int cpu_exec(CPUState *cpu)
 
     for(;;) {
 
-        if (panda_exit_loop) break;       
-
         /* prepare setjmp context for exception handling */
         if (sigsetjmp(cpu->jmp_env, 0) == 0) {
             TranslationBlock *tb, *last_tb = NULL;
             int tb_exit = 0;
 
             /* if an exception is pending, we execute it here */
-            if (cpu_handle_exception(cpu, &ret)) {
+            if (cpu_handle_exception(cpu, &ret) || panda_exit_loop) {
                 break;
             }
 

--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -717,7 +717,7 @@ static void detect_infinite_loops(void) {
 int cpu_exec(CPUState *cpu)
 {
     CPUClass *cc = CPU_GET_CLASS(cpu);
-    int ret;
+    int ret = 0;
     SyncClocks sc;
 
     /* replay_interrupt may need current_cpu */

--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -751,9 +751,10 @@ int cpu_exec(CPUState *cpu)
             int tb_exit = 0;
 
             /* if an exception is pending, we execute it here */
-            if (cpu_handle_exception(cpu, &ret) || panda_exit_loop) {
+            if (cpu_handle_exception(cpu, &ret)) {
                 break;
             }
+            if (panda_exit_loop) break;                
 
             for(;;) {
 

--- a/panda/include/panda/callback_support.h
+++ b/panda/include/panda/callback_support.h
@@ -31,4 +31,6 @@ void panda_callbacks_asid_changed(CPUState *env, target_ulong old_asid, target_u
 // vl.c
 void panda_callbacks_after_machine_init(void);
 
+void panda_callbacks_top_loop(void);
+
 #endif

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -76,6 +76,8 @@ typedef enum panda_cb_type {
     PANDA_CB_REPLAY_HANDLE_PACKET,   // in replay, packet in / out
     PANDA_CB_AFTER_MACHINE_INIT,     // Right after the machine is initialized, before any code runs
 
+    PANDA_CB_TOP_LOOP,               // at top of loop that manages emulation.  good place to take a snapshot
+
     PANDA_CB_LAST
 } panda_cb_type;
 
@@ -588,6 +590,8 @@ typedef union panda_cb {
   int (*replay_net_transfer)(CPUState *env, uint32_t type, uint64_t src_addr, uint64_t dest_addr, uint32_t num_bytes);
 
   void (*after_machine_init)(CPUState *env);
+
+  void (*top_loop)(CPUState *env);
 
 } panda_cb;
 

--- a/panda/include/panda/rr/rr_log.h
+++ b/panda/include/panda/rr/rr_log.h
@@ -196,4 +196,6 @@ static inline uint64_t rr_num_instr_before_next_interrupt(void) {
 uint32_t rr_checksum_memory(void);
 uint32_t rr_checksum_regs(void);
 
+bool rr_queue_empty(void);
+
 #endif

--- a/panda/src/callback_support.c
+++ b/panda/src/callback_support.c
@@ -216,6 +216,15 @@ void panda_callbacks_after_machine_init(void) {
     }
 }
 
+void panda_callbacks_top_loop(void) {
+    panda_cb_list *plist;
+    for(plist = panda_cbs[PANDA_CB_TOP_LOOP]; plist != NULL;
+        plist = panda_cb_list_next(plist)) {
+        plist->entry.top_loop(first_cpu);
+    }
+}
+
+
 // target-i386/misc_helpers.c
 void panda_callbacks_cpuid(CPUState *env) {
     panda_cb_list *plist;

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -68,6 +68,8 @@ bool panda_help_wanted = false;
 bool panda_plugin_load_failed = false;
 bool panda_abort_requested = false;
 
+bool panda_exit_loop = false;
+
 bool panda_add_arg(const char *plugin_name, const char *plugin_arg) {
     if (plugin_name == NULL)    // PANDA argument
         panda_argv[panda_argc++] = g_strdup(plugin_arg);


### PR DESCRIPTION
This somewhat considerable rewrite of scissors seems to fix it.  As in now only 2 failures out of 6000 random scissorings.  These are some infinite loop nonsense.

Two big changes to scissors.  First is that it now sets a global to force exit of nested emulation loop in before_block callback at bb closest to start / end snip.  It does this in order to be able to take a snapshot from same kind of place that snapshots are typically taken by monitor or record.  The hope is this would be more reliable.  This also entailed adding a new panda callback, TOP_LOOP, in cpus.c at top of while(1) loop in qemu_tcg_cpu_thread_fn().  This somewhat elaborate fix means scissoring is now quite precise.  Actual start / end instr we snip at are within a few instr of requests.  So that's nice.  Second change to scissors was related.  At start of snip, scissors copies all the nondet log entries it thinks it needs to the new log.  But it uses the end instr count specified as arg to scissors to figure out how many items to copy.  Unfortunately, that can be wrong since actual end instr count can be different by a few instructions still.  So I fixed this by detecting when this is the case at end snip point and copying a few more nd log entries.

Again, it seems to work well and now only 2 random scissorings out of 6000 fail.   