### PR TITLE
fixes for plugin name generation + wintrospection

### DIFF
--- a/panda/include/panda/plugin_plugin.h
+++ b/panda/include/panda/plugin_plugin.h
@@ -112,7 +112,7 @@ to add a callback to be run inside of plugin A.
 #define PPP_REG_CB(other_plugin, cb_name, cb_func)			\
   {									\
     dlerror();								\
-    void *op = panda_get_plugin_by_name("panda_" other_plugin ".so");	\
+    void *op = panda_get_plugin_by_name(other_plugin);			\
     if (!op) {								\
       printf("In trying to add plugin callback, couldn't load %s plugin\n", other_plugin); \
       assert (op);							\

--- a/panda/plugins/syscalls2/syscalls2_info.c
+++ b/panda/plugins/syscalls2/syscalls2_info.c
@@ -22,11 +22,11 @@ int load_syscall_info(void) {
 
     if (panda_os_familyno == OS_WINDOWS) {
         // for windows, take into account the panda_os_variant
-        syscall_info_dlname = g_strdup_printf("dso_%s_gen_syscall_info_%s_%s_%s.so", PLUGIN_NAME, panda_os_family, panda_os_variant, arch);
+        syscall_info_dlname = g_strdup_printf("dso_%s_gen_syscall_info_%s_%s_%s" HOST_DSOSUF, PLUGIN_NAME, panda_os_family, panda_os_variant, arch);
     }
     else {
         // for everything else (i.e. linux), only use panda_os_family
-        syscall_info_dlname = g_strdup_printf("dso_%s_gen_syscall_info_%s_%s.so", PLUGIN_NAME, panda_os_family, arch);
+        syscall_info_dlname = g_strdup_printf("dso_%s_gen_syscall_info_%s_%s" HOST_DSOSUF, PLUGIN_NAME, panda_os_family, arch);
     }
 
     // panda_os_bits will be useful when support for 64bit operating systems is added

--- a/panda/plugins/wintrospection/wintrospection.h
+++ b/panda/plugins/wintrospection/wintrospection.h
@@ -8,6 +8,14 @@ typedef struct handle_object_struct {
     uint32_t pObj;
 } HandleObject;
 
+
+// See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa380518(v=vs.85).aspx
+typedef struct {
+    uint16_t Length;        // length excluding terminator in bytes
+    uint16_t MaximumLength; // allocated memory for buffer
+    target_ulong Buffer;    // pointer to allocated memory
+} win_unicode_string_t;
+
 // Size of guest pointer.
 // Note that this can't just be target_ulong since
 // a 32-bit OS will run on x86_64-softmmu

--- a/panda/scripts/apigen.py
+++ b/panda/scripts/apigen.py
@@ -102,7 +102,7 @@ def generate_code(functions, module, includes):
 
         static inline bool init_{0}_api(void);
         static inline bool init_{0}_api(void) {{
-            void *module = panda_get_plugin_by_name("panda_" API_PLUGIN_NAME ".so");
+            void *module = panda_get_plugin_by_name(API_PLUGIN_NAME);
             if (!module) {{
                 fprintf(stderr, "Couldn't load %s plugin: %s\\n", API_PLUGIN_NAME, dlerror());
                 return false;


### PR DESCRIPTION
- Added stripping of trailing ".so" for auto-generated name for the plugin struct.
- Eliminated hardcoded ".so" (which should cause problem on OSX - if anyone still cares :)).

While merging with master, I noticed that wintrospection was causing my build to fail due to an assertion on an assignment. Took the opportunity to fix that + make some improvements on the nearby code.

@MarkMankins, could you check that g_str_to_ascii() from glib works same as the "hack" function it replaces?