### PR TITLE
Fix issues when using 4GB or more of RAM

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -2714,7 +2714,9 @@ static MemTxResult address_space_write_continue(AddressSpace *as, hwaddr addr,
             /* RAM case */
             ptr = qemu_map_ram_ptr(mr->ram_block, addr1);
             if (rr_in_record() && (rr_record_in_progress || rr_record_in_main_loop_wait)) {
-                rr_device_mem_rw_call_record(addr1, buf, l, /*is_write*/1);
+                // We should record the memory address relative to the address space, not physical memory.
+                // During replay, this address will be translated into the physical address.
+                rr_device_mem_rw_call_record(addr, buf, l, /*is_write*/1);
             }
             panda_callbacks_before_dma(first_cpu, addr1, buf, l, /*is_write=1*/ 1);
             memcpy(ptr, buf, l);


### PR DESCRIPTION
This PR fixes two issues. First the CRC32 computation is wrong when 4GB of RAM or more is used. Secondly, the recorded DMA write address should be the address relative to the guest address space, not physical guest memory. Explanations below.

The CRC32 from zlib accepts an unsigned integer as its length parameter. If the length parameter is 2^32 in the case of 4GB of RAM, then the compiler converts this into an unsigned integer which would be zero. Thus, the CRC32 computation processes zero bytes of guest memory. The solution was to compute the guest memory checksum in chunks of 2^32-1 bytes. I tested this fix by dumping the guest memory to a file and running the `crc32` command on the file and comparing that with the resulting checksum from this fix. This does seem to slow down PANDA at the end when you use large amounts of memory, but at 4GB of memory the crc32 computation was nearly instant because it wasn't processing anything.

DMA writes when using 4GB of guest memory also seem to break replays. For this issue, I think the problem occurs close to 4GB of RAM because of the guest memory mapping, but I don't have an exact threshold. If a DMA write occurs during recording, PANDA records the memory address relative to the physical memory. During replay, PANDA (QEMU) still tries to convert the recorded address into a physical address, even though the address is already a physical one. When the memory write occurs, if the resulting translated address isn't mapped by the MMU, you will experience a segfault.