### PR TITLE
Port PANDA 1 'network' plugin to PANDA 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,9 @@ dist: trusty
 before_install:
     - sudo pip install pycparser
     - git submodule update --init dtc
-script: sudo panda/scripts/install_ubuntu.sh && cd ./build && sudo make check
+script:
+    - travis_wait 35 sleep infinity &
+    - sudo panda/scripts/install_ubuntu.sh && cd ./build && sudo make check
 #before_script:
 #  - ./configure ${CONFIG}
 #script:

--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -20,5 +20,6 @@ memsavep
 unigrams
 textprinter
 net
+network
 filereadmon
 win2000x86intro

--- a/panda/plugins/network/Makefile
+++ b/panda/plugins/network/Makefile
@@ -1,0 +1,9 @@
+# Don't forget to add your plugin to config.panda!
+
+# If you need custom CFLAGS or LIBS, set them up here
+QEMU_INCLUDES += -I/usr/include/wireshark
+LIBS += -lwiretap
+
+# The main rule for your plugin. List all object-file dependencies.
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
+	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o

--- a/panda/plugins/network/USAGE.md
+++ b/panda/plugins/network/USAGE.md
@@ -1,0 +1,32 @@
+Plugin: network
+===========
+
+Summary
+-------
+
+The `network` plugin produces a PCAP file containing network traffic seen during the replay. This is handy if you forgot to enable QEMU's native PCAP logging when making the initial recording. You can then analyze the resulting PCAP in Wireshark.
+
+This is only currently supported for the E1000 network card, which is the default for x86 guests.
+
+Arguments
+---------
+
+* `file`: string, no default. The filename to save the network traffic to.
+
+Dependencies
+------------
+
+None.
+
+APIs and Callbacks
+------------------
+
+None.
+
+Example
+-------
+
+To save traffic to `foo.pcap`:
+
+    $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
+        -panda network:file=foo.pcap

--- a/panda/plugins/network/network.cpp
+++ b/panda/plugins/network/network.cpp
@@ -1,0 +1,138 @@
+/* PANDABEGINCOMMENT
+ * 
+ * Authors:
+ *  Tim Leek               tleek@ll.mit.edu
+ *  Ryan Whelan            rwhelan@ll.mit.edu
+ *  Joshua Hodosh          josh.hodosh@ll.mit.edu
+ *  Michael Zhivich        mzhivich@ll.mit.edu
+ *  Brendan Dolan-Gavitt   brendandg@gatech.edu
+ * 
+ * This work is licensed under the terms of the GNU GPL, version 2. 
+ * See the COPYING file in the top-level directory. 
+ * 
+ PANDAENDCOMMENT */
+// This needs to be defined before anything is included in order to get
+// the PRIx64 macro
+#define __STDC_FORMAT_MACROS
+
+#define COMMENT_BUF_LEN 1024
+
+#include "panda/plugin.h"
+
+#include <wireshark/config.h>
+#include <wiretap/wtap.h>
+
+// These need to be extern "C" so that the ABI is compatible with
+// QEMU/PANDA, which is written in C
+extern "C" {
+
+    bool init_plugin(void *);
+    void uninit_plugin(void *);
+
+    int handle_packet(CPUState *env, uint8_t *buf, int size, uint8_t direction,
+                uint64_t old_buf_addr);
+
+    extern uint64_t rr_get_guest_instr_count(void);
+}
+
+panda_arg_list *args;
+wtap_dumper *plugin_log;
+
+bool init_plugin(void *self) {
+    panda_cb pcb;
+
+    int i;
+    char *tblog_filename = NULL;
+    args = panda_get_args("network");
+    if (args != NULL) {
+        for (i = 0; i < args->nargs; i++) {
+            // Format is sample:file=<file>
+            if (0 == strncmp(args->list[i].key, "file", 4)) {
+                tblog_filename = args->list[i].value;
+            }
+        }
+    }
+
+    if (!tblog_filename) {
+        fprintf(stderr, "Plugin 'network' needs argument: -panda-arg network:file=<file>\n");
+        return false;
+    }
+
+#if VERSION_MAJOR == 2 && VERSION_MINOR == 2 && VERSION_MICRO >= 4
+    wtap_init();
+#endif
+
+    int err;
+    plugin_log = wtap_dump_open_ng(
+            /*filename*/tblog_filename,
+            /*file_type_subtype*/WTAP_FILE_TYPE_SUBTYPE_PCAPNG,
+            /*encap*/WTAP_ENCAP_ETHERNET,
+            /*snaplen*/65535,
+            /*compressed*/1,
+            /*shb_hdrs*/NULL,
+            /*idb_inf*/NULL,
+#if VERSION_MAJOR >= 2 && VERSION_MINOR >= 0 && VERSION_MICRO >= 0
+            /*nrb_hdrs*/NULL,
+#endif
+            /*err*/&err);
+    if(!plugin_log) {
+        fprintf(stderr, "Plugin 'network': failed wtap_dump_open_ng() with error %d\n", err);
+        return false;
+    }
+
+    pcb.replay_handle_packet = handle_packet;
+    panda_register_callback(self, PANDA_CB_REPLAY_HANDLE_PACKET, pcb);
+
+    return true;
+}
+
+void uninit_plugin(void *self) {
+    printf("Unloading network plugin.\n");
+    panda_free_args(args);
+    int err;
+    gboolean ret = wtap_dump_close(plugin_log, &err);
+    if (!ret) {
+        fprintf(stderr, "Plugin 'network': failed wtap_dump_close() with error %d\n", err);
+    }
+}
+
+int handle_packet(CPUState *env, uint8_t *buf, int size, uint8_t direction,
+                uint64_t old_buf_addr) {
+    int err;
+    struct wtap_pkthdr header;
+    struct timeval now_tv;
+    char comment_buf[COMMENT_BUF_LEN];
+#if VERSION_MAJOR >= 2 && VERSION_MINOR >= 0 && VERSION_MICRO >= 0
+    char *err_info;
+    wtap_phdr_init(&header);
+#endif
+    gettimeofday(&now_tv, NULL);
+    header.ts.secs = now_tv.tv_sec;
+    header.ts.nsecs = now_tv.tv_usec * 1000;
+    header.caplen = size;
+    header.len = size;
+    header.opt_comment = comment_buf;
+    snprintf(comment_buf, COMMENT_BUF_LEN, "Guest instruction count: %" PRIu64, rr_get_guest_instr_count());
+    gboolean ret = wtap_dump(
+        /*wtap_dumper*/plugin_log,
+        /*wtap_pkthdr*/&header,
+        /*buf*/buf,
+        /*err*/&err
+#if VERSION_MAJOR >= 2 && VERSION_MINOR >= 0 && VERSION_MICRO >= 0
+        ,
+        /*err_info*/&err_info
+#endif
+        );
+    if (!ret) {
+      fprintf(stderr, "Plugin 'network': failed wtap_dump() with error %d", err);
+#if VERSION_MAJOR >= 2 && VERSION_MINOR >= 0 && VERSION_MICRO >= 0
+      fprintf(stderr, " and error_info %s", err_info);
+#endif
+      fprintf(stderr, "\n");
+    }
+#if VERSION_MAJOR >= 2 && VERSION_MINOR >= 0 && VERSION_MICRO >= 0
+    wtap_phdr_cleanup(&header);
+#endif
+
+    return 0;
+}

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -25,7 +25,8 @@ sudo apt-get -y build-dep qemu
 
 progress "Installing PANDA dependencies..."
 sudo apt-get -y install python-pip git protobuf-compiler protobuf-c-compiler \
-  libprotobuf-c0-dev libprotoc-dev python-protobuf libelf-dev libc++-dev pkg-config
+  libprotobuf-c0-dev libprotoc-dev python-protobuf libelf-dev libc++-dev pkg-config \
+  libwiretap-dev libwireshark-dev
 
 pushd /tmp
 


### PR DESCRIPTION
This PR brings in the PANDA 1 network plugin to PANDA 2. Tested with various protocols and operating systems.

Little changes were needed. I did have to add a call to `wtap_init(...)` and change the Makefile a little bit.