### PR TITLE
Windows introspection rework, Enable file-taint for Windows 2000

### DIFF
--- a/panda/plugins/file_taint/file_taint.cpp
+++ b/panda/plugins/file_taint/file_taint.cpp
@@ -275,7 +275,7 @@ void read_enter(CPUState *cpu, target_ulong pc, std::string filename, uint64_t p
 // 3 long sys_read(unsigned int fd, char __user *buf, size_t count);
 // typedef void (*on_sys_read_return_t)(CPUState *cpu,target_ulong pc,uint32_t fd,target_ulong buf,uint32_t count);
 void read_return(CPUState *cpu, target_ulong pc, uint32_t buf, uint32_t actual_count) {
-    ThreadInfo thread{ panda_current_asid(cpu), panda_current_sp(cpu) };
+    ThreadInfo thread{ panda_current_asid(cpu), panda_current_sp(cpu) - get_ntreadfile_esp_off() };
     auto it = seen_reads.find(thread);
     if (it != seen_reads.end()) {
         ReadInfo read_info = it->second;
@@ -335,6 +335,7 @@ void windows_read_enter(CPUState *cpu, target_ulong pc, uint32_t FileHandle, uin
         else // last resort. just assume last_pos.
             read_enter(cpu, pc, filename, last_pos, Buffer, BufferLength);
     }
+    g_free(filename);
 }
 
 #define STATUS_SUCCESS 0

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -205,14 +205,6 @@ bool init_plugin(void *self) {
     }
     if (panda_os_familyno == OS_WINDOWS) {
         g_printf("OSI grabbing Windows introspection backend.\n");
-        if (0 == strcmp(panda_os_variant, "2000")) {
-            panda_require("win2000x86intro");
-        } else if (0 == strcmp(panda_os_variant, "7")) {
-            panda_require("win7x86intro");
-        } else {
-            g_printf("No Windows introspection support for OS variant %s.\n", panda_os_variant ? panda_os_variant : "Unspecified");
-            assert(false);
-        }
         panda_require("wintrospection");
     }
     return true;

--- a/panda/plugins/win2000x86intro/win2000x86intro.cpp
+++ b/panda/plugins/win2000x86intro/win2000x86intro.cpp
@@ -13,136 +13,43 @@
 PANDAENDCOMMENT */
 #define __STDC_FORMAT_MACROS
 
-#include "qemu/atomic.h"
 #include "panda/plugin.h"
 #include "panda/plugin_plugin.h"
-
-#include <cstdio>
-#include <cstdlib>
 
 extern "C" {
 
 #include "osi/osi_types.h"
 #include "osi/os_intro.h"
 
-#if defined(TARGET_I386) && !defined(TARGET_X86_64)
-
 #include "qemu/rcu.h"
 #include "qemu/rcu_queue.h"
 
 #include "exec/address-spaces.h"
 
+#include "wintrospection/wintrospection.h"
+#include "wintrospection/wintrospection_ext.h"
+
 bool init_plugin(void *);
 void uninit_plugin(void *);
-void on_get_current_process(CPUState *cpu, OsiProc **out_p);
-void on_get_processes(CPUState *cpu, OsiProcs **out_ps);
 void on_get_libraries(CPUState *cpu, OsiProc *p, OsiModules **out_ms);
-void on_free_osiproc(OsiProc *p);
-void on_free_osiprocs(OsiProcs *ps);
-void on_free_osimodules(OsiModules *ms);
-
-#define KPCR_CURTHREAD_OFF (0x120 + 0x04) // _KPCR.PrcbData.CurrentThread
-#define KDBG_PSLML         0x48  // _KDDEBUGGER_DATA64.PsLoadedModuleList
-#define KTHREAD_KPROC_OFF  0x22c // _KTHREAD.Process
-#define EPROC_LINKS_OFF    0x0a0 // _EPROCESS.ActiveProcessLinks
-#define EPROC_DTB_OFF      0x018 // _EPROCESS.Pcb.DirectoryTableBase
-#define EPROC_PID_OFF      0x09c // _EPROCESS.UniqueProcessId
-#define EPROC_PPID_OFF     0x1c8 // _EPROCESS.InheritedFromUniqueProcessId
-#define EPROC_NAME_OFF     0x1fc // _EPROCESS.ImageFileName
-#define EPROC_TYPE_OFF     0x000 // _EPROCESS.Pcb.Header.Type
-#define EPROC_SIZE_OFF     0x002 // _EPROCESS.Pcb.Header.Size
-#define EPROC_TYPE          0x03 // Value of Type
-#define EPROC_SIZE          0x1b // Value of Size
-#define EPROC_PEB_OFF      0x1b0 // _EPROCESS.Peb
-#define PEB_LDR_OFF        0x00c // _PEB.Ldr
-#define PEB_LDR_MEM_LINKS_OFF  0x14 // _PEB_LDR_DATA.InMemoryOrderModuleList
-#define PEB_LDR_LOAD_LINKS_OFF 0x0c // _PEB_LDR_DATA.InLoadOrderModuleList
-#define LDR_LOAD_LINKS_OFF 0x000 // _LDR_DATA_TABLE_ENTRY.InLoadOrderLinks
-#define LDR_BASE_OFF       0x018 // _LDR_DATA_TABLE_ENTRY.DllBase
-#define LDR_SIZE_OFF       0x020 // _LDR_DATA_TABLE_ENTRY.SizeOfImage
-#define LDR_BASENAME_OFF   0x02c // _LDR_DATA_TABLE_ENTRY.BaseDllName
-#define LDR_FILENAME_OFF   0x024 // _LDR_DATA_TABLE_ENTRY.FullDllName
-
-// Size of a guest pointer. Note that this can't just be target_ulong since
-// a 32-bit OS will run on x86_64-softmmu
-#define PTR uint32_t
-
-static inline char * make_pagedstr() {
-    char *m = strdup("(paged)");
-    assert(m);
-    return m;
+PTR get_win2000_kpcr(CPUState *cpu);
+HandleObject *get_win2000_handle_object(CPUState *cpu, uint32_t eproc, uint32_t handle);
 }
 
-// Gets a unicode string. Does its own mem allocation.
-// Output is a null-terminated UTF8 string
-char * get_unicode_str(CPUState *cpu, PTR ustr) {
-    uint16_t size = 0;
-    PTR str_ptr = 0;
-    if (-1 == panda_virtual_memory_rw(cpu, ustr, (uint8_t *)&size, 2, false)) {
-        return make_pagedstr();
-    }
+#include <cstdio>
+#include <cstdlib>
 
-    // Clamp size
-    if (size > 1024) size = 1024;
-    if (-1 == panda_virtual_memory_rw(cpu, ustr+4, (uint8_t *)&str_ptr, 4, false)) {
-        return make_pagedstr();
-    }
+#ifdef TARGET_I386
 
-    gchar *in_str = (gchar *)g_malloc0(size);
-    if (-1 == panda_virtual_memory_rw(cpu, str_ptr, (uint8_t *)in_str, size, false)) {
-        g_free(in_str);
-        return make_pagedstr();
-    }
+#define KDBG_PSLML             0x048 // _KDDEBUGGER_DATA64.PsLoadedModuleList
+#define EPROC_PEB_OFF          0x1b0 // _EPROCESS.Peb
+#define PEB_LDR_OFF            0x00c // _PEB.Ldr
+#define PEB_LDR_MEM_LINKS_OFF  0x014 // _PEB_LDR_DATA.InMemoryOrderModuleList
+#define PEB_LDR_LOAD_LINKS_OFF 0x00c // _PEB_LDR_DATA.InLoadOrderModuleList
 
-    gsize bytes_written = 0;
-    gchar *out_str = g_convert(in_str, size,
-            "UTF-8", "UTF-16LE", NULL, &bytes_written, NULL);
 
-    // An abundance of caution: we copy it over to something allocated
-    // with our own malloc. In the future we need to provide a way for
-    // someone else to free the memory allocated in here...
-    char *ret = (char *)malloc(bytes_written+1);
-    memcpy(ret, out_str, bytes_written+1);
-    g_free(in_str);
-    g_free(out_str);
-    return ret;
-}
-
-// Process introspection
-static PTR get_next_proc(CPUState *cpu, PTR eproc) {
-    PTR next;
-    if (-1 == panda_virtual_memory_rw(cpu, eproc+EPROC_LINKS_OFF, (uint8_t *)&next, sizeof(PTR), false))
-        return 0;
-    next -= EPROC_LINKS_OFF;
-    return next;
-}
-
-static PTR get_pid(CPUState *cpu, PTR eproc) {
-    PTR pid;
-    panda_virtual_memory_rw(cpu, eproc+EPROC_PID_OFF, (uint8_t *)&pid, sizeof(PTR), false);
-    return pid;
-}
-
-static PTR get_ppid(CPUState *cpu, PTR eproc) {
-    PTR ppid;
-    panda_virtual_memory_rw(cpu, eproc+EPROC_PPID_OFF, (uint8_t *)&ppid, sizeof(PTR), false);
-    return ppid;
-}
-
-static PTR get_dtb(CPUState *cpu, PTR eproc) {
-    PTR dtb;
-    panda_virtual_memory_rw(cpu, eproc+EPROC_DTB_OFF, (uint8_t *)&dtb, sizeof(PTR), false);
-    return dtb;
-}
-
-// *must* be called on a buffer of size 17 or greater
-static void get_procname(CPUState *cpu, PTR eproc, char *name) {
-    panda_virtual_memory_rw(cpu, eproc+EPROC_NAME_OFF, (uint8_t *)name, 16, false);
-    name[16] = '\0';
-}
-
-static PTR get_kpcr(CPUState *cpu) {
-    // Windows 2000 has a fixed location for the KPCR
+// Windows 2000 has a fixed location for the KPCR
+PTR get_win2000_kpcr(CPUState *cpu) {
     return 0xFFDFF000;
 }
 
@@ -183,151 +90,7 @@ static PTR get_loaded_module_list(CPUState *cpu) {
     return lml;
 }
 
-static bool is_valid_process(CPUState *cpu, PTR eproc) {
-    uint8_t type;
-    uint8_t size;
 
-    if(eproc == 0) return false;
-
-    panda_virtual_memory_rw(cpu, eproc+EPROC_TYPE_OFF, (uint8_t *)&type, 1, false);
-    panda_virtual_memory_rw(cpu, eproc+EPROC_SIZE_OFF, (uint8_t *)&size, 1, false);
-
-    return (type == EPROC_TYPE && size == EPROC_SIZE) &&
-        get_next_proc(cpu, eproc);
-}
-
-static PTR get_current_proc(CPUState *cpu) {
-    PTR thread, proc;
-    PTR kpcr = get_kpcr(cpu);
-
-    // Read KPCR->CurrentThread->Process
-    if (-1 == panda_virtual_memory_rw(cpu, kpcr+KPCR_CURTHREAD_OFF, (uint8_t *)&thread, sizeof(PTR), false)) return 0;
-    if (-1 == panda_virtual_memory_rw(cpu, thread+KTHREAD_KPROC_OFF, (uint8_t *)&proc, sizeof(PTR), false)) return 0;
-
-    // Sometimes, proc == 0 here.  Is there a better way to do this?
-
-    return is_valid_process(cpu, proc) ? proc : 0;
-}
-
-// Module stuff
-static const char *get_mod_basename(CPUState *cpu, PTR mod) {
-    return get_unicode_str(cpu, mod+LDR_BASENAME_OFF);
-}
-
-static const char *get_mod_filename(CPUState *cpu, PTR mod) {
-    return get_unicode_str(cpu, mod+LDR_FILENAME_OFF);
-}
-
-static PTR get_mod_base(CPUState *cpu, PTR mod) {
-    PTR base;
-    panda_virtual_memory_rw(cpu, mod+LDR_BASE_OFF, (uint8_t *)&base, sizeof(PTR), false);
-    return base;
-}
-
-static PTR get_mod_size(CPUState *cpu, PTR mod) {
-    uint32_t size;
-    panda_virtual_memory_rw(cpu, mod+LDR_SIZE_OFF, (uint8_t *)&size, sizeof(uint32_t), false);
-    return size;
-}
-
-static PTR get_next_mod(CPUState *cpu, PTR mod) {
-    PTR next;
-    if (-1 == panda_virtual_memory_rw(cpu, mod+LDR_LOAD_LINKS_OFF, (uint8_t *)&next, sizeof(PTR), false))
-        return 0;
-    next -= LDR_LOAD_LINKS_OFF;
-    return next;
-}
-
-static void fill_osiproc(CPUState *cpu, OsiProc *p, PTR eproc) {
-    p->offset = eproc;
-    char *name = (char *)malloc(17);
-    get_procname(cpu, eproc, name);
-    p->name = name;
-    p->asid = get_dtb(cpu, eproc);
-    p->pages = NULL;
-    p->pid = get_pid(cpu, eproc);
-    p->ppid = get_ppid(cpu, eproc);
-}
-
-static void fill_osimod(CPUState *cpu, OsiModule *m, PTR mod, bool ignore_basename) {
-    m->offset = mod;
-    m->file = (char *)get_mod_filename(cpu, mod);
-    m->base = get_mod_base(cpu, mod);
-    m->size = get_mod_size(cpu, mod);
-    m->name = ignore_basename ? strdup("-") : (char *)get_mod_basename(cpu, mod);
-    assert(m->name);
-}
-
-static void add_proc(CPUState *cpu, OsiProcs *ps, PTR eproc) {
-    static uint32_t capacity = 16;
-    if (ps->proc == NULL) {
-        ps->proc = (OsiProc *)malloc(sizeof(OsiProc) * capacity);
-    }
-    else if (ps->num == capacity) {
-        capacity *= 2;
-        ps->proc = (OsiProc *)realloc(ps->proc, sizeof(OsiProc) * capacity);
-    }
-
-    OsiProc *p = &ps->proc[ps->num++];
-    fill_osiproc(cpu, p, eproc);
-}
-
-static void add_mod(CPUState *cpu, OsiModules *ms, PTR mod, bool ignore_basename) {
-    static uint32_t capacity = 16;
-    if (ms->module == NULL) {
-        ms->module = (OsiModule *)malloc(sizeof(OsiModule) * capacity);
-    }
-    else if (ms->num == capacity) {
-        capacity *= 2;
-        ms->module = (OsiModule *)realloc(ms->module, sizeof(OsiModule) * capacity);
-    }
-
-    OsiModule *p = &ms->module [ms->num++];
-    fill_osimod(cpu, p, mod, ignore_basename);
-}
-
-void on_get_current_process(CPUState *cpu, OsiProc **out_p) {
-    PTR eproc = get_current_proc(cpu);
-    if(eproc) {
-        OsiProc *p = (OsiProc *) malloc(sizeof(OsiProc));
-        fill_osiproc(cpu, p, eproc);
-        *out_p = p;
-    } else {
-        *out_p = NULL;
-    }
-}
-
-void on_get_processes(CPUState *cpu, OsiProcs **out_ps) {
-    PTR first = get_current_proc(cpu);
-    if(first == NULL) {
-        *out_ps = NULL;
-        return;
-    }
-    PTR first_pid = get_pid(cpu, first);
-    PTR current = first;
-
-    if (first_pid == 0) { // Idle proc, don't try
-        *out_ps = NULL;
-        return;
-    }
-
-    OsiProcs *ps = (OsiProcs *)malloc(sizeof(OsiProcs));
-    ps->num = 0;
-    ps->proc = NULL;
-
-    do {
-        // One of these will be the loop head,
-        // which we don't want to include
-        if (is_valid_process(cpu, current)) {
-            add_proc(cpu, ps, current);
-        }
-
-        current = get_next_proc(cpu, current);
-        if (!current) break;
-    } while (current != first);
-
-    *out_ps = ps;
-}
 
 void on_get_libraries(CPUState *cpu, OsiProc *p, OsiModules **out_ms) {
     // Find the process we're interested in
@@ -403,46 +166,62 @@ void on_get_modules(CPUState *cpu, OsiModules **out_ms) {
     *out_ms = ms;
 }
 
-void on_free_osiproc(OsiProc *p) {
-    if (!p) return;
-    free(p->name);
-    free(p);
+// i.e. return pointer to the object represented by this handle
+static uint32_t get_handle_table_entry(CPUState *cpu, uint32_t pHandleTable, uint32_t handle) {
+    uint32_t L1_index = (handle & HANDLE_MASK3) >> HANDLE_SHIFT3;
+    uint32_t L1_table_off = handle_table_L1_addr(cpu, pHandleTable, L1_index);
+    uint32_t L1_table;
+    if(panda_virtual_memory_rw(cpu, L1_table_off, (uint8_t *) &L1_table, 4, false) == -1) return 0;
+
+    uint32_t L2_index = (handle & HANDLE_MASK2) >> HANDLE_SHIFT2;
+    uint32_t L2_table_off = handle_table_L2_addr(L1_table, L2_index);
+    uint32_t L2_table;
+    if(panda_virtual_memory_rw(cpu, L2_table_off, (uint8_t *) &L2_table, 4, false) == -1) return 0;
+
+    uint32_t index = (handle & HANDLE_MASK1) >> HANDLE_SHIFT1;
+    uint32_t pEntry = handle_table_L3_entry(pHandleTable, L2_table, index);
+    uint32_t pObjectHeader;
+    if ((panda_virtual_memory_rw(cpu, pEntry, (uint8_t *) &pObjectHeader, 4, false)) == -1) return 0;
+
+    //  printf ("processHandle_to_pid pObjectHeader = 0x%x\n", pObjectHeader);
+    pObjectHeader |= 0x80000000;
+    pObjectHeader &= ~0x00000007;
+
+    return pObjectHeader;
 }
 
-void on_free_osiprocs(OsiProcs *ps) {
-    if(!ps) return;
-    if(ps->proc) {
-        for(uint32_t i = 0; i < ps->num; i++) {
-            free(ps->proc[i].name);
-        }
-        free(ps->proc);
+
+HandleObject *get_win2000_handle_object(CPUState *cpu, uint32_t eproc, uint32_t handle) {
+    uint32_t pObjectTable;
+    uint32_t handleTable;
+    if (-1 == panda_virtual_memory_rw(cpu, eproc+get_eproc_objtable_off(), (uint8_t *)&pObjectTable, 4, false)) {
+        return NULL;
     }
-    free(ps);
+    if (-1 == panda_virtual_memory_rw(cpu, pObjectTable + 0x08, (uint8_t *)&handleTable, 4, false)) {
+        return NULL;
+    }
+    uint32_t pObjHeader = get_handle_table_entry(cpu, handleTable, handle);
+    if (pObjHeader == 0) return NULL;
+    uint32_t pObj = pObjHeader + 0x18;
+    uint8_t objType = 0;
+    if (-1 == panda_virtual_memory_rw(cpu, pObjHeader+get_obj_type_offset(), (uint8_t *)&objType, 1, false)) {
+        return NULL;
+    }
+    HandleObject *ho = (HandleObject *) malloc(sizeof(HandleObject));
+    ho->objType = objType;
+    ho->pObj = pObj;
+    return ho;
 }
 
-void on_free_osimodules(OsiModules *ms) {
-    if(!ms) return;
-    if(ms->module) {
-        for(uint32_t i = 0; i < ms->num; i++) {
-            free(ms->module[i].file);
-            free(ms->module[i].name);
-        }
-        free(ms->module);
-    }
-    free(ms);
-}
+
 
 #endif
 
 bool init_plugin(void *self) {
 #if defined(TARGET_I386) && !defined(TARGET_X86_64)
-    PPP_REG_CB("osi", on_get_current_process, on_get_current_process);
-    PPP_REG_CB("osi", on_get_processes, on_get_processes);
     PPP_REG_CB("osi", on_get_libraries, on_get_libraries);
     PPP_REG_CB("osi", on_get_modules, on_get_modules);
-    PPP_REG_CB("osi", on_free_osiproc, on_free_osiproc);
-    PPP_REG_CB("osi", on_free_osiprocs, on_free_osiprocs);
-    PPP_REG_CB("osi", on_free_osimodules, on_free_osimodules);
+    assert(init_wintrospection_api());
     return true;
 #else
     return false;
@@ -450,6 +229,5 @@ bool init_plugin(void *self) {
 
 }
 
-void uninit_plugin(void *self) { }
-
+void uninit_plugin(void *self) {
 }

--- a/panda/plugins/win2000x86intro/win2000x86intro_int.h
+++ b/panda/plugins/win2000x86intro/win2000x86intro_int.h
@@ -1,0 +1,6 @@
+typedef void PTR;
+typedef void CPUState;
+typedef void HandleObject;
+typedef void uint32_t;
+
+#include "win2000x86intro_int_fns.h"

--- a/panda/plugins/win2000x86intro/win2000x86intro_int_fns.h
+++ b/panda/plugins/win2000x86intro/win2000x86intro_int_fns.h
@@ -1,0 +1,7 @@
+#ifndef __WIN2000X86INTRO_INT_FNS_H__
+#define __WIN2000X86INTRO_INT_FNS_H__
+
+PTR get_win2000_kpcr(CPUState *cpu);
+HandleObject *get_win2000_handle_object(CPUState *cpu, uint32_t eproc, uint32_t handle);
+
+#endif

--- a/panda/plugins/win7x86intro/win7x86intro.cpp
+++ b/panda/plugins/win7x86intro/win7x86intro.cpp
@@ -21,14 +21,14 @@ extern "C" {
 #include "osi/osi_types.h"
 #include "osi/os_intro.h"
 
+#include "wintrospection/wintrospection.h"
+#include "wintrospection/wintrospection_ext.h"
+
 bool init_plugin(void *);
 void uninit_plugin(void *);
-void on_get_current_process(CPUState *cpu, OsiProc **out_p);
-void on_get_processes(CPUState *cpu, OsiProcs **out_ps);
 void on_get_libraries(CPUState *cpu, OsiProc *p, OsiModules **out_ms);
-void on_free_osiproc(OsiProc *p);
-void on_free_osiprocs(OsiProcs *ps);
-void on_free_osimodules(OsiModules *ms);
+PTR get_win7_kpcr(CPUState *cpu);
+HandleObject *get_win7_handle_object(CPUState *cpu, uint32_t eproc, uint32_t handle);
 }
 
 #include <cstdio>
@@ -36,112 +36,18 @@ void on_free_osimodules(OsiModules *ms);
 
 #ifdef TARGET_I386
 
-// Code should work for other versions of Windows once these constants
-// are redefined. Possibly we should move them to a config file?
-#define KMODE_FS           0x030 // Segment number of FS in kernel mode
-#define KPCR_CURTHREAD_OFF 0x124 // _KPCR.PrcbData.CurrentThread
-#define KPCR_KDVERSION_OFF 0x34  // _KPCR.KdVersionBlock
-#define KDVERSION_DDL_OFF  0x20  // _DBGKD_GET_VERSION64.DebuggerDataList
-#define KDBG_PSLML         0x48  // _KDDEBUGGER_DATA64.PsLoadedModuleList
-#define KTHREAD_KPROC_OFF  0x150 // _KTHREAD.Process
-#define EPROC_LINKS_OFF    0x0b8 // _EPROCESS.ActiveProcessLinks
-#define EPROC_DTB_OFF      0x018 // _EPROCESS.Pcb.DirectoryTableBase
-#define EPROC_PID_OFF      0x0b4 // _EPROCESS.UniqueProcessId
-#define EPROC_PPID_OFF     0x140 // _EPROCESS.InheritedFromUniqueProcessId
-#define EPROC_NAME_OFF     0x16c // _EPROCESS.ImageFileName
-#define EPROC_TYPE_OFF     0x000 // _EPROCESS.Pcb.Header.Type
-#define EPROC_SIZE_OFF     0x002 // _EPROCESS.Pcb.Header.Size
-#define EPROC_TYPE          0x03 // Value of Type
-#define EPROC_SIZE          0x26 // Value of Size
-#define EPROC_PEB_OFF      0x1a8 // _EPROCESS.Peb
-#define PEB_LDR_OFF        0x00c // _PEB.Ldr
-#define PEB_LDR_MEM_LINKS_OFF  0x14 // _PEB_LDR_DATA.InMemoryOrderModuleLinks
-#define PEB_LDR_LOAD_LINKS_OFF 0x0c // _PEB_LDR_DATA.InMemoryOrderModuleLinks
-#define LDR_MEM_LINKS_OFF  0x008 // _LDR_DATA_TABLE_ENTRY.InMemoryOrderLinks
-#define LDR_LOAD_LINKS_OFF 0x000 // _LDR_DATA_TABLE_ENTRY.InLoadOrderLinks
-#define LDR_BASE_OFF       0x018 // _LDR_DATA_TABLE_ENTRY.DllBase
-#define LDR_SIZE_OFF       0x020 // _LDR_DATA_TABLE_ENTRY.SizeOfImage
-#define LDR_BASENAME_OFF   0x02c // _LDR_DATA_TABLE_ENTRY.BaseDllName
-#define LDR_FILENAME_OFF   0x024 // _LDR_DATA_TABLE_ENTRY.FullDllName
-
-// Size of a guest pointer. Note that this can't just be target_ulong since
-// a 32-bit OS will run on x86_64-softmmu
-#define PTR uint32_t
-
-static inline char * make_pagedstr() {
-    char *m = (char *)malloc(8);
-    strcpy(m, "(paged)");
-    return m;
-}
-
-// Gets a unicode string. Does its own mem allocation.
-// Output is a null-terminated UTF8 string
-char * get_unicode_str(CPUState *cpu, PTR ustr) {
-    uint16_t size = 0;
-    PTR str_ptr = 0;
-    if (-1 == panda_virtual_memory_rw(cpu, ustr, (uint8_t *)&size, 2, false)) {
-        return make_pagedstr();
-    }
-    // Clamp size
-    if (size > 1024) size = 1024;
-    if (-1 == panda_virtual_memory_rw(cpu, ustr+4, (uint8_t *)&str_ptr, 4, false)) {
-        return make_pagedstr();
-    }
-    gchar *in_str = (gchar *)g_malloc0(size);
-    if (-1 == panda_virtual_memory_rw(cpu, str_ptr, (uint8_t *)in_str, size, false)) {
-        g_free(in_str);
-        return make_pagedstr();
-    }
-
-    gsize bytes_written = 0;
-    gchar *out_str = g_convert(in_str, size,
-            "UTF-8", "UTF-16LE", NULL, &bytes_written, NULL);
-
-    // An abundance of caution: we copy it over to something allocated
-    // with our own malloc. In the future we need to provide a way for
-    // someone else to free the memory allocated in here...
-    char *ret = (char *)malloc(bytes_written+1);
-    memcpy(ret, out_str, bytes_written+1);
-    g_free(in_str);
-    g_free(out_str);
-    return ret;
-}
-
-// Process introspection
-static PTR get_next_proc(CPUState *cpu, PTR eproc) {
-    PTR next;
-    if (-1 == panda_virtual_memory_rw(cpu, eproc+EPROC_LINKS_OFF, (uint8_t *)&next, sizeof(PTR), false)) 
-        return 0;
-    next -= EPROC_LINKS_OFF;
-    return next;
-}
-
-static PTR get_pid(CPUState *cpu, PTR eproc) {
-    PTR pid;
-    panda_virtual_memory_rw(cpu, eproc+EPROC_PID_OFF, (uint8_t *)&pid, sizeof(PTR), false);
-    return pid;
-}
-
-static PTR get_ppid(CPUState *cpu, PTR eproc) {
-    PTR ppid;
-    panda_virtual_memory_rw(cpu, eproc+EPROC_PPID_OFF, (uint8_t *)&ppid, sizeof(PTR), false);
-    return ppid;
-}
-
-static PTR get_dtb(CPUState *cpu, PTR eproc) {
-    PTR dtb;
-    panda_virtual_memory_rw(cpu, eproc+EPROC_DTB_OFF, (uint8_t *)&dtb, sizeof(PTR), false);
-    return dtb;
-}
-
-// *must* be called on a buffer of size 17 or greater
-static void get_procname(CPUState *cpu, PTR eproc, char *name) {
-    panda_virtual_memory_rw(cpu, eproc+EPROC_NAME_OFF, (uint8_t *)name, 16, false);
-    name[16] = '\0';
-}
+#define KMODE_FS               0x030 // Segment number of FS in kernel mode
+#define KPCR_KDVERSION_OFF     0x034  // _KPCR.KdVersionBlock
+#define KDVERSION_DDL_OFF      0x020  // _DBGKD_GET_VERSION64.DebuggerDataList
+#define KDBG_PSLML             0x048  // _KDDEBUGGER_DATA64.PsLoadedModuleList
+#define EPROC_PEB_OFF          0x1a8 // _EPROCESS.Peb
+#define PEB_LDR_OFF            0x00c // _PEB.Ldr
+#define PEB_LDR_MEM_LINKS_OFF  0x014 // _PEB_LDR_DATA.InMemoryOrderModuleLinks
+#define PEB_LDR_LOAD_LINKS_OFF 0x00c // _PEB_LDR_DATA.InMemoryOrderModuleLinks
+#define LDR_LOAD_LINKS_OFF     0x000 // _LDR_DATA_TABLE_ENTRY.InLoadOrderLinks
 
 // XXX: this will have to change for 64-bit
-static PTR get_kpcr(CPUState *cpu) {
+PTR get_win7_kpcr(CPUState *cpu) {
     // Read the kernel-mode FS segment base
     uint32_t e1, e2;
     PTR fs_base;
@@ -158,7 +64,7 @@ static PTR get_kpcr(CPUState *cpu) {
 }
 
 static PTR get_kdbg(CPUState *cpu) {
-    PTR kpcr = get_kpcr(cpu);
+    PTR kpcr = get_win7_kpcr(cpu);
     PTR kdversion, kddl, kddlp;
     if (-1 == panda_virtual_memory_rw(cpu, kpcr+KPCR_KDVERSION_OFF, (uint8_t *)&kdversion, sizeof(PTR), false)) {
         return 0;
@@ -174,141 +80,16 @@ static PTR get_kdbg(CPUState *cpu) {
     return kddl;
 }
 
-static PTR get_current_proc(CPUState *cpu) {
-    PTR thread, proc;
-    PTR kpcr = get_kpcr(cpu);
 
-    // Read KPCR->CurrentThread->Process
-    panda_virtual_memory_rw(cpu, kpcr+KPCR_CURTHREAD_OFF, (uint8_t *)&thread, sizeof(PTR), false);
-    panda_virtual_memory_rw(cpu, thread+KTHREAD_KPROC_OFF, (uint8_t *)&proc, sizeof(PTR), false);
 
-    return proc;
-}
-
-static bool is_valid_process(CPUState *cpu, PTR eproc) {
-    uint8_t type;
-    uint8_t size;
-
-    panda_virtual_memory_rw(cpu, eproc+EPROC_TYPE_OFF, (uint8_t *)&type, 1, false);
-    panda_virtual_memory_rw(cpu, eproc+EPROC_SIZE_OFF, (uint8_t *)&size, 1, false);
-
-    return (type == EPROC_TYPE && size == EPROC_SIZE);
-}
-
-// Module stuff
-static const char *get_mod_basename(CPUState *cpu, PTR mod) {
-    return get_unicode_str(cpu, mod+LDR_BASENAME_OFF);
-}
-
-static const char *get_mod_filename(CPUState *cpu, PTR mod) {
-    return get_unicode_str(cpu, mod+LDR_FILENAME_OFF);
-}
-
-static PTR get_mod_base(CPUState *cpu, PTR mod) {
-    PTR base;
-    panda_virtual_memory_rw(cpu, mod+LDR_BASE_OFF, (uint8_t *)&base, sizeof(PTR), false);
-    return base;
-}
-
-static PTR get_mod_size(CPUState *cpu, PTR mod) {
-    uint32_t size;
-    panda_virtual_memory_rw(cpu, mod+LDR_SIZE_OFF, (uint8_t *)&size, sizeof(uint32_t), false);
-    return size;
-}
-
-static PTR get_next_mod(CPUState *cpu, PTR mod) {
-    PTR next;
-    if (-1 == panda_virtual_memory_rw(cpu, mod+LDR_LOAD_LINKS_OFF, (uint8_t *)&next, sizeof(PTR), false))
-        return 0;
-    next -= LDR_LOAD_LINKS_OFF;
-    return next;
-}
-
-static void fill_osiproc(CPUState *cpu, OsiProc *p, PTR eproc) {
-    p->offset = eproc;
-    char *name = (char *)malloc(17);
-    get_procname(cpu, eproc, name);
-    p->name = name;
-    p->asid = get_dtb(cpu, eproc);
-    p->pages = NULL;
-    p->pid = get_pid(cpu, eproc);
-    p->ppid = get_ppid(cpu, eproc);
-}
-
-static void fill_osimod(CPUState *cpu, OsiModule *m, PTR mod) {
-    m->offset = mod;
-    m->file = (char *)get_mod_filename(cpu, mod);
-    m->base = get_mod_base(cpu, mod);
-    m->size = get_mod_size(cpu, mod);
-    m->name = (char *)get_mod_basename(cpu, mod);
-}
-
-static void add_proc(CPUState *cpu, OsiProcs *ps, PTR eproc) {
-    static uint32_t capacity = 16;
-    if (ps->proc == NULL) {
-        ps->proc = (OsiProc *)malloc(sizeof(OsiProc) * capacity);
-    }
-    else if (ps->num == capacity) {
-        capacity *= 2;
-        ps->proc = (OsiProc *)realloc(ps->proc, sizeof(OsiProc) * capacity);
-    }
-
-    OsiProc *p = &ps->proc[ps->num++];
-    fill_osiproc(cpu, p, eproc);
-}
-
-static void add_mod(CPUState *cpu, OsiModules *ms, PTR mod) {
-    static uint32_t capacity = 16;
-    if (ms->module == NULL) {
-        ms->module = (OsiModule *)malloc(sizeof(OsiModule) * capacity);
-    }
-    else if (ms->num == capacity) {
-        capacity *= 2;
-        ms->module = (OsiModule *)realloc(ms->module, sizeof(OsiModule) * capacity);
-    }
-
-    OsiModule *p = &ms->module [ms->num++];
-    fill_osimod(cpu, p, mod);
-}
-
-void on_get_current_process(CPUState *cpu, OsiProc **out_p) {
-    OsiProc *p = (OsiProc *) malloc(sizeof(OsiProc));
-    PTR eproc = get_current_proc(cpu);
-    fill_osiproc(cpu, p, eproc);
-    *out_p = p;
-}
-
-void on_get_processes(CPUState *cpu, OsiProcs **out_ps) {
-    PTR first = get_current_proc(cpu);
-    PTR first_pid = get_pid(cpu, first);
-    PTR current = first;
-
-    if (first_pid == 0) { // Idle proc, don't try
-        out_ps = NULL;
-        return;
-    }
-
-    OsiProcs *ps = (OsiProcs *)malloc(sizeof(OsiProcs));
-    ps->num = 0;
-    ps->proc = NULL;
-
-    do {
-        // One of these will be the loop head,
-        // which we don't want to include
-        if (is_valid_process(cpu, current)) {
-            add_proc(cpu, ps, current);
-        }
-
-        current = get_next_proc(cpu, current);
-        if (!current) break;
-    } while (current != first);
-
-    *out_ps = ps;
-}
 
 void on_get_libraries(CPUState *cpu, OsiProc *p, OsiModules **out_ms) {
     // Find the process we're interested in
     PTR eproc = get_current_proc(cpu);
+    if(!eproc) {
+        *out_ms = NULL; return;
+    }
+
     bool found = false;
     PTR first_proc = eproc;
     do {
@@ -341,7 +122,7 @@ void on_get_libraries(CPUState *cpu, OsiProc *p, OsiModules **out_ms) {
     // We want while loop here -- we are starting at the head,
     // which is not a valid module
     while (current_mod != first_mod) {
-        add_mod(cpu, ms, current_mod);
+        add_mod(cpu, ms, current_mod, false);
         current_mod = get_next_mod(cpu, current_mod);
         if (!current_mod) break;
     }
@@ -353,9 +134,6 @@ void on_get_libraries(CPUState *cpu, OsiProc *p, OsiModules **out_ms) {
 void on_get_modules(CPUState *cpu, OsiModules **out_ms) {
     PTR kdbg = get_kdbg(cpu);
 
-    OsiModules *ms = (OsiModules *)malloc(sizeof(OsiModules));
-    ms->num = 0;
-    ms->module = NULL;
     PTR PsLoadedModuleList;
     // Dbg.PsLoadedModuleList
     if (-1 == panda_virtual_memory_rw(cpu, kdbg+KDBG_PSLML, (uint8_t *)&PsLoadedModuleList, sizeof(PTR), false)) {
@@ -363,11 +141,15 @@ void on_get_modules(CPUState *cpu, OsiModules **out_ms) {
         return;
     }
 
+    OsiModules *ms = (OsiModules *)malloc(sizeof(OsiModules));
+    ms->num = 0;
+    ms->module = NULL;
     PTR current_mod = get_next_mod(cpu, PsLoadedModuleList);
+
     // We want while loop here -- we are starting at the head,
     // which is not a valid module
     while (current_mod != PsLoadedModuleList) {
-        add_mod(cpu, ms, current_mod);
+        add_mod(cpu, ms, current_mod, false);
         current_mod = get_next_mod(cpu, current_mod);
         if (!current_mod) break;
     }
@@ -375,43 +157,81 @@ void on_get_modules(CPUState *cpu, OsiModules **out_ms) {
     *out_ms = ms;
 }
 
-void on_free_osiproc(OsiProc *p) {
-    if (!p) return;
-    free(p->name);
-    free(p);
+// i.e. return pointer to the object represented by this handle
+static uint32_t get_handle_table_entry(CPUState *cpu, uint32_t pHandleTable, uint32_t handle) {
+    uint32_t tableCode, tableLevels;
+    // get tablecode
+    panda_virtual_memory_rw(cpu, pHandleTable, (uint8_t *)&tableCode, 4, false);
+    //printf ("tableCode = 0x%x\n", tableCode);
+    // extract levels
+    tableLevels = tableCode & LEVEL_MASK;
+    //printf("tableLevels = %d\n", tableLevels);
+    //  assert (tableLevels <= 2);
+    if (tableLevels > 2) {
+        return 0;
+    }
+    uint32_t pEntry=0;
+    if (tableLevels == 0) {
+        uint32_t index = (handle & HANDLE_MASK1) >> HANDLE_SHIFT1;
+        pEntry = handle_table_L1_entry(cpu, pHandleTable, index);
+    }
+    if (tableLevels == 1) {
+        uint32_t L1_index = (handle & HANDLE_MASK2) >> HANDLE_SHIFT2;
+        uint32_t L1_table_off = handle_table_L1_addr(cpu, pHandleTable, L1_index);
+        uint32_t L1_table;
+        panda_virtual_memory_rw(cpu, L1_table_off, (uint8_t *) &L1_table, 4, false);
+        uint32_t index = (handle & HANDLE_MASK1) >> HANDLE_SHIFT1;
+        pEntry = handle_table_L2_entry(pHandleTable, L1_table, index);
+    }
+    if (tableLevels == 2) {
+        uint32_t L1_index = (handle & HANDLE_MASK3) >> HANDLE_SHIFT3;
+        uint32_t L1_table_off = handle_table_L1_addr(cpu, pHandleTable, L1_index);
+        uint32_t L1_table;
+        panda_virtual_memory_rw(cpu, L1_table_off, (uint8_t *) &L1_table, 4, false);
+        uint32_t L2_index = (handle & HANDLE_MASK2) >> HANDLE_SHIFT2;
+        uint32_t L2_table_off = handle_table_L2_addr(L1_table, L2_index);
+        uint32_t L2_table;
+        panda_virtual_memory_rw(cpu, L2_table_off, (uint8_t *) &L2_table, 4, false);
+        uint32_t index = (handle & HANDLE_MASK1) >> HANDLE_SHIFT1;
+        pEntry = handle_table_L3_entry(pHandleTable, L2_table, index);
+    }
+    uint32_t pObjectHeader;
+    if ((panda_virtual_memory_rw(cpu, pEntry, (uint8_t *) &pObjectHeader, 4, false)) == -1) {
+        return 0;
+    }
+    //  printf ("processHandle_to_pid pObjectHeader = 0x%x\n", pObjectHeader);
+    pObjectHeader &= ~0x00000007;
+
+    return pObjectHeader;
 }
 
-void on_free_osiprocs(OsiProcs *ps) {
-    if (!ps) return;
-    for(uint32_t i = 0; i < ps->num; i++) {
-        free(ps->proc[i].name);
+
+HandleObject *get_win7_handle_object(CPUState *cpu, uint32_t eproc, uint32_t handle) {
+    uint32_t pObjectTable;
+    if (-1 == panda_virtual_memory_rw(cpu, eproc+get_eproc_objtable_off(), (uint8_t *)&pObjectTable, 4, false)) {
+        return NULL;
     }
-    if(ps->proc) free(ps->proc);
-    free(ps);
+    uint32_t pObjHeader = get_handle_table_entry(cpu, pObjectTable, handle);
+    if (pObjHeader == 0) return NULL;
+    uint32_t pObj = pObjHeader + 0x18;
+    uint8_t objType = 0;
+    if (-1 == panda_virtual_memory_rw(cpu, pObjHeader+get_obj_type_offset(), &objType, 1, false)) {
+        return NULL;
+    }
+    HandleObject *ho = (HandleObject *) malloc(sizeof(HandleObject));
+    ho->objType = objType;
+    ho->pObj = pObj;
+    return ho;
 }
 
-void on_free_osimodules(OsiModules *ms) {
-    if (!ms) return;
-    for(uint32_t i = 0; i < ms->num; i++) {
-        free(ms->module[i].file);
-        free(ms->module[i].name);
-    }
-    if (ms->module) free(ms->module);
-    free(ms);
-}
 
 #endif
 
 bool init_plugin(void *self) {
-    // panda_require("osi");
 #ifdef TARGET_I386
-    PPP_REG_CB("osi", on_get_current_process, on_get_current_process);
-    PPP_REG_CB("osi", on_get_processes, on_get_processes);
     PPP_REG_CB("osi", on_get_libraries, on_get_libraries);
     PPP_REG_CB("osi", on_get_modules, on_get_modules);
-    PPP_REG_CB("osi", on_free_osiproc, on_free_osiproc);
-    PPP_REG_CB("osi", on_free_osiprocs, on_free_osiprocs);
-    PPP_REG_CB("osi", on_free_osimodules, on_free_osimodules);
+    init_wintrospection_api();
     return true;
 #else
     return false;

--- a/panda/plugins/win7x86intro/win7x86intro_int.h
+++ b/panda/plugins/win7x86intro/win7x86intro_int.h
@@ -1,0 +1,6 @@
+typedef void PTR;
+typedef void CPUState;
+typedef void HandleObject;
+typedef void uint32_t;
+
+#include "win7x86intro_int_fns.h"

--- a/panda/plugins/win7x86intro/win7x86intro_int_fns.h
+++ b/panda/plugins/win7x86intro/win7x86intro_int_fns.h
@@ -1,0 +1,7 @@
+#ifndef __WIN7X86INTRO_INT_FNS_H__
+#define __WIN7X86INTRO_INT_FNS_H__
+
+PTR get_win7_kpcr(CPUState *cpu);
+HandleObject *get_win7_handle_object(CPUState *cpu, uint32_t eproc, uint32_t handle);
+
+#endif

--- a/panda/plugins/wintrospection/wintrospection.c
+++ b/panda/plugins/wintrospection/wintrospection.c
@@ -408,17 +408,23 @@ char *read_unicode_string(CPUState *cpu, uint32_t pUstr) {
     uint16_t fileNameLen;
     uint32_t fileNamePtr;
     char fileNameUnicode[260*2] = {};
+    char *fileName;
 
     assert(!panda_virtual_memory_rw(cpu, pUstr,
             (uint8_t *) &fileNameLen, 2, false));
     assert(!panda_virtual_memory_rw(cpu, pUstr+4,
             (uint8_t *) &fileNamePtr, 4, false));
 
+    if((fileNameLen == 0) || (!fileNamePtr)) {
+        assert(fileName = g_strdup(""));
+        return fileName;
+    }
+
     if (fileNameLen > 259*2) {
         fileNameLen = 259*2;
     }
     assert(!panda_virtual_memory_rw(cpu, fileNamePtr, (uint8_t *)fileNameUnicode, fileNameLen, false));
-    char *fileName = (char *)malloc(fileNameLen/2+1);
+    fileName = (char *)g_malloc(fileNameLen/2+1);
     assert(fileName);
     unicode_to_ascii(fileNameUnicode, fileName, fileNameLen/2);
 

--- a/panda/plugins/wintrospection/wintrospection.c
+++ b/panda/plugins/wintrospection/wintrospection.c
@@ -20,6 +20,10 @@ PANDAENDCOMMENT */
 #include <sys/types.h>
 
 #include "panda/rr/rr_log.h"
+
+#include "osi/osi_types.h"
+#include "osi/os_intro.h"
+
 #include "panda/plugin.h"
 #include "panda/plugin_plugin.h"
 #include "panda/plog.h"
@@ -30,71 +34,250 @@ PANDAENDCOMMENT */
 #include "wintrospection.h"
 #include "wintrospection_int_fns.h"
 
-char *get_keyname(uint32_t KeyHandle);
+#include "win2000x86intro/win2000x86intro_ext.h"
+#include "win7x86intro/win7x86intro_ext.h"
+
+#include "glib.h"
+
 bool init_plugin(void *);
 void uninit_plugin(void *);
+void add_proc(CPUState *cpu, OsiProcs *ps, PTR eproc);
+void on_free_osiproc(OsiProc *p);
+void on_free_osiprocs(OsiProcs *ps);
+void on_free_osimodules(OsiModules *ms);
 
 // this stuff only makes sense for win x86 32-bit
 #ifdef TARGET_I386
 
-#define KMODE_FS           0x030
-#define KPCR_CURTHREAD_OFF 0x124
-#define KTHREAD_KPROC_OFF  0x150
-#define EPROC_PID_OFF      0x0b4
-#define EPROC_NAME_OFF     0x16c
+// Constants that are the same in all supported versions of windows
+// Currently just Windows 7 and Windows 2000
+#define KPCR_CURTHREAD_OFF   0x124 // _KPCR.PrcbData.CurrentThread
+#define EPROC_DTB_OFF        0x018 // _EPROCESS.Pcb.DirectoryTableBase
+#define EPROC_TYPE_OFF       0x000 // _EPROCESS.Pcb.Header.Type
+#define EPROC_SIZE_OFF       0x002 // _EPROCESS.Pcb.Header.Size
+#define EPROC_TYPE           0x003 // Value of Type
+#define LDR_LOAD_LINKS_OFF   0x000 // _LDR_DATA_TABLE_ENTRY.InLoadOrderLinks
+#define LDR_BASE_OFF         0x018 // _LDR_DATA_TABLE_ENTRY.DllBase
+#define LDR_SIZE_OFF         0x020 // _LDR_DATA_TABLE_ENTRY.SizeOfImage
+#define LDR_BASENAME_OFF     0x02c // _LDR_DATA_TABLE_ENTRY.BaseDllName
+#define LDR_FILENAME_OFF     0x024 // _LDR_DATA_TABLE_ENTRY.FullDllName
+#define OBJNAME_OFF          0x008
+#define FILE_OBJECT_NAME_OFF 0x030
+#define FILE_OBJECT_POS_OFF  0x038
+
+
+// "Constants" specific to the guest operating system.
+// These are initialized in the init_plugin function.
+static uint32_t kthread_kproc_off;  // _KTHREAD.Process
+static uint32_t eproc_pid_off;      // _EPROCESS.UniqueProcessId
+static uint32_t eproc_ppid_off;     // _EPROCESS.InheritedFromUniqueProcessId
+static uint32_t eproc_name_off;     // _EPROCESS.ImageFileName
+static uint32_t eproc_objtable_off; // _EPROCESS.ObjectTable
+static uint32_t eproc_size;         // Value of Size
+static uint32_t eproc_links_off;    // _EPROCESS.ActiveProcessLinks
+static uint32_t obj_type_file;      // FILE object type
+static uint32_t obj_type_key;       // KEY object type
+static uint32_t obj_type_process;   // PROCESS object type
+static uint32_t obj_type_offset;    // XXX_OBJECT.Type (offset from start of OBJECT_TYPE_HEADER)
+static uint32_t ntreadfile_esp_off; // Number of bytes left on stack when NtReadFile returns
+
+// Function pointer, returns location of KPCR structure.  OS-specific.
+static PTR(*get_kpcr)(CPUState *cpu);
+
+// Function pointer, returns handle table entry.  OS-specific.
+static HandleObject *(*get_handle_object)(CPUState *cpu, uint32_t eproc, uint32_t handle);
+
+
+char *make_pagedstr(void) {
+    char *m = g_strdup("(paged)");
+    assert(m);
+    return m;
+}
+
+// Gets a unicode string. Does its own mem allocation.
+// Output is a null-terminated UTF8 string
+char *get_unicode_str(CPUState *cpu, PTR ustr) {
+    uint16_t size = 0;
+    PTR str_ptr = 0;
+    if (-1 == panda_virtual_memory_rw(cpu, ustr, (uint8_t *)&size, 2, false)) {
+        return make_pagedstr();
+    }
+
+    // Clamp size
+    if (size > 1024) size = 1024;
+    if (-1 == panda_virtual_memory_rw(cpu, ustr+4, (uint8_t *)&str_ptr, 4, false)) {
+        return make_pagedstr();
+    }
+
+    gchar *in_str = (gchar *)g_malloc0(size);
+    if (-1 == panda_virtual_memory_rw(cpu, str_ptr, (uint8_t *)in_str, size, false)) {
+        g_free(in_str);
+        return make_pagedstr();
+    }
+
+    gsize bytes_written = 0;
+    gchar *out_str = g_convert(in_str, size,
+            "UTF-8", "UTF-16LE", NULL, &bytes_written, NULL);
+
+    // An abundance of caution: we copy it over to something allocated
+    // with our own malloc. In the future we need to provide a way for
+    // someone else to free the memory allocated in here...
+    char *ret = (char *)malloc(bytes_written+1);
+    memcpy(ret, out_str, bytes_written+1);
+    g_free(in_str);
+    g_free(out_str);
+    return ret;
+}
+
+
+void add_proc(CPUState *cpu, OsiProcs *ps, PTR eproc) {
+    static uint32_t capacity = 8;
+    if ((ps->proc == NULL) || (ps->num == capacity)) {
+        capacity *= 2;
+        ps->proc = (OsiProc *)realloc(ps->proc, sizeof(OsiProc) * capacity);
+        assert(ps->proc);
+    }
+
+    OsiProc *p = &ps->proc[ps->num++];
+    fill_osiproc(cpu, p, eproc);
+}
+
+void add_mod(CPUState *cpu, OsiModules *ms, PTR mod, bool ignore_basename) {
+    static uint32_t capacity = 8;
+    if ((ms->module == NULL ) || (ms->num == capacity)) {
+        capacity *= 2;
+        ms->module = (OsiModule *)realloc(ms->module, sizeof(OsiModule) * capacity);
+        assert(ms->module);
+    }
+
+    OsiModule *p = &ms->module [ms->num++];
+    fill_osimod(cpu, p, mod, ignore_basename);
+}
+
+void on_get_current_process(CPUState *cpu, OsiProc **out_p) {
+    PTR eproc = get_current_proc(cpu);
+    if(eproc) {
+        OsiProc *p = (OsiProc *) malloc(sizeof(OsiProc));
+        fill_osiproc(cpu, p, eproc);
+        *out_p = p;
+    } else {
+        *out_p = NULL;
+    }
+}
+
+void on_get_processes(CPUState *cpu, OsiProcs **out_ps) {
+    PTR first = get_current_proc(cpu);
+    if(first == 0) {
+        *out_ps = NULL;
+        return;
+    }
+    PTR first_pid = get_pid(cpu, first);
+    PTR current = first;
+
+    if (first_pid == 0) { // Idle proc, don't try
+        *out_ps = NULL;
+        return;
+    }
+
+    OsiProcs *ps = (OsiProcs *)malloc(sizeof(OsiProcs));
+    ps->num = 0;
+    ps->proc = NULL;
+
+    do {
+        // One of these will be the loop head,
+        // which we don't want to include
+        if (is_valid_process(cpu, current)) {
+            add_proc(cpu, ps, current);
+        }
+
+        current = get_next_proc(cpu, current);
+        if (!current) break;
+    } while (current != first);
+
+    *out_ps = ps;
+}
+
+
+uint32_t get_ntreadfile_esp_off(void) { return ntreadfile_esp_off; }
+
+uint32_t get_kthread_kproc_off(void) { return kthread_kproc_off; }
+
+uint32_t get_eproc_pid_off(void) { return eproc_pid_off; }
+
+uint32_t get_eproc_name_off(void) { return eproc_name_off; }
+
+uint32_t get_eproc_objtable_off(void) { return eproc_objtable_off; }
+
+uint32_t get_obj_type_offset(void) { return obj_type_offset; }
 
 uint32_t get_pid(CPUState *cpu, uint32_t eproc) {
     uint32_t pid;
-    panda_virtual_memory_rw(cpu, eproc+EPROC_PID_OFF, (uint8_t *)&pid, 4, false);
+    if(-1 == panda_virtual_memory_rw(cpu, eproc+eproc_pid_off, (uint8_t *)&pid, 4, false)) return 0;
     return pid;
 }
 
-void get_procname(CPUState *cpu, uint32_t eproc, char *name) {
-    panda_virtual_memory_rw(cpu, eproc+EPROC_NAME_OFF, (uint8_t *)name, 16, false);
-    name[16] = '\0';
+PTR get_ppid(CPUState *cpu, PTR eproc) {
+    PTR ppid;
+    if(-1 == panda_virtual_memory_rw(cpu, eproc+eproc_ppid_off, (uint8_t *)&ppid, sizeof(PTR), false)) return 0;
+    return ppid;
 }
+
+PTR get_dtb(CPUState *cpu, PTR eproc) {
+    PTR dtb = 0;
+    assert(!panda_virtual_memory_rw(cpu, eproc+EPROC_DTB_OFF, (uint8_t *)&dtb, sizeof(PTR), false));
+    assert(dtb);
+    return dtb;
+}
+
+
+void get_procname(CPUState *cpu, uint32_t eproc, char **name) {
+    assert(name);
+    *name = (char *) malloc(17);
+    assert(*name);
+    assert(!panda_virtual_memory_rw(cpu, eproc+eproc_name_off, (uint8_t *)*name, 16, false));
+    (*name)[16] = '\0';
+}
+
+bool is_valid_process(CPUState *cpu, PTR eproc) {
+    uint8_t type;
+    uint8_t size;
+
+    if(eproc == 0) return false;
+
+    if(-1 == panda_virtual_memory_rw(cpu, eproc+EPROC_TYPE_OFF, (uint8_t *)&type, 1, false)) return false;
+    if(-1 == panda_virtual_memory_rw(cpu, eproc+EPROC_SIZE_OFF, (uint8_t *)&size, 1, false)) return false;
+
+    return type == EPROC_TYPE && size == eproc_size &&
+        get_next_proc(cpu, eproc);
+}
+
 
 uint32_t get_current_proc(CPUState *cpu) {
-    CPUArchState *env = (CPUArchState*)cpu->env_ptr;
-    // Read the kernel-mode FS segment base
-    uint32_t e1, e2;
-    uint32_t fs_base, thread, proc;
-
-    // Read out the two 32-bit ints that make up a segment descriptor
-    panda_virtual_memory_rw(cpu, env->gdt.base + KMODE_FS, (uint8_t *)&e1, 4, false);
-    panda_virtual_memory_rw(cpu, env->gdt.base + KMODE_FS + 4, (uint8_t *)&e2, 4, false);
-
-    // Turn wacky segment into base
-    fs_base = (e1 >> 16) | ((e2 & 0xff) << 16) | (e2 & 0xff000000);
+    PTR thread, proc;
+    PTR kpcr = get_kpcr(cpu);
 
     // Read KPCR->CurrentThread->Process
-    panda_virtual_memory_rw(cpu, fs_base+KPCR_CURTHREAD_OFF, (uint8_t *)&thread, 4, false);
-    panda_virtual_memory_rw(cpu, thread+KTHREAD_KPROC_OFF, (uint8_t *)&proc, 4, false);
+    if (-1 == panda_virtual_memory_rw(cpu, kpcr+KPCR_CURTHREAD_OFF, (uint8_t *)&thread, sizeof(PTR), false)) return 0;
+    if (-1 == panda_virtual_memory_rw(cpu, thread+get_kthread_kproc_off(), (uint8_t *)&proc, sizeof(PTR), false)) return 0;
 
-    return proc;
+    // Sometimes, proc == 0 here.  Is there a better way to do this?
+
+    return is_valid_process(cpu, proc) ? proc : 0;
 }
 
+// Process introspection
+PTR get_next_proc(CPUState *cpu, PTR eproc) {
+    PTR next;
+    if (-1 == panda_virtual_memory_rw(cpu, eproc+eproc_links_off, (uint8_t *)&next, sizeof(PTR), false))
+        return 0;
+    next -= eproc_links_off;
+    return next;
+}
 
-
-
-
-#define IMAGEPATHNAME_OFF      0x38
-#define OBJNAME_OFF            0x8
-#define EPROC_OBJTABLE_OFF     0xf4
-
-#define HANDLE_MASK1  0x000007fc
-#define HANDLE_SHIFT1  2
-#define HANDLE_MASK2  0x001ff800
-#define HANDLE_SHIFT2  11
-#define HANDLE_MASK3  0x7fe00000
-#define HANDLE_SHIFT3  21
-#define LEVEL_MASK 0x00000007
-#define TABLE_MASK ~LEVEL_MASK
-#define ADDR_SIZE 4
-#define HANDLE_TABLE_ENTRY_SIZE 8
 
 
 // Win7 Obj Type Indices
+/*
 typedef enum {
     OBJ_TYPE_Type = 2,
     OBJ_TYPE_Directory = 3,
@@ -139,22 +322,23 @@ typedef enum {
     OBJ_TYPE_FilterCommunicationPort = 42,
     OBJ_TYPE_PcwObject = 43
 } OBJ_TYPES;
+*/
 
 
-static uint32_t handle_table_code(CPUState *cpu, uint32_t table_vaddr) {
+uint32_t handle_table_code(CPUState *cpu, uint32_t table_vaddr) {
     uint32_t tableCode;
     // HANDLE_TABLE.TableCode is offest 0
-    panda_virtual_memory_rw(cpu, table_vaddr, (uint8_t *)&tableCode, 4, false);
+    assert(!panda_virtual_memory_rw(cpu, table_vaddr, (uint8_t *)&tableCode, 4, false));
     return (tableCode & TABLE_MASK);
 }
 
 
-static uint32_t handle_table_L1_addr(CPUState *cpu, uint32_t table_vaddr, uint32_t entry_num) {
-    return handle_table_code(cpu, table_vaddr) + ADDR_SIZE * entry_num;
+uint32_t handle_table_L1_addr(CPUState *cpu, uint32_t table_vaddr, uint32_t entry_num) {
+    return table_vaddr + ADDR_SIZE * entry_num;
 }
 
 
-static uint32_t handle_table_L2_addr(uint32_t L1_table, uint32_t L2) {
+uint32_t handle_table_L2_addr(uint32_t L1_table, uint32_t L2) {
     if (L1_table != 0x0) {
         uint32_t L2_entry = L1_table + ADDR_SIZE * L2;
         return L2_entry;
@@ -163,69 +347,52 @@ static uint32_t handle_table_L2_addr(uint32_t L1_table, uint32_t L2) {
 }
 
 
-static uint32_t handle_table_L1_entry(CPUState *cpu, uint32_t table_vaddr, uint32_t entry_num) {
-    return (handle_table_code(cpu, table_vaddr) +    
+uint32_t handle_table_L1_entry(CPUState *cpu, uint32_t table_vaddr, uint32_t entry_num) {
+    return (handle_table_code(cpu, table_vaddr) +
             HANDLE_TABLE_ENTRY_SIZE * entry_num);
 }
 
 
-static uint32_t handle_table_L2_entry(uint32_t table_vaddr, uint32_t L1_table, uint32_t L2) {
+uint32_t handle_table_L2_entry(uint32_t table_vaddr, uint32_t L1_table, uint32_t L2) {
     if (L1_table == 0) return 0;
     return L1_table + HANDLE_TABLE_ENTRY_SIZE * L2;
 }
 
 
-static uint32_t handle_table_L3_entry(uint32_t table_vaddr, uint32_t L2_table, uint32_t L3) {
+uint32_t handle_table_L3_entry(uint32_t table_vaddr, uint32_t L2_table, uint32_t L3) {
     if (L2_table == 0) return 0;
     return L2_table + HANDLE_TABLE_ENTRY_SIZE * L3;
 }
 
-// i.e. return pointer to the object represented by this handle
-uint32_t get_handle_table_entry(CPUState *cpu, uint32_t pHandleTable, uint32_t handle) {
-    uint32_t tableCode, tableLevels;
-    // get tablecode
-    panda_virtual_memory_rw(cpu, pHandleTable, (uint8_t *)&tableCode, 4, false);
-    //printf ("tableCode = 0x%x\n", tableCode);
-    // extract levels
-    tableLevels = tableCode & LEVEL_MASK;
-    //printf("tableLevels = %d\n", tableLevels);
-    //  assert (tableLevels <= 2);
-    if (tableLevels > 2) {
-        return 0;
-    }
-    uint32_t pEntry=0;
-    if (tableLevels == 0) {
-        uint32_t index = (handle & HANDLE_MASK1) >> HANDLE_SHIFT1;
-        pEntry = handle_table_L1_entry(cpu, pHandleTable, index);
-    }
-    if (tableLevels == 1) {
-        uint32_t L1_index = (handle & HANDLE_MASK2) >> HANDLE_SHIFT2;
-        uint32_t L1_table_off = handle_table_L1_addr(cpu, pHandleTable, L1_index);
-        uint32_t L1_table;
-        panda_virtual_memory_rw(cpu, L1_table_off, (uint8_t *) &L1_table, 4, false);
-        uint32_t index = (handle & HANDLE_MASK1) >> HANDLE_SHIFT1;
-        pEntry = handle_table_L2_entry(pHandleTable, L1_table, index);
-    }
-    if (tableLevels == 2) {
-        uint32_t L1_index = (handle & HANDLE_MASK3) >> HANDLE_SHIFT3;
-        uint32_t L1_table_off = handle_table_L1_addr(cpu, pHandleTable, L1_index);
-        uint32_t L1_table;
-        panda_virtual_memory_rw(cpu, L1_table_off, (uint8_t *) &L1_table, 4, false);
-        uint32_t L2_index = (handle & HANDLE_MASK2) >> HANDLE_SHIFT2;
-        uint32_t L2_table_off = handle_table_L2_addr(L1_table, L2_index);
-        uint32_t L2_table;
-        panda_virtual_memory_rw(cpu, L2_table_off, (uint8_t *) &L2_table, 4, false);
-        uint32_t index = (handle & HANDLE_MASK1) >> HANDLE_SHIFT1;
-        pEntry = handle_table_L3_entry(pHandleTable, L2_table, index);
-    }
-    uint32_t pObjectHeader;
-    if ((panda_virtual_memory_rw(cpu, pEntry, (uint8_t *) &pObjectHeader, 4, false)) == -1) {
-        return 0;
-    }
-    //  printf ("processHandle_to_pid pObjectHeader = 0x%x\n", pObjectHeader);
-    pObjectHeader &= ~0x00000007;
 
-    return pObjectHeader;
+
+// Module stuff
+const char *get_mod_basename(CPUState *cpu, PTR mod) {
+    return get_unicode_str(cpu, mod+LDR_BASENAME_OFF);
+}
+
+const char *get_mod_filename(CPUState *cpu, PTR mod) {
+    return get_unicode_str(cpu, mod+LDR_FILENAME_OFF);
+}
+
+PTR get_mod_base(CPUState *cpu, PTR mod) {
+    PTR base;
+    assert(!panda_virtual_memory_rw(cpu, mod+LDR_BASE_OFF, (uint8_t *)&base, sizeof(PTR), false));
+    return base;
+}
+
+PTR get_mod_size(CPUState *cpu, PTR mod) {
+    uint32_t size;
+    assert(!panda_virtual_memory_rw(cpu, mod+LDR_SIZE_OFF, (uint8_t *)&size, sizeof(uint32_t), false));
+    return size;
+}
+
+PTR get_next_mod(CPUState *cpu, PTR mod) {
+    PTR next;
+    if (-1 == panda_virtual_memory_rw(cpu, mod+LDR_LOAD_LINKS_OFF, (uint8_t *)&next, sizeof(PTR), false))
+        return 0;
+    next -= LDR_LOAD_LINKS_OFF;
+    return next;
 }
 
 // Hack
@@ -234,23 +401,25 @@ static void unicode_to_ascii(char *uni, char *ascii, int len) {
     for (i = 0; i < len; i++) {
         ascii[i] = uni[i*2];
     }
+    ascii[i] = '\0';
 }
 
 char *read_unicode_string(CPUState *cpu, uint32_t pUstr) {
     uint16_t fileNameLen;
     uint32_t fileNamePtr;
-    char *fileName = (char *)calloc(1, 260);
     char fileNameUnicode[260*2] = {};
 
-    panda_virtual_memory_rw(cpu, pUstr,
-            (uint8_t *) &fileNameLen, 2, false);
-    panda_virtual_memory_rw(cpu, pUstr+4,
-            (uint8_t *) &fileNamePtr, 4, false);
+    assert(!panda_virtual_memory_rw(cpu, pUstr,
+            (uint8_t *) &fileNameLen, 2, false));
+    assert(!panda_virtual_memory_rw(cpu, pUstr+4,
+            (uint8_t *) &fileNamePtr, 4, false));
 
     if (fileNameLen > 259*2) {
         fileNameLen = 259*2;
     }
-    panda_virtual_memory_rw(cpu, fileNamePtr, (uint8_t *)fileNameUnicode, fileNameLen, false);
+    assert(!panda_virtual_memory_rw(cpu, fileNamePtr, (uint8_t *)fileNameUnicode, fileNameLen, false));
+    char *fileName = (char *)malloc(fileNameLen/2+1);
+    assert(fileName);
     unicode_to_ascii(fileNameUnicode, fileName, fileNameLen/2);
 
     return fileName;
@@ -260,17 +429,15 @@ char *read_unicode_string(CPUState *cpu, uint32_t pUstr) {
 char * get_objname(CPUState *cpu, uint32_t obj) {
   uint32_t pObjectName;
 
-  panda_virtual_memory_rw(cpu, obj+OBJNAME_OFF,
-              (uint8_t *) &pObjectName, 4, false);
+  assert(!panda_virtual_memory_rw(cpu, obj+OBJNAME_OFF,
+              (uint8_t *) &pObjectName, 4, false));
   return read_unicode_string(cpu, pObjectName);
 }
 
-#define FILE_OBJECT_NAME_OFF 0x30
 char *get_file_obj_name(CPUState *cpu, uint32_t fobj) {
     return read_unicode_string(cpu, fobj+FILE_OBJECT_NAME_OFF);
 }
 
-#define FILE_OBJECT_POS_OFF 0x38
 int64_t get_file_obj_pos(CPUState *cpu, uint32_t fobj) {
     int64_t file_pos = -1;
     if (-1 == panda_virtual_memory_rw(cpu, fobj+FILE_OBJECT_POS_OFF, (uint8_t *)&file_pos, 8, false))
@@ -279,65 +446,21 @@ int64_t get_file_obj_pos(CPUState *cpu, uint32_t fobj) {
         return file_pos;
 }
 
-HandleObject *get_handle_object(CPUState *cpu, uint32_t eproc, uint32_t handle) {
-    uint32_t pObjectTable;
-    if (-1 == panda_virtual_memory_rw(cpu, eproc+EPROC_OBJTABLE_OFF, (uint8_t *)&pObjectTable, 4, false)) {
-        return NULL;
-    }
-    uint32_t pObjHeader = get_handle_table_entry(cpu, pObjectTable, handle);
-    if (pObjHeader == 0) return NULL;
-    uint32_t pObj = pObjHeader + 0x18;
-    uint8_t objType = 0;
-    if (-1 == panda_virtual_memory_rw(cpu, pObjHeader+0xc, &objType, 1, false)) {
-        return NULL;
-    }
-    HandleObject *ho = (HandleObject *) malloc(sizeof(HandleObject));
-    ho->objType = objType;
-    ho->pObj = pObj;
-    return ho;
-}
-
-/*
-HandleObject *get_handle_object_current(CPUState *cpu, uint32_t HandleVariable) {
-  uint32_t eproc = get_current_proc(cpu);
-  uint32_t handle;
-  if (-1 == panda_virtual_memory_rw(cpu, HandleVariable, (uint8_t *)&handle, 4, false)) {
-    return NULL;
-  }
-  return get_handle_object(cpu, eproc, handle);
-}
-*/
-
 char *get_handle_object_name(CPUState *cpu, HandleObject *ho) {
-    if (ho == NULL){
-        char *procName = (char *) calloc(8, 1);
-        sprintf(procName, "unknown");
-        return procName;
+    char *name;
+    if (ho == NULL) {
+        name = g_strdup("unknown");
+    } else if(ho->objType == obj_type_file) {
+        name = get_file_obj_name(cpu, ho->pObj);
+    } else if(ho->objType == obj_type_key) {
+        name = g_strdup_printf("_CM_KEY_BODY@%08x", ho->pObj);
+    } else if(ho->objType == obj_type_process) {
+        get_procname(cpu, ho->pObj, &name);
+    } else {
+        name=g_strdup_printf("unknown object type %d", ho->objType);
     }
-    switch (ho->objType) {
-    case OBJ_TYPE_File:
-        return get_file_obj_name(cpu, ho->pObj);
-    case OBJ_TYPE_Key: {
-        char *fileName = (char *) calloc(100, 1);
-        sprintf(fileName, "_CM_KEY_BODY@%08x", ho->pObj);
-        return fileName;
-        break;
-    }
-    case OBJ_TYPE_Process: {
-        char *procName = (char *) calloc(17, 1);
-        //char procExeName[16] = {};
-        //uint32_t procPid = get_pid(cpu, ho->pObj);
-        get_procname(cpu, ho->pObj, procName);
-        //sprintf(procName, "[%d] %s", procPid, procExeName);
-        return procName;
-        break;
-    }
-    default: {
-        char *procName = (char *) calloc(8, 1);
-        sprintf(procName, "unknown");
-        return procName;
-    }
-    }
+    assert(name);
+    return name;
 }
 
 
@@ -350,11 +473,60 @@ int64_t get_file_handle_pos(CPUState *cpu, uint32_t eproc, uint32_t handle) {
     HandleObject *ho = get_handle_object(cpu, eproc, handle);
     if (!ho) {
         return -1;
-    }
-    else {
+    } else {
         return get_file_obj_pos(cpu, ho->pObj);
     }
 }
+
+void fill_osiproc(CPUState *cpu, OsiProc *p, PTR eproc) {
+    p->offset = eproc;
+    get_procname(cpu, eproc, &p->name);
+    p->asid = get_dtb(cpu, eproc);
+    p->pages = NULL;
+    p->pid = get_pid(cpu, eproc);
+    p->ppid = get_ppid(cpu, eproc);
+}
+
+void fill_osimod(CPUState *cpu, OsiModule *m, PTR mod, bool ignore_basename) {
+    m->offset = mod;
+    m->file = (char *)get_mod_filename(cpu, mod);
+    m->base = get_mod_base(cpu, mod);
+    m->size = get_mod_size(cpu, mod);
+    m->name = ignore_basename ? g_strdup("-") : (char *)get_mod_basename(cpu, mod);
+    assert(m->name);
+}
+
+
+void on_free_osiproc(OsiProc *p) {
+    if (!p) return;
+    free(p->name);
+    free(p);
+}
+
+void on_free_osiprocs(OsiProcs *ps) {
+    if(!ps) return;
+    if(ps->proc) {
+        for(uint32_t i = 0; i < ps->num; i++) {
+            free(ps->proc[i].name);
+        }
+        free(ps->proc);
+    }
+    free(ps);
+}
+
+void on_free_osimodules(OsiModules *ms) {
+    if(!ms) return;
+    if(ms->module) {
+        for(uint32_t i = 0; i < ms->num; i++) {
+            free(ms->module[i].file);
+            free(ms->module[i].name);
+        }
+        free(ms->module);
+    }
+    free(ms);
+}
+
+
 
 #endif
 
@@ -364,7 +536,53 @@ bool init_plugin(void *self) {
     // this stuff only currently works for win7 or win2000, 32-bit
     assert (panda_os_familyno == OS_WINDOWS);
     assert (panda_os_bits == 32);
-    assert (0 == strcmp(panda_os_variant, "7") || 0 == strcmp(panda_os_variant, "2000"));
+    assert (panda_os_variant);
+
+    if(0 == strcmp(panda_os_variant, "7")) {
+        kthread_kproc_off=0x150;
+        eproc_pid_off=0x0b4;
+        eproc_ppid_off=0x140;
+        eproc_name_off=0x16c;
+        eproc_objtable_off=0xf4;
+        obj_type_file = 28;
+        obj_type_key = 35;
+        obj_type_process = 7;
+        obj_type_offset = 0xc;
+        eproc_size = 0x26;
+        eproc_links_off = 0x0b8;
+        ntreadfile_esp_off = 0;
+        panda_require("win7x86intro");
+        assert(init_win7x86intro_api());
+        get_kpcr = get_win7_kpcr;
+        get_handle_object = get_win7_handle_object;
+    } else if (0 == strcmp(panda_os_variant, "2000")) {
+        kthread_kproc_off=0x22c;
+        eproc_pid_off=0x09c;
+        eproc_ppid_off=0x1c8;
+        eproc_name_off=0x1fc;
+        eproc_objtable_off=0x128;
+        obj_type_file = 0x05;
+        obj_type_key = 0x32;
+        obj_type_process = 0x03;
+        obj_type_offset = 0x18;
+        eproc_size = 0x1b;
+        eproc_links_off = 0x0a0;
+        ntreadfile_esp_off = 0x24;
+        panda_require("win2000x86intro");
+        assert(init_win2000x86intro_api());
+        get_kpcr = get_win2000_kpcr;
+        get_handle_object = get_win2000_handle_object;
+    } else {
+        fprintf(stderr, "Plugin is not supported for this windows "
+            "version (%s).\n", panda_os_variant);
+    }
+
+    PPP_REG_CB("osi", on_get_current_process, on_get_current_process);
+    PPP_REG_CB("osi", on_get_processes, on_get_processes);
+    PPP_REG_CB("osi", on_free_osiproc, on_free_osiproc);
+    PPP_REG_CB("osi", on_free_osiprocs, on_free_osiprocs);
+    PPP_REG_CB("osi", on_free_osimodules, on_free_osimodules);
+
     return true;
 #else
     fprintf(stderr, "Plugin is not supported on this platform.\n");

--- a/panda/plugins/wintrospection/wintrospection.h
+++ b/panda/plugins/wintrospection/wintrospection.h
@@ -8,7 +8,22 @@ typedef struct handle_object_struct {
     uint32_t pObj;
 } HandleObject;
 
+// Size of guest pointer.
+// Note that this can't just be target_ulong since
+// a 32-bit OS will run on x86_64-softmmu
+// To add support for a 64-bit OS, consider creating a wintrospection64 plugin.
+#define PTR uint32_t
 
+#define HANDLE_MASK1  0x000007fc
+#define HANDLE_SHIFT1 2
+#define HANDLE_MASK2  0x001ff800
+#define HANDLE_SHIFT2  11
+#define HANDLE_MASK3  0x7fe00000
+#define HANDLE_SHIFT3  21
+#define LEVEL_MASK 0x00000007
+#define TABLE_MASK ~LEVEL_MASK
+#define ADDR_SIZE 4
+#define HANDLE_TABLE_ENTRY_SIZE 8
 
 #endif
 

--- a/panda/plugins/wintrospection/wintrospection_int.h
+++ b/panda/plugins/wintrospection/wintrospection_int.h
@@ -3,6 +3,12 @@ typedef void HandleObject;
 typedef void CPUState;
 typedef void uint32_t;
 typedef void int64_t;
+typedef void bool;
+typedef void PTR;
+typedef void OsiProc;
+typedef void OsiProcs;
+typedef void OsiModule;
+typedef void OsiModules;
 
 #include "wintrospection_int_fns.h"
 

--- a/panda/plugins/wintrospection/wintrospection_int_fns.h
+++ b/panda/plugins/wintrospection/wintrospection_int_fns.h
@@ -1,16 +1,29 @@
 #ifndef __WINTROSPECTION_INT_FNS_H__
 #define __WINTROSPECTION_INT_FNS_H__
 
-// returns virtual address of EPROCESS data structure of currently running process
-uint32_t get_current_proc(CPUState *cpu) ;
+char *make_pagedstr(void);
 
-// returns pid, given virtual address of EPROCESS data structure
+char *get_unicode_str(CPUState *cpu, PTR ustr);
+
+// returns virtual address of EPROCESS data structure of currently running process
+uint32_t get_current_proc(CPUState *cpu);
+
+// returns next process in process list
+PTR get_next_proc(CPUState *cpu, PTR eproc);
+
+// returns true if eproc points to an EPROCESS structure
+bool is_valid_process(CPUState *cpu, PTR eproc);
+
+// returns pid,given virtual address of EPROCESS data structure
 uint32_t get_pid(CPUState *cpu, uint32_t eproc) ;
 
-// fills name (assumed alloced) for process given virtual address of EPROCESS data structure
-void get_procname(CPUState *cpu, uint32_t eproc, char *name) ;
+// returns parent pid,given virtual address of EPROCESS data structure
+PTR get_ppid(CPUState *cpu, uint32_t eproc);
 
-HandleObject *get_handle_object(CPUState *cpu, uint32_t eproc, uint32_t handle);
+PTR get_dtb(CPUState *cpu, PTR eproc);
+
+// fills name (assumed alloced) for process given virtual address of EPROCESS data structure
+void get_procname(CPUState *cpu, uint32_t eproc, char **name) ;
 
 char *get_handle_object_name(CPUState *cpu, HandleObject *ho);
 
@@ -20,12 +33,56 @@ char *get_handle_name(CPUState *cpu, uint32_t eproc, uint32_t handle) ;
 
 char * get_objname(CPUState *cpu, uint32_t obj) ;
 
-uint32_t get_handle_table_entry(CPUState *cpu, uint32_t pHandleTable, uint32_t handle) ;
-
 char *get_file_obj_name(CPUState *cpu, uint32_t fobj) ;
 
 int64_t get_file_obj_pos(CPUState *cpu, uint32_t fobj) ;
 
 char *read_unicode_string(CPUState *cpu, uint32_t pUstr);
+
+const char *get_mod_basename(CPUState *cpu, PTR mod);
+
+const char *get_mod_filename(CPUState *cpu, PTR mod);
+
+PTR get_mod_base(CPUState *cpu, PTR mod);
+
+PTR get_mod_size(CPUState *cpu, PTR mod);
+
+PTR get_next_mod(CPUState *cpu, PTR mod);
+
+void fill_osiproc(CPUState *cpu, OsiProc *p, PTR eproc);
+
+void fill_osimod(CPUState *cpu, OsiModule *m, PTR mod, bool ignore_basename);
+
+void add_mod(CPUState *cpu, OsiModules *ms, PTR mod, bool ignore_basename);
+
+void on_get_current_process(CPUState *cpu, OsiProc **out_p);
+
+void on_get_processes(CPUState *cpu, OsiProcs **out_ps);
+
+// Getters for os-specific constants
+uint32_t get_ntreadfile_esp_off(void);
+
+uint32_t get_eproc_pid_off(void);
+
+uint32_t get_eproc_name_off(void);
+
+uint32_t get_kthread_kproc_off(void);
+
+uint32_t get_eproc_objtable_off(void);
+
+uint32_t get_obj_type_offset(void);
+
+uint32_t handle_table_code(CPUState *cpu, uint32_t table_vaddr);
+
+uint32_t handle_table_L1_addr(CPUState *cpu, uint32_t table_vaddr, uint32_t entry_num);
+
+uint32_t handle_table_L2_addr(uint32_t L1_table, uint32_t L2);
+
+uint32_t handle_table_L1_entry(CPUState *cpu, uint32_t table_vaddr, uint32_t entry_num);
+
+uint32_t handle_table_L2_entry(uint32_t table_vaddr, uint32_t L1_table, uint32_t L2);
+
+uint32_t handle_table_L3_entry(uint32_t table_vaddr, uint32_t L2_table, uint32_t L3);
+
 
 #endif


### PR DESCRIPTION
I reworked the windows introspection plugins a bit.  Code that works on all supported versions of windows, with perhaps slight configuration variations due to kernel structure offsets, lives in the wintrospection plugin.  When necessary for OS-specific support, the wintrospection plugin will consult os-specific functions in the win7x86intro or win2000x86intro plugins.

Made a slight tweak to the file-taint plugin to account for some windows 2000 behavior in regards to system calls.  With this change, file-taint appears to be working with windows 2000 guests.