### PR TITLE
Compile plog_reader during build process.

### DIFF
--- a/panda/Makefile.panda.target
+++ b/panda/Makefile.panda.target
@@ -126,10 +126,7 @@ $(PLOG_READER_PROG): panda/src/plog_reader.o \
 
 PROGS+=$(RR_PRINT_PROG) plog_pb2.py
 
-# Uncomment next two lines to enable compiled plog_reader.
-# if PLOG_READER is defined, plog writing functions in plog-cc.cpp will be disabled.
-#PROGS+=$(PLOG_READER_PROG) 
-#QEMU_CFLAGS += -DPLOG_READER
+PROGS+=$(PLOG_READER_PROG) 
 
 clean: clean-panda
 

--- a/panda/src/plog-cc.cpp
+++ b/panda/src/plog-cc.cpp
@@ -8,9 +8,7 @@
 
 using namespace std; 
 
-#ifndef PLOG_READER
 extern int panda_in_main_loop;
-#endif
 
 void PandaLog::create(uint32_t chunk_size) {
     this->chunk.size = chunk_size;
@@ -255,7 +253,6 @@ int PandaLog::close(){
 // compress current chunk and write it to file,
 // also update directory map
 void PandaLog::write_current_chunk(){
-#ifndef PLOG_READER
     
     //uncompressed chunk size
     unsigned long chunk_sz = this->chunk.buf_p - this->chunk.buf;
@@ -293,13 +290,11 @@ void PandaLog::write_current_chunk(){
     this->chunk.buf_p = this->chunk.buf;
     this->chunk_num ++;
     this->chunk.ind_entry = 0;
-#endif
 }
 
 uint64_t last_instr_entry = -1;
 
 void PandaLog::write_entry(std::unique_ptr<panda::LogEntry> entry){
-#ifndef PLOG_READER
     if (panda_in_main_loop) {
         entry->set_pc(panda_current_pc(first_cpu));
         entry->set_instr(rr_get_guest_instr_count());
@@ -340,7 +335,6 @@ void PandaLog::write_entry(std::unique_ptr<panda::LogEntry> entry){
     // remember instr for last entry
     last_instr_entry = entry->instr();
     this->chunk.ind_entry ++;
-#endif
 }
 
 void PandaLog::unmarshall_chunk(uint32_t chunk_num){  

--- a/panda/src/plog_reader.cpp
+++ b/panda/src/plog_reader.cpp
@@ -6,35 +6,31 @@
  *
  * Note that using the C wrappers requires a few more object files to be linked in (see Makefile.panda.target).
  *
- * To compile as part of Panda's make,
- * Uncomment two lines in Makefile.panda.target. This will define PLOG_READER, which causes some rr code in plog-cc.cpp to be ignored
- *
- * To compile standalone:
- * First, compile the plog.proto file to generate the plog.pb.h and plog.pb.cc files
- * plog.proto is created by combining all the plugins' individual .proto files
- *
- * protoc -I=$SRC_DIR --cpp_out=$DST_DIR plog.proto
- *
- * Then, assuming headers are in panda/include/panda/
- * g++ -g -o plog_reader_new plog_reader_new.cpp plog.cpp plog.pb.cc -I../include/ -std=c++11 -lz -lprotobuf
- *
  * You will have to implement your own printing functions.
  *
  * 8/30/17 Ray Wang
  *
 */
 
-#define __STDC_FORMAT_MACROS
+#include <fstream>
+#include "panda/plog-cc.hpp"
 
-extern "C" {
-    #include <inttypes.h>
-    #include <stdio.h>
-    #include <stdlib.h>
-    #include <stdint.h>
-    //#include "panda/plog.h"
+/* plog-cc.cpp dependencies.
+
+   These are needed so we can link with the same version of plog-cc.o that is
+   linked with the main PANDA binary.
+
+   As long as this file only calls functions that read a pandalog file, these
+   will never be accessed by plog_reader. */
+
+int panda_in_main_loop = 0;
+struct CPUTailQ cpus;
+
+target_ulong panda_current_pc(CPUState *env) {
+    assert(false);
 }
 
-#include "panda/plog-cc.hpp"
+/* *** */
 
 void pprint(std::unique_ptr<panda::LogEntry> ple) {
     if (ple == NULL) {
@@ -53,6 +49,9 @@ void pprint(std::unique_ptr<panda::LogEntry> ple) {
 }
 
 int main (int argc, char **argv) {
+
+    memset(&cpus, 0, sizeof(cpus));
+
     if (argc < 2) {
          printf("USAGE: %s <plog>\n", argv[0]);
          exit(1);


### PR DESCRIPTION
Removed PLOG_READER preprocessor symbol.  Updated plog_reader.cpp
so it can be linked with the same version of plog-cc.o that is linked
with the main PANDA binary.

Proposed fix for issue #267.