### PR TITLE
Ubuntu 18.04LTS support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,51 +1,96 @@
 #!/bin/bash
 
+# Prefer greadlink over readlink if present. Important for OSX (incompatible readlink).
+if type greadlink >/dev/null 2>&1; then
+    READLINK=greadlink
+else
+    READLINK=readlink
+fi
+
 # Get the location of the LLVM compiled for PANDA, respecting environment variables.
 PANDA_LLVM_ROOT="${PANDA_LLVM_ROOT:-$(dirname $0)/../llvm}"
 PANDA_LLVM_BUILD="${PANDA_LLVM_BUILD:-Release}"
-PANDA_LLVM="$(/bin/readlink -f "${PANDA_LLVM_ROOT}/${PANDA_LLVM_BUILD}" 2>/dev/null)"
+PANDA_LLVM="$("$READLINK" -f "${PANDA_LLVM_ROOT}/${PANDA_LLVM_BUILD}" 2>/dev/null)"
 
 # stop on any error
 set -e
 
-#Check if the path actually exists
+### Check gcc/g++ versions. 5 is currently the supported version.
+### PANDA no longer builds with versions 4.x.
+### Versions >5 may not compile due to more aggressive sanitization defaults.
+GCC_TOOLCHAIN_VERSION_REQ=5
+GCC_VERSION_MAJOR=$(gcc -dumpversion | cut -d. -f1)
+GCXX_VERSION_MAJOR=$(g++ -dumpversion | cut -d. -f1)
+if [ $GCC_VERSION_MAJOR -eq $GCC_TOOLCHAIN_VERSION_REQ -a $GCXX_VERSION_MAJOR -ge $GCC_TOOLCHAIN_VERSION_REQ ]; then
+    echo "Building with default gcc/g++."
+    COMPILER_CONFIG=""
+elif (type gcc-$GCC_TOOLCHAIN_VERSION_REQ && type g++-$GCC_TOOLCHAIN_VERSION_REQ) >/dev/null 2>&1; then
+    echo "Building with gcc-$GCC_TOOLCHAIN_VERSION_REQ/g++-$GCC_TOOLCHAIN_VERSION_REQ."
+    COMPILER_CONFIG="--cc=gcc-$GCC_TOOLCHAIN_VERSION_REQ --cxx=g++-$GCC_TOOLCHAIN_VERSION_REQ"
+else
+    echo "No suitable gcc/g++ found -- ABORTING"
+    exit 1
+fi
+
+### Check for protobuf v2.
+if pkg-config --exists protobuf "protobuf > 1 protobuf < 3"; then
+    echo "Using protobuf $(pkg-config --modversion protobuf)."
+else
+    echo "Found incompatible protobuf $(pkg-config --modversion protobuf) -- ABORTING"
+    echo "See panda/docs/compile.md for instructions on building protobuf v2."
+    exit 1
+fi
+
+### Check that PANDA_LLVM is correct and attempt to fix it if not.
 if [ "$PANDA_LLVM" != "" ] && [ ! -d "$PANDA_LLVM" ]; then
     echo "$PANDA_LLVM does not exist"
     if [ -f "$PANDA_LLVM_ROOT/bin/llvm-config" ]; then
         echo "llvm-config found in ${PANDA_LLVM_ROOT}/bin/llvm-config, setting llvm path to just $PANDA_LLVM_ROOT"
-        PANDA_LLVM="$(/bin/readlink -f "${PANDA_LLVM_ROOT}")"
+        PANDA_LLVM="$("$READLINK" -f "${PANDA_LLVM_ROOT}")"
     else
         echo "$PANDA_LLVM_ROOT/bin/llvm-config not found either, are you sure that PANDA_LLVM_ROOT is correct?"
         PANDA_LLVM=""
     fi
 
 fi
-# set the LLVM_BIT
+
+### Set LLVM_CONFIG to be used with the configure script.
 if [ "$PANDA_LLVM" != "" ]; then
-  ## Using PANDA LLVM.
-  echo "Found PANDA LLVM on ${PANDA_LLVM_ROOT} -- LLVM SUPPORT IS ENABLED"
-  LLVM_BIT="--enable-llvm --with-llvm=${PANDA_LLVM}"
+    ## Using PANDA LLVM.
+    echo "Found PANDA LLVM on ${PANDA_LLVM_ROOT} -- LLVM SUPPORT IS ENABLED"
+    LLVM_CONFIG="--enable-llvm --with-llvm=${PANDA_LLVM}"
 else
   ## Fallback to system LLVM.
-  if llvm-config --version >/dev/null 2>/dev/null && [ $(llvm-config --version) == "3.3" ]; then
-    echo "Found SYSTEM LLVM -- LLVM SUPPORT IS ENABLED"
-    LLVM_BIT="--enable-llvm --with-llvm=$(llvm-config --prefix)"
-  elif llvm-config-3.3 --version >/dev/null 2>/dev/null; then
-    echo "Found SYSTEM LLVM -- LLVM SUPPORT IS ENABLED"
-    LLVM_BIT="--enable-llvm --with-llvm=$(llvm-config-3.3 --prefix)"
-  else
-    echo "No suitable LLVM found -- LLVM SUPPORT IS DISABLED"
-    LLVM_BIT=""
-  fi
+    if llvm-config --version >/dev/null 2>/dev/null && [ $(llvm-config --version) == "3.3" ]; then
+        echo "Found SYSTEM LLVM -- LLVM SUPPORT IS ENABLED"
+        LLVM_CONFIG="--enable-llvm --with-llvm=$(llvm-config --prefix)"
+    elif llvm-config-3.3 --version >/dev/null 2>/dev/null; then
+        echo "Found SYSTEM LLVM -- LLVM SUPPORT IS ENABLED"
+        LLVM_CONFIG="--enable-llvm --with-llvm=$(llvm-config-3.3 --prefix)"
+    else
+        echo "No suitable LLVM found -- LLVM SUPPORT IS DISABLED"
+        LLVM_CONFIG=""
+    fi
 fi
 
+### Set other configuration flags, depending on environment.
+MISC_CONFIG="--python=python2 --disable-vhost-net"
+if pkg-config --exists --atleast-version 4.9 xencontrol; then
+    ## Enable xencontrol compat API for libxen-4.9 (Ubuntu 18.04LTS).
+    MISC_CONFIG="$MISC_CONFIG --extra-cflags=-DXC_WANT_COMPAT_DEVICEMODEL_API"
+
+    ## Alternatively disable Xen altogether and wait for an upstream fix.
+    #MISC_CONFIG="$MISC_CONFIG --disable-xen"
+fi
 
 "$(dirname $0)/configure" \
-    --disable-vhost-net \
     --target-list=x86_64-softmmu,i386-softmmu,arm-softmmu,ppc-softmmu \
     --prefix="$(pwd)/install" \
-    --python=python2 \
-    $LLVM_BIT \
+    $COMPILER_CONFIG \
+    $LLVM_CONFIG \
+    $MISC_CONFIG \
     "$@"
 
 make -j ${PANDA_NPROC:-$(nproc || sysctl -n hw.ncpu)}
+
+# vim: set et ts=4 sts=4 sw=4 ai ft=sh :

--- a/build.sh
+++ b/build.sh
@@ -28,8 +28,8 @@ elif (type gcc-$GCC_TOOLCHAIN_VERSION_REQ && type g++-$GCC_TOOLCHAIN_VERSION_REQ
     echo "Building with gcc-$GCC_TOOLCHAIN_VERSION_REQ/g++-$GCC_TOOLCHAIN_VERSION_REQ."
     COMPILER_CONFIG="--cc=gcc-$GCC_TOOLCHAIN_VERSION_REQ --cxx=g++-$GCC_TOOLCHAIN_VERSION_REQ"
 else
-    echo "No suitable gcc/g++ found -- ABORTING"
-    exit 1
+    echo "No suitable gcc/g++ found. Trying with default."
+    COMPILER_CONFIG=""
 fi
 
 ### Check for protobuf v2.

--- a/configure
+++ b/configure
@@ -3835,7 +3835,7 @@ fi
 # check if memfd is supported
 memfd=no
 cat > $TMPC << EOF
-#include <sys/memfd.h>
+#include <sys/mman.h>
 
 int main(void)
 {

--- a/include/qemu/osdep.h
+++ b/include/qemu/osdep.h
@@ -63,6 +63,12 @@ extern int daemon(int, int);
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 27
+/* Macros defined in sys/sysmacros.h have to be explicitly included from
+ * glibc 2.27 onwards. Before they were included through sys/types.h.
+ */
+#include <sys/sysmacros.h>
+#endif
 #include <sys/types.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/panda/docs/compile.md
+++ b/panda/docs/compile.md
@@ -134,7 +134,60 @@ sudo cp libdwarf/libdwarf.so /usr/local/lib/
 cd ../
 ```
 
-### Protocol Buffers
+### Protocol Buffers - Ubuntu package for 18.04LTS
+Ubuntu 18.04LTS ships with protocol buffers v3, which is incompatible with PANDA.
+Following are instructions on how to build your own deb packages for protocol
+buffers v2, and replace the ones supplied by Ubuntu.
+
+First, make the source of the v2 packages available to apt and install the 
+building environment pre-requisites:
+
+```sh
+echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial main" | sudo tee -a /etc/apt/sources.list
+sudo apt-get update
+sudo apt-get install build-essential fakeroot devscripts
+```
+
+Then, remove all installed protofbuf-related packages and create a build directory:
+
+```sh
+sudo apt-get remove --purge libprotobuf'*' protobuf'*' python-protobuf
+mkdir $HOME/build
+```
+
+Then build and install the base protobuf packages:
+
+```sh
+cd $HOME/build
+v=$(apt-cache showsrc protobuf-compiler | awk -F:\  '/^Version: 2\./{ print $2 }')
+sudo apt-get build-dep protobuf-compiler=$v
+apt-get source protobuf-compiler=$v
+cd protobuf-2.*
+debuild -e CC=gcc-5 -e CXX=g++-5 -b -uc -us
+cd ..
+dpkg -i *.deb
+```
+
+Next, build and and install the protobuf C compiler:
+
+```sh
+cd $HOME/build
+v=$(apt-cache showsrc protobuf-c-compiler | awk -F:\  '/^Version: 1\./{ print $2 }')
+sudo apt-get build-dep protobuf-c-compiler=$v
+apt-get source protobuf-c-compiler=$v
+cd protobuf-c-1.*
+debuild -e CC=gcc-5 -e CXX=g++-5 -b -uc -us
+cd ..
+dpkg -i *.deb
+```
+
+Finally, remove the old sources from apt:
+
+```sh
+sudo sed -i '/^deb-src.*xenial/d' /etc/apt/sources.list
+```
+
+### Protocol Buffers - manual installation
 
 #### C Library
 Protocol buffers are used by pandalog.  You want it.

--- a/panda/src/checkpoint.c
+++ b/panda/src/checkpoint.c
@@ -1,7 +1,5 @@
 #include <stdio.h>
 #include <unistd.h>
-#include <asm/unistd.h>
-#include <sys/syscall.h>
 #include <sys/types.h>
 
 #include "qemu/osdep.h"
@@ -16,9 +14,11 @@
 
 #include "panda/rr/rr_log.h"
 #include "panda/common.h"
+#include "qemu/memfd.h"
 
-#include "panda/checkpoint.h"
-
+#if defined CONFIG_LINUX && !defined CONFIG_MEMFD
+#include <sys/syscall.h>
+#include <asm/unistd.h>
 static int memfd_create(const char *name, unsigned int flags)
 {
 #ifdef __NR_memfd_create
@@ -27,6 +27,9 @@ static int memfd_create(const char *name, unsigned int flags)
     return -1;
 #endif
 }
+#endif
+
+#include "panda/checkpoint.h"
 
 static QLIST_HEAD(, Checkpoint) checkpoints = QLIST_HEAD_INITIALIZER(checkpoints);
 

--- a/util/memfd.c
+++ b/util/memfd.c
@@ -31,9 +31,7 @@
 
 #include "qemu/memfd.h"
 
-#ifdef CONFIG_MEMFD
-#include <sys/memfd.h>
-#elif defined CONFIG_LINUX
+#if defined CONFIG_LINUX && !defined CONFIG_MEMFD
 #include <sys/syscall.h>
 #include <asm/unistd.h>
 


### PR DESCRIPTION
Fixes for compiling on Ubuntu 18.04LTS (currently on beta2).
A new annoyance for the build process is that Ubuntu now ships with protocol buffers v3, so you need to rebuild packages for v2.
If you happen to use other software that requires protocol buffers v3 on the host, then you have a real problem.