### PR TITLE
Return callstack information in a most-recent-first fashion.

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -297,7 +297,7 @@ uint32_t get_callers(target_ulong callers[], uint32_t n, CPUState* cpu) {
     std::vector<stack_entry> &v = callstacks[get_stackid(env)];
 
     n = std::min((uint32_t)v.size(), n);
-    for (uint32_t i=0; i<n; i++) { callers[i] = v[i].pc; }
+    for (uint32_t i=0; i<n; i++) { callers[i] = v[n-1-i].pc; }
     return n;
 }
 
@@ -316,7 +316,7 @@ Panda__CallStack *pandalog_callstack_create() {
     cs->n_addr = std::min((uint32_t)v.size(), (uint32_t)CALLSTACK_MAX_SIZE);
     cs->addr = (uint64_t *)malloc(cs->n_addr * sizeof(uint64_t));
 
-    for (uint32_t i=0; i<cs->n_addr; i++) { cs->addr[i] = v[i].pc; }
+    for (uint32_t i=0; i<cs->n_addr; i++) { cs->addr[i] = v[cs->n_addr-1-i].pc; }
 
     return cs;
 }
@@ -339,7 +339,7 @@ uint32_t get_functions(target_ulong functions[], uint32_t n, CPUState* cpu) {
     std::vector<target_ulong> &v = function_stacks[get_stackid(env)];
 
     n = std::min((uint32_t)v.size(), n);
-    for (uint32_t i=0; i<n; i++) { functions[i] = v[i]; }
+    for (uint32_t i=0; i<n; i++) { functions[i] = v[n-1-i]; }
     return n;
 }
 


### PR DESCRIPTION
This is the behaviour described in the documentation and expected by many plugins.
Fixes #324.