### PR TITLE
improve taint precision for a few ops

### DIFF
--- a/panda/plugins/taint2/Makefile
+++ b/panda/plugins/taint2/Makefile
@@ -4,7 +4,7 @@
 # 	-DTAINT2_DEBUG enables debug output.
 # 	-DTAINT2_HYPERCALLS enables taint-related PANDA hypercalls, as used by LAVA
 #
-TAINT2_FLAGS   += -DTAINT2_HYPERCALLS -DTAINT2_DEBUG 
+TAINT2_FLAGS   += -DTAINT2_HYPERCALLS #-DTAINT2_DEBUG 
 
 ### Flags setup #####################################################
 QEMU_CXXFLAGS += $(LLVM_CXXFLAGS) -Wno-type-limits -Wno-cast-qual $(TAINT2_FLAGS)

--- a/panda/plugins/taint2/Makefile
+++ b/panda/plugins/taint2/Makefile
@@ -4,7 +4,7 @@
 # 	-DTAINT2_DEBUG enables debug output.
 # 	-DTAINT2_HYPERCALLS enables taint-related PANDA hypercalls, as used by LAVA
 #
-TAINT2_FLAGS   += -DTAINT2_HYPERCALLS -g
+TAINT2_FLAGS   += -DTAINT2_HYPERCALLS -g -DTAINT2_DEBUG 
 
 ### Flags setup #####################################################
 QEMU_CXXFLAGS += $(LLVM_CXXFLAGS) -Wno-type-limits -Wno-cast-qual $(TAINT2_FLAGS)

--- a/panda/plugins/taint2/Makefile
+++ b/panda/plugins/taint2/Makefile
@@ -4,13 +4,13 @@
 # 	-DTAINT2_DEBUG enables debug output.
 # 	-DTAINT2_HYPERCALLS enables taint-related PANDA hypercalls, as used by LAVA
 #
-TAINT2_FLAGS   += -DTAINT2_HYPERCALLS -g -DTAINT2_DEBUG 
+TAINT2_FLAGS   += -DTAINT2_HYPERCALLS -DTAINT2_DEBUG 
 
 ### Flags setup #####################################################
 QEMU_CXXFLAGS += $(LLVM_CXXFLAGS) -Wno-type-limits -Wno-cast-qual $(TAINT2_FLAGS)
 QEMU_CFLAGS   += $(TAINT2_FLAGS)
 
-TAINT_OP_CFLAGS  = -O0 -std=c11 -Wno-typedef-redefinition -fno-stack-protector
+TAINT_OP_CFLAGS  = -O3 -std=c11 -Wno-typedef-redefinition -fno-stack-protector
 TAINT_OP_CFLAGS += -fno-omit-frame-pointer -Wno-type-limits -stdlib=libc++ -x c++
 TAINT_OP_CFLAGS += $(CLANG_CXXFLAGS) $(TAINT2_FLAGS)
 

--- a/panda/plugins/taint2/Makefile
+++ b/panda/plugins/taint2/Makefile
@@ -4,13 +4,13 @@
 # 	-DTAINT2_DEBUG enables debug output.
 # 	-DTAINT2_HYPERCALLS enables taint-related PANDA hypercalls, as used by LAVA
 #
-TAINT2_FLAGS   += -DTAINT2_HYPERCALLS
+TAINT2_FLAGS   += -DTAINT2_HYPERCALLS -g
 
 ### Flags setup #####################################################
 QEMU_CXXFLAGS += $(LLVM_CXXFLAGS) -Wno-type-limits -Wno-cast-qual $(TAINT2_FLAGS)
 QEMU_CFLAGS   += $(TAINT2_FLAGS)
 
-TAINT_OP_CFLAGS  = -O3 -std=c11 -Wno-typedef-redefinition -fno-stack-protector
+TAINT_OP_CFLAGS  = -O0 -std=c11 -Wno-typedef-redefinition -fno-stack-protector
 TAINT_OP_CFLAGS += -fno-omit-frame-pointer -Wno-type-limits -stdlib=libc++ -x c++
 TAINT_OP_CFLAGS += $(CLANG_CXXFLAGS) $(TAINT2_FLAGS)
 

--- a/panda/plugins/taint2/Makefile
+++ b/panda/plugins/taint2/Makefile
@@ -4,7 +4,7 @@
 # 	-DTAINT2_DEBUG enables debug output.
 # 	-DTAINT2_HYPERCALLS enables taint-related PANDA hypercalls, as used by LAVA
 #
-TAINT2_FLAGS   += -DTAINT2_HYPERCALLS #-DTAINT2_DEBUG 
+TAINT2_FLAGS   += -DTAINT2_HYPERCALLS
 
 ### Flags setup #####################################################
 QEMU_CXXFLAGS += $(LLVM_CXXFLAGS) -Wno-type-limits -Wno-cast-qual $(TAINT2_FLAGS)

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -627,14 +627,18 @@ void PandaTaintVisitor::insertTaintMul(Instruction &I, Value *dest, Value *src1,
         } else if (llvm::ConstantFP* CFP = dyn_cast<llvm::ConstantFP>(src1)){
             if (CFP->isZero()) return;
         }
+        insertTaintMix(I, src2);
+        return;
     } else if (isa<Constant>(src2)) {
         if (llvm::ConstantInt* CI = dyn_cast<llvm::ConstantInt>(src2)){
             if (CI->isZero()) return;
         } else if (llvm::ConstantFP* CFP = dyn_cast<llvm::ConstantFP>(src2)){
             if (CFP->isZero()) return;
         }
+        insertTaintMix(I, src1);
+        return;
     }
-    //neither are constants, but one can be an untainted zero
+    //neither are constants, but one can be a dynamic untainted zero
 
     assert(getValueSize(src1) == getValueSize(src2)); //if this fails we can keep size independent
     Constant *dest_size = const_uint64(ctx, getValueSize(dest));

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -113,7 +113,7 @@ void taint_pointer_run(uint64_t src, uint64_t ptr, uint64_t dest, bool is_store,
     // I think this has to be an LLVM register
     Addr ptr_addr = make_laddr(ptr / MAXREGSIZE, 0);
     if (is_store) {
-        PPP_RUN_CB(on_ptr_store, ptr_addr, dest, size);    
+        PPP_RUN_CB(on_ptr_store, ptr_addr, dest, size);
     }
     else {
         PPP_RUN_CB(on_ptr_load, ptr_addr, src, size);
@@ -598,7 +598,7 @@ void PandaTaintVisitor::insertTaintCompute(Instruction &I, Value *dest, Value *s
     if (!is_mixed) {
         assert(getValueSize(dest) == getValueSize(src1));
     }
-    assert(getValueSize(src1) == getValueSize(src1));
+    assert(getValueSize(src1) == getValueSize(src1)); //what?? for cache?
 
     Constant *dest_size = const_uint64(ctx, getValueSize(dest));
     Constant *src_size = const_uint64(ctx, getValueSize(src1));
@@ -880,7 +880,7 @@ bool PandaTaintVisitor::getAddr(Value *addrVal, Addr& addrOut) {
         return true;
     }
 
-#if defined (TARGET_PPC) 
+#if defined (TARGET_PPC)
     if (contains_offset(gpr)) {
         addrOut.typ = GREG;
         addrOut.val.gr = (offset - cpu_off(gpr)) / cpu_size(gpr[0]);
@@ -1008,8 +1008,8 @@ void PandaTaintVisitor::visitStoreInst(StoreInst &I) {
 
 /*
  * In TCG->LLVM translation, it seems like this instruction is only used to get
- * the pointer to the CPU state.  Because of this, we will just delete taint at
- * the destination LLVM register.
+ * the pointer to the CPU state.  Because of this, we will just delete taint in
+ * later ops at the destination LLVM register.
  */
 void PandaTaintVisitor::visitGetElementPtrInst(GetElementPtrInst &I) {
     insertTaintMix(I, I.getOperand(0));

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -27,7 +27,6 @@ PANDAENDCOMMENT */
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Analysis/Verifier.h>
 #include <llvm/Support/SourceMgr.h>
-#include <llvm/Support/raw_ostream.h>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/Pass.h>
@@ -168,7 +167,6 @@ bool PandaTaintFunctionPass::doInitialization(Module &M) {
     PTV.mixF = M.getFunction("taint_mix"),
     PTV.pointerF = M.getFunction("taint_pointer"),
     PTV.mixCompF = M.getFunction("taint_mix_compute"),
-    PTV.taintQueryF = M.getFunction("taint_query_wrapper"),
     PTV.mulCompF = M.getFunction("taint_mul_compute"),
     PTV.parallelCompF = M.getFunction("taint_parallel_compute"),
     PTV.copyF = M.getFunction("taint_copy");
@@ -236,7 +234,6 @@ bool PandaTaintFunctionPass::doInitialization(Module &M) {
     ADD_MAPPING(taint_mix);
     ADD_MAPPING(taint_pointer);
     ADD_MAPPING(taint_mix_compute);
-    ADD_MAPPING(taint_query_wrapper);
     ADD_MAPPING(taint_mul_compute);
     ADD_MAPPING(taint_parallel_compute);
     ADD_MAPPING(taint_copy);
@@ -1491,9 +1488,6 @@ void PandaTaintVisitor::visitInsertElementInst(InsertElementInst &I) {
 
 void PandaTaintVisitor::visitShuffleVectorInst(ShuffleVectorInst &I) {
     assert(I.getType()->getBitWidth() <= 8 * MAXREGSIZE);
-    printf("Found shufflevector, is this a c helper\n");
-    printf("taint2: shufflevector in basic block: %s.\n",
-        I.getParent()->getName().str().c_str());
     insertTaintCompute(I, I.getOperand(0), I.getOperand(1), true);
 }
 

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -831,9 +831,14 @@ void PandaTaintVisitor::visitBinaryOperator(BinaryOperator &I) {
         case Instruction::Sub:
         case Instruction::UDiv:
         case Instruction::SDiv:
-        case Instruction::FAdd:
-        case Instruction::FSub:
         case Instruction::FDiv:
+        case Instruction::FSub:
+            if (I.getOperand(0) == I.getOperand(1)){ //afaik you can test value equal like this
+                return; // these operations have exactly 1 result if op is repeated, no need to taint
+            }
+            is_mixed = true;
+            break;
+        case Instruction::FAdd:
         case Instruction::URem:
         case Instruction::SRem:
         case Instruction::FRem:

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -741,8 +741,8 @@ void PandaTaintVisitor::insertTaintMul(Instruction &I, Value *dest, Value *src1,
     src1->getType()->print(rso);
     printf("argtype %s", rso.str().c_str());
     //this might be 32bit arch specific
-    Value *arg1 = b.CreateBitCast(src1, Type::getInt32Ty(ctx));
-    Value *arg2 = b.CreateBitCast(src2, Type::getInt32Ty(ctx));
+    Value *arg1 = b.CreateSExtOrBitCast(src1, Type::getInt64Ty(ctx));
+    Value *arg2 = b.CreateSExtOrBitCast(src2, Type::getInt64Ty(ctx));
     vector<Value*> args{
         llvConst, dslot, dest_size,
         src1slot, src2slot, src_size,

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -600,7 +600,7 @@ void PandaTaintVisitor::insertTaintCompute(Instruction &I, Value *dest, Value *s
     if (!is_mixed) {
         assert(getValueSize(dest) == getValueSize(src1));
     }
-    assert(getValueSize(src1) == getValueSize(src1)); //what?? for cache?
+    assert(getValueSize(src1) == getValueSize(src2));
 
     Constant *dest_size = const_uint64(ctx, getValueSize(dest));
     Constant *src_size = const_uint64(ctx, getValueSize(src1));
@@ -636,6 +636,7 @@ void PandaTaintVisitor::insertTaintMul(Instruction &I, Value *dest, Value *src1,
     }
     //neither are constants, but one can be an untainted zero
 
+    assert(getValueSize(src1) == getValueSize(src2)); //if this fails we can keep size independent
     Constant *dest_size = const_uint64(ctx, getValueSize(dest));
     Constant *src_size = const_uint64(ctx, getValueSize(src1));
 

--- a/panda/plugins/taint2/llvm_taint_lib.h
+++ b/panda/plugins/taint2/llvm_taint_lib.h
@@ -114,6 +114,8 @@ private:
             Value *src1, Value *src2, bool is_mixed);
     void insertTaintCompute(Instruction &I, Value *dest,
             Value *src1, Value *src2, bool is_mixed);
+    void insertTaintMul(Instruction &I, Value *dest,
+            Value *src1, Value *src2);
     void insertTaintSext(Instruction &I, Value *src);
     void insertTaintSelect(Instruction &after, Value *dest,
             Value *selector, vector<pair<Value *, Value *>> &selections);
@@ -130,6 +132,7 @@ public:
     Function *mixF;
     Function *pointerF;
     Function *mixCompF;
+    Function *mulCompF;
     Function *parallelCompF;
     Function *copyF;
     Function *moveF;

--- a/panda/plugins/taint2/llvm_taint_lib.h
+++ b/panda/plugins/taint2/llvm_taint_lib.h
@@ -133,7 +133,6 @@ public:
     Function *pointerF;
     Function *mixCompF;
     Function *mulCompF;
-    Function *taintQueryF;
     Function *parallelCompF;
     Function *copyF;
     Function *moveF;

--- a/panda/plugins/taint2/llvm_taint_lib.h
+++ b/panda/plugins/taint2/llvm_taint_lib.h
@@ -133,6 +133,7 @@ public:
     Function *pointerF;
     Function *mixCompF;
     Function *mulCompF;
+    Function *taintQueryF;
     Function *parallelCompF;
     Function *copyF;
     Function *moveF;

--- a/panda/plugins/taint2/shad.h
+++ b/panda/plugins/taint2/shad.h
@@ -88,7 +88,7 @@ struct TaintData {
     TaintData() : ls(NULL), tcn(0), cb_mask(0), one_mask(0), zero_mask(0) {}
     explicit TaintData(LabelSetP ls) : ls(ls), tcn(0), cb_mask(ls ? 0xFF : 0),
             one_mask(0), zero_mask(0) {}
-    TaintData(LabelSetP ls, uint32_t tcn, uint8_t cb_mask, 
+    TaintData(LabelSetP ls, uint32_t tcn, uint8_t cb_mask,
             uint8_t one_mask, uint8_t zero_mask)
         : ls(ls), tcn(ls ? tcn : 0), cb_mask(ls ? cb_mask : 0),
         one_mask(one_mask), zero_mask(zero_mask) {}
@@ -129,7 +129,7 @@ class Shad
     // inheritance tree, and only by methods that already take care of reporting
     // taint changes.
     virtual void set_full_quiet(uint64_t addr, TaintData td) = 0;
-        
+
   public:
     virtual ~Shad() = 0;
 
@@ -154,7 +154,7 @@ class Shad
 
         for (uint64_t i = 0; i < size; i++) {
             auto td = shad_src->query_full(src + i);
-            
+
             // don't report taint changes when store the taint data, as it is
             // already taken care of for all bytes below
             shad_dest->set_full_quiet(dest + i, td);
@@ -216,7 +216,7 @@ class FastShad : public Shad
         tassert(addr < size);
         labels[addr] = td;
     }
-    
+
   public:
     FastShad(std::string name, uint64_t size);
     ~FastShad();
@@ -312,7 +312,7 @@ class LazyShad : public Shad
     {
         labels[addr] = td;
     }
-    
+
   public:
     LazyShad(std::string name, uint64_t size);
     ~LazyShad();

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -285,7 +285,7 @@ bool taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size){
 //2
 void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
-                       llvm::Instruction *inst, uint32_t arg1, uint32_t arg2)
+                       llvm::Instruction *inst, uint64_t arg1, uint64_t arg2)
 {
     std::string type_str;
     llvm::raw_string_ostream rso(type_str);

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -16,7 +16,7 @@ PANDAENDCOMMENT */
  * Change Log:
  * 2018-MAY-07   Detaint bytes whose control mask bits all become 0
  */
- 
+
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
@@ -182,7 +182,7 @@ void taint_parallel_compute(Shad *shad, uint64_t dest, uint64_t ignored,
             cb_mask_1.cb_mask, cb_mask_2.cb_mask, cb_mask_out.cb_mask);
     taint_log_labels(shad, dest, src_size);
     write_cb_masks(shad, dest, src_size, cb_mask_out);
-    
+
     if (detaint_cb0_bytes)
     {
         detaint_on_cb0(shad, dest, src_size);
@@ -260,10 +260,18 @@ void taint_pointer_run(uint64_t src, uint64_t ptr, uint64_t dest, bool is_store,
 // union that mix with each byte of the actual copied data. So if the pointer
 // is labeled [1], [2], [3], [4], and the bytes are labeled [5], [6], [7], [8],
 // we get [12345], [12346], [12347], [12348] as output taint of the load/store.
+<<<<<<< 107343da20d452b542fa970ae40e40722961c7fb
 void taint_pointer(Shad *shad_dest, uint64_t dest, Shad *shad_ptr, uint64_t ptr,
                    uint64_t ptr_size, Shad *shad_src, uint64_t src,
                    uint64_t size, uint64_t is_store)
 {
+=======
+void taint_pointer(
+        FastShad *shad_dest, uint64_t dest,
+        FastShad *shad_ptr, uint64_t ptr, uint64_t ptr_size,
+        FastShad *shad_src, uint64_t src, uint64_t size,
+        uint64_t is_store) {
+>>>>>>> a few debug prints
     taint_log("ptr: %s[%lx+%lx] <- %s[%lx] @ %s[%lx+%lx]\n",
             shad_dest->name(), dest, size,
             shad_src->name(), src, shad_ptr->name(), ptr, ptr_size);
@@ -332,13 +340,14 @@ void taint_select(Shad *shad, uint64_t dest, uint64_t size, uint64_t selector,
             if (src != ones) { // otherwise it's a constant.
                 taint_log("slct\n");
                 Shad::copy(shad, dest, shad, src, size);
+                taint_log("does_it_happen?\n");
             }
             return;
         }
 
         src = va_arg(argp, uint64_t);
         srcsel = va_arg(argp, uint64_t);
-    } 
+    }
 
     tassert(false && "Couldn't find selected argument!!");
 }
@@ -355,7 +364,7 @@ static void find_offset(Shad *greg, Shad *gspec, uint64_t offset,
 {
 #ifdef TARGET_PPC
     if (cpu_contains(gpr, offset)) {
-#else 
+#else
     if (cpu_contains(regs, offset)) {
 #endif
         *dest = greg;
@@ -421,7 +430,7 @@ void taint_host_memcpy(uint64_t env_ptr, uint64_t dest, uint64_t src,
                        uint64_t labels_per_reg)
 {
     int64_t dest_offset = dest - env_ptr, src_offset = src - env_ptr;
-    if (dest_offset < 0 || (size_t)dest_offset >= sizeof(CPUArchState) || 
+    if (dest_offset < 0 || (size_t)dest_offset >= sizeof(CPUArchState) ||
             src_offset < 0 || (size_t)src_offset >= sizeof(CPUArchState)) {
         taint_log("hostmemcpy: irrelevant\n");
         return;
@@ -684,7 +693,7 @@ static void update_cb(Shad *shad_dest, uint64_t dest, Shad *shad_src,
             orig_zero_mask, zero_mask, orig_one_mask, one_mask);
 
     write_cb_masks(shad_dest, dest, size, cb_masks);
-    
+
     if (detaint_cb0_bytes)
     {
         detaint_on_cb0(shad_dest, dest, size);

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -228,58 +228,89 @@ void taint_mix_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
     taint_log_labels(shad, dest, dest_size);
 }
 
-void taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size){
+bool taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size){
     bool isTainted = false;
-    for (int i = 0; i < src_size; ++i) {
-        isTainted |= shad->query_full(src + i) != NULL;
+    for (int i = 0; i < size; ++i) {
+        isTainted |= shad->query(src + i) != NULL;
     }
     return isTainted;
 }
 
-void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
-                       uint64_t src1, uint64_t src2, uint64_t src_size,
-                       llvm::Instruction *inst)
-{
+//void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
+                       //uint64_t src1, uint64_t src2, uint64_t src_size,
+                       //llvm::Instruction *inst)
+//{
 
-    taint_log("mul_compute now a noop \n");
-    //std::string type_str;
-    //llvm::raw_string_ostream rso(type_str);
-    //taint_log("mul_compute invoked! \n");
-    //bool isTainted1 = false;
-    //bool isTainted2 = false;
-    //for (int i = 0; i < src_size; ++i) {
-        //isTainted1 |= shad->query_full(src1+i).cb_mask != 0;
-        //isTainted2 |= shad->query_full(src2+i).cb_mask != 0;
-    //}
-    //if (!isTainted1 && !isTainted2) {
-        //taint_log("mul_com untainted args \n");
-        //return; //nothing to propagate
-    //} else if (!(isTainted1 && isTainted2)){ //the case we won't propagate
-        //llvm::Value *cleanArg = isTainted1 ? inst->getOperand(1) : inst->getOperand(0);
-        //cleanArg->getType()->print(rso);
-        //taint_log("mul_compute val type %s", rso.str().c_str());
-        //// newer version of llvm api add constant->isOne, so you could clean this up
-        //if (llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(cleanArg)){
-            //printf("constantint\n");
-            //if (CI->isZero())  return ;
-            //else if (CI->isOne()) { //mul X untainted 1(one) should be a parallel taint
-                //taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
-                //taint_log("hello from mul X 1");
-                //return;
-            //}
-        //} else if (llvm::ConstantFP *CFP = llvm::dyn_cast<llvm::ConstantFP>(cleanArg)){
-            //if (CFP->isZero() ) return ;
-            //// CFP->isOne() does not in this llvm versionexist
-            ////else if (CFP->isOne()) { //mul X untainted 1(one) should be a parallel taint
+    //taint_log("mul_compute now a noop \n");
+    ////std::string type_str;
+    ////llvm::raw_string_ostream rso(type_str);
+    ////taint_log("mul_compute invoked! \n");
+    ////bool isTainted1 = false;
+    ////bool isTainted2 = false;
+    ////for (int i = 0; i < src_size; ++i) {
+        ////isTainted1 |= shad->query(src1+i) != 0;
+        ////isTainted2 |= shad->query(src2+i) != 0;
+    ////}
+    ////if (!isTainted1 && !isTainted2) {
+        ////taint_log("mul_com untainted args \n");
+        ////return; //nothing to propagate
+    ////} else if (!(isTainted1 && isTainted2)){ //the case we won't propagate
+        ////llvm::Value *cleanArg = isTainted1 ? inst->getOperand(1) : inst->getOperand(0);
+        ////cleanArg->getType()->print(rso);
+        ////taint_log("mul_compute val type %s", rso.str().c_str());
+        ////// newer version of llvm api add constant->isOne, so you could clean this up
+        ////if (llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(cleanArg)){
+            ////printf("constantint\n");
+            ////if (CI->isZero())  return ;
+            ////else if (CI->isOne()) { //mul X untainted 1(one) should be a parallel taint
                 ////taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
                 ////taint_log("hello from mul X 1");
                 ////return;
             ////}
-        //} else{
-            //taint_log("mul_compute arg of type %s", cleanArg->getType()->getStructName().str().c_str());
-        //}
-    //}
-    //taint_mix_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
+        ////} else if (llvm::ConstantFP *CFP = llvm::dyn_cast<llvm::ConstantFP>(cleanArg)){
+            ////if (CFP->isZero() ) return ;
+            ////// CFP->isOne() does not in this llvm versionexist
+            //////else if (CFP->isOne()) { //mul X untainted 1(one) should be a parallel taint
+                //////taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
+                //////taint_log("hello from mul X 1");
+                //////return;
+            //////}
+        ////} else{
+            ////taint_log("mul_compute arg of type %s", cleanArg->getType()->getStructName().str().c_str());
+        ////}
+    ////}
+    ////taint_mix_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
+//}
+
+//2
+void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
+                       uint64_t src1, uint64_t src2, uint64_t src_size,
+                       llvm::Instruction *inst, uint32_t arg1, uint32_t arg2)
+{
+    std::string type_str;
+    llvm::raw_string_ostream rso(type_str);
+    taint_log("mul_compute invoked! \n");
+    bool isTainted1 = false;
+    bool isTainted2 = false;
+    for (int i = 0; i < src_size; ++i) {
+        isTainted1 |= shad->query(src1+i) != NULL;
+        isTainted2 |= shad->query(src2+i) != NULL;
+    }
+    if (!isTainted1 && !isTainted2) {
+        taint_log("mul_com untainted args \n");
+        return; //nothing to propagate
+    } else if (!(isTainted1 && isTainted2)){ //the case we won't propagate
+        uint64_t cleanArg = isTainted1 ? arg2 : arg1;
+        taint_log("mul_compute val %lu", cleanArg);
+        // newer version of llvm api add constant->isOne, so you could clean this up
+        if (cleanArg == 0) return ;
+        else if (cleanArg == 1) { //mul X untainted 1(one) should be a parallel taint
+            taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
+            taint_log("hello from mul X 1");
+            return;
+        }
+    }
+    taint_mix_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
 }
 
 void taint_delete(Shad *shad, uint64_t dest, uint64_t size)

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -30,8 +30,6 @@ PANDAENDCOMMENT */
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Value.h>
 
-#include <llvm/Support/raw_ostream.h>
-
 #include "panda/plugin.h"
 #include "panda/plugin_plugin.h"
 
@@ -50,7 +48,6 @@ extern bool detaint_cb0_bytes;
 
 void detaint_on_cb0(Shad *shad, uint64_t addr, uint64_t size);
 void taint_delete(FastShad *shad, uint64_t dest, uint64_t size);
-
 
 // Remove the taint marker from any bytes whose control mask bits go to 0.
 // A 0 control mask bit means that bit does not impact the value in the byte.
@@ -227,14 +224,6 @@ void taint_mix_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
     taint_log("mcompute: %s[%lx+%lx] <- %lx + %lx ",
             shad->name(), dest, dest_size, src1, src2);
     taint_log_labels(shad, dest, dest_size);
-}
-
-bool taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size){
-    bool isTainted = false;
-    for (int i = 0; i < size; ++i) {
-        isTainted |= shad->query(src + i) != NULL;
-    }
-    return isTainted;
 }
 
 void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -228,48 +228,58 @@ void taint_mix_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
     taint_log_labels(shad, dest, dest_size);
 }
 
+void taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size){
+    bool isTainted = false;
+    for (int i = 0; i < src_size; ++i) {
+        isTainted |= shad->query_full(src + i) != NULL;
+    }
+    return isTainted;
+}
+
 void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
                        llvm::Instruction *inst)
 {
-    std::string type_str;
-    llvm::raw_string_ostream rso(type_str);
-    taint_log("mul_compute invoked! \n");
-    bool isTainted1 = false;
-    bool isTainted2 = false;
-    for (int i = 0; i < src_size; ++i) {
-        isTainted1 |= shad->query_full(src1+i).cb_mask != 0;
-        isTainted2 |= shad->query_full(src2+i).cb_mask != 0;
-    }
-    if (!isTainted1 && !isTainted2) {
-        taint_log("mul_com untainted args \n");
-        return; //nothing to propagate
-    } else if (!(isTainted1 && isTainted2)){ //the case we won't propagate
-        llvm::Value *cleanArg = isTainted1 ? inst->getOperand(1) : inst->getOperand(0);
-        cleanArg->print(rso);
-        taint_log("mul_compute val %s", rso.str().c_str());
-        // newer version of llvm api add constant->isOne, so you could clean this up
-        if (llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(cleanArg)){
-            printf("constantint\n");
-            if (CI->isZero())  return ;
-            else if (CI->isOne()) { //mul X untainted 1(one) should be a parallel taint
-                taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
-                taint_log("hello from mul X 1");
-                return;
-            }
-        } else if (llvm::ConstantFP *CFP = llvm::dyn_cast<llvm::ConstantFP>(cleanArg)){
-            if (CFP->isZero() ) return ;
-            // CFP->isOne() does not in this llvm versionexist
-            //else if (CFP->isOne()) { //mul X untainted 1(one) should be a parallel taint
+
+    taint_log("mul_compute now a noop \n");
+    //std::string type_str;
+    //llvm::raw_string_ostream rso(type_str);
+    //taint_log("mul_compute invoked! \n");
+    //bool isTainted1 = false;
+    //bool isTainted2 = false;
+    //for (int i = 0; i < src_size; ++i) {
+        //isTainted1 |= shad->query_full(src1+i).cb_mask != 0;
+        //isTainted2 |= shad->query_full(src2+i).cb_mask != 0;
+    //}
+    //if (!isTainted1 && !isTainted2) {
+        //taint_log("mul_com untainted args \n");
+        //return; //nothing to propagate
+    //} else if (!(isTainted1 && isTainted2)){ //the case we won't propagate
+        //llvm::Value *cleanArg = isTainted1 ? inst->getOperand(1) : inst->getOperand(0);
+        //cleanArg->getType()->print(rso);
+        //taint_log("mul_compute val type %s", rso.str().c_str());
+        //// newer version of llvm api add constant->isOne, so you could clean this up
+        //if (llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(cleanArg)){
+            //printf("constantint\n");
+            //if (CI->isZero())  return ;
+            //else if (CI->isOne()) { //mul X untainted 1(one) should be a parallel taint
                 //taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
                 //taint_log("hello from mul X 1");
                 //return;
             //}
-        } else{
-            taint_log("mul_compute arg of type %s", cleanArg->getType()->getStructName().str().c_str());
-        }
-    }
-    taint_mix_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
+        //} else if (llvm::ConstantFP *CFP = llvm::dyn_cast<llvm::ConstantFP>(cleanArg)){
+            //if (CFP->isZero() ) return ;
+            //// CFP->isOne() does not in this llvm versionexist
+            ////else if (CFP->isOne()) { //mul X untainted 1(one) should be a parallel taint
+                ////taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
+                ////taint_log("hello from mul X 1");
+                ////return;
+            ////}
+        //} else{
+            //taint_log("mul_compute arg of type %s", cleanArg->getType()->getStructName().str().c_str());
+        //}
+    //}
+    //taint_mix_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
 }
 
 void taint_delete(Shad *shad, uint64_t dest, uint64_t size)

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -242,6 +242,7 @@ void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
         llvm::Value *cleanArg = isTainted1 ? inst->getOperand(1) : inst->getOperand(0);
         // newer version of llvm api add constant->isOne, so you could clean this up
         if (llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(cleanArg)){
+            printf("constantint\n");
             if (CI->isZero())  return ;
             else if (CI->isOne()) { //mul X untainted 1(one) should be a parallel taint
                 taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -29,6 +29,8 @@ PANDAENDCOMMENT */
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Value.h>
 
+#include <llvm/Support/raw_ostream.h>
+
 #include "panda/plugin.h"
 #include "panda/plugin_plugin.h"
 
@@ -230,37 +232,43 @@ void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
                        llvm::Instruction *inst)
 {
-    taint_log("mul_compute invoked! ");
-    bool isTainted1 = false;
-    bool isTainted2 = false;
-    for (int i = 0; i < src_size; ++i) {
-        isTainted1 |= shad->query_full(src1+i).cb_mask != 0;
-        isTainted2 |= shad->query_full(src2+i).cb_mask != 0;
-    }
-    tassert((isTainted1 || isTainted2) && "error: should not both be untainted");
-    if (!(isTainted1 && isTainted2)){ //the case we won't propagate
-        llvm::Value *cleanArg = isTainted1 ? inst->getOperand(1) : inst->getOperand(0);
-        // newer version of llvm api add constant->isOne, so you could clean this up
-        if (llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(cleanArg)){
-            printf("constantint\n");
-            if (CI->isZero())  return ;
-            else if (CI->isOne()) { //mul X untainted 1(one) should be a parallel taint
-                taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
-                taint_log("hello from mul X 1");
-                return;
-            }
-        } else if (llvm::ConstantFP *CFP = llvm::dyn_cast<llvm::ConstantFP>(cleanArg)){
-            if (CFP->isZero() ) return ;
-            // CFP->isOne() does not in this llvm versionexist
-            //else if (CFP->isOne()) { //mul X untainted 1(one) should be a parallel taint
+    //std::string type_str;
+    //llvm::raw_string_ostream rso(type_str);
+    //taint_log("mul_compute invoked! \t");
+    //bool isTainted1 = false;
+    //bool isTainted2 = false;
+    //for (int i = 0; i < src_size; ++i) {
+        //isTainted1 |= shad->query_full(src1+i).cb_mask != 0;
+        //isTainted2 |= shad->query_full(src2+i).cb_mask != 0;
+    //}
+    //if (!isTainted1 && !isTainted2) {
+        //taint_log("mul_com untainted args \n");
+        //return; //nothing to propagate
+    //} else if (!(isTainted1 && isTainted2)){ //the case we won't propagate
+        //llvm::Value *cleanArg = isTainted1 ? inst->getOperand(1) : inst->getOperand(0);
+        //cleanArg->getType()->print(rso);
+        //taint_log("mul_compute val type %s", rso.str().c_str());
+        //// newer version of llvm api add constant->isOne, so you could clean this up
+        //if (llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(cleanArg)){
+            //printf("constantint\n");
+            //if (CI->isZero())  return ;
+            //else if (CI->isOne()) { //mul X untainted 1(one) should be a parallel taint
                 //taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
                 //taint_log("hello from mul X 1");
                 //return;
             //}
-        } else{
-            taint_log("mul_compute arg of type %s", cleanArg->getType()->getStructName().str().c_str());
-        }
-    }
+        //} else if (llvm::ConstantFP *CFP = llvm::dyn_cast<llvm::ConstantFP>(cleanArg)){
+            //if (CFP->isZero() ) return ;
+            //// CFP->isOne() does not in this llvm versionexist
+            ////else if (CFP->isOne()) { //mul X untainted 1(one) should be a parallel taint
+                ////taint_parallel_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
+                ////taint_log("hello from mul X 1");
+                ////return;
+            ////}
+        //} else{
+            //taint_log("mul_compute arg of type %s", cleanArg->getType()->getStructName().str().c_str());
+        //}
+    //}
     taint_mix_compute(shad, dest, dest_size, src1, src2,  src_size, inst);
 }
 
@@ -370,9 +378,7 @@ void taint_select(Shad *shad, uint64_t dest, uint64_t size, uint64_t selector,
     while (!(src == ones && srcsel == ones)) {
         if (srcsel == selector) { // bingo!
             if (src != ones) { // otherwise it's a constant.
-                taint_log("slct\n");
                 Shad::copy(shad, dest, shad, src, size);
-                taint_log("does_it_happen?\n");
             }
             return;
         }

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -247,7 +247,7 @@ void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
             if (CFP->isZero() ) return ;
         }
         else{
-            taint_log("mul_compute arg of type %s", cleanArg->getType());
+            taint_log("mul_compute arg of type %s", cleanArg->getType()->getStructName().str().c_str());
         }
     }
 

--- a/panda/plugins/taint2/taint_ops.h
+++ b/panda/plugins/taint2/taint_ops.h
@@ -75,6 +75,11 @@ void taint_mix_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
                        llvm::Instruction *ignored);
 
+//for mul or fmul. can do parallel or mixed or no prop depending on vals and their taints
+void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
+                       uint64_t src1, uint64_t src2, uint64_t src_size,
+                       llvm::Instruction *inst);
+
 // Clear taint.
 void taint_delete(Shad *shad, uint64_t dest, uint64_t size);
 

--- a/panda/plugins/taint2/taint_ops.h
+++ b/panda/plugins/taint2/taint_ops.h
@@ -75,6 +75,8 @@ void taint_mix_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
                        llvm::Instruction *ignored);
 
+void taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size);
+
 //for mul or fmul. can do parallel or mixed or no prop depending on vals and their taints
 void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,

--- a/panda/plugins/taint2/taint_ops.h
+++ b/panda/plugins/taint2/taint_ops.h
@@ -75,8 +75,6 @@ void taint_mix_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
                        llvm::Instruction *ignored);
 
-bool taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size);
-
 //for mul or fmul. can do parallel or mixed or no prop depending on vals and their taints
 void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,

--- a/panda/plugins/taint2/taint_ops.h
+++ b/panda/plugins/taint2/taint_ops.h
@@ -75,12 +75,12 @@ void taint_mix_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
                        llvm::Instruction *ignored);
 
-void taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size);
+bool taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size);
 
 //for mul or fmul. can do parallel or mixed or no prop depending on vals and their taints
 void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
-                       llvm::Instruction *inst);
+                       llvm::Instruction *inst, uint32_t arg1, uint32_t arg2);
 
 // Clear taint.
 void taint_delete(Shad *shad, uint64_t dest, uint64_t size);

--- a/panda/plugins/taint2/taint_ops.h
+++ b/panda/plugins/taint2/taint_ops.h
@@ -80,7 +80,7 @@ bool taint_query_wrapper(Shad *shad, uint64_t src, uint64_t size);
 //for mul or fmul. can do parallel or mixed or no prop depending on vals and their taints
 void taint_mul_compute(Shad *shad, uint64_t dest, uint64_t dest_size,
                        uint64_t src1, uint64_t src2, uint64_t src_size,
-                       llvm::Instruction *inst, uint32_t arg1, uint32_t arg2);
+                       llvm::Instruction *inst, uint64_t arg1, uint64_t arg2);
 
 // Clear taint.
 void taint_delete(Shad *shad, uint64_t dest, uint64_t size);


### PR DESCRIPTION
added dynamic checks for mul
  mul tainted 0(untainted) -> no taint propagation
  mul tainted 1(untainted) -> parallel taint propagation
lshr 0 , ashr 0 -> parallel propagation just like shl 0
sub, sdiv, udiv, fsub, fdiv (x,x) -> a repeated operand makes the output range exactly 1 value, no need to taint