### PR TITLE
osi_linux fixes

### DIFF
--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -746,21 +746,18 @@ int cpu_exec(CPUState *cpu)
 
     /* if an exception is pending, we execute it here */
     while (!cpu_handle_exception(cpu, &ret)) {
-
-        if (panda_exit_loop) break;
-
         TranslationBlock *last_tb = NULL;
         int tb_exit = 0;
 
-        while (true) {
-
-            if (panda_exit_loop) break;
-
+        /* Note: We usually break out of the loop manually and
+         * not because panda_exit_loop is true. */
+        while (likely(!panda_exit_loop)) {
             bool panda_invalidate_tb = false;
             debug_checkpoint(cpu);
             detect_infinite_loops();
             rr_maybe_progress();
-    
+
+            /* Replay skipped calls from the I/O thread here. */
             if (rr_in_replay()) {
                 rr_skipped_callsite_location = RR_CALLSITE_MAIN_LOOP_WAIT;
                 rr_replay_skipped_calls();
@@ -781,6 +778,8 @@ int cpu_exec(CPUState *cpu)
             if (panda_invalidate_tb
                     || (rr_mode == RR_REPLAY && until_interrupt > 0
                         && tb->icount > until_interrupt)) {
+                /* Retranslate so that basic block boundary matches
+                 * record & replay for interrupt delivery. */
                 tb_lock();
                 tb_phys_invalidate(tb, -1);
                 tb_unlock();
@@ -793,6 +792,7 @@ int cpu_exec(CPUState *cpu)
                 panda_exit_loop = true;
                 break;
             }
+
             if (!rr_in_replay() || until_interrupt > 0) {
                 cpu_loop_exec_tb(cpu, tb, &last_tb, &tb_exit, &sc);
                 /* Try to align the host and virtual clocks

--- a/panda/plugins/osi_linux/Makefile
+++ b/panda/plugins/osi_linux/Makefile
@@ -1,26 +1,30 @@
-# Don't forget to add your plugin to config.panda!
-
+### Additional plugin object files.
 PLUGIN_OBJ_FILES=$(PLUGIN_OBJ_DIR)/kernelinfo_read.o
 
-# Influential plugin-specific flags.
+### Preprocessor flags.
+# Start process enumeration with current task. Default is to start with the init task.
+# QEMU_FLAGS += -DOSI_LINUX_LIST_FROM_CURRENT
+
 # Include threads when listing all processes.
-#QEMU_CFLAGS += -DOSI_LINUX_LIST_THREADS
+# QEMU_CFLAGS += -DOSI_LINUX_LIST_THREADS
 
 # Enable test mode. See osi_linux.cpp:asid_changed().
-#QEMU_CFLAGS += -DOSI_LINUX_TEST
+# QEMU_CFLAGS += -DOSI_LINUX_TEST
 
 # Enable extra debugging for process listing.
-#QEMU_CFLAGS += -DOSI_LINUX_PSDEBUG
+# QEMU_CFLAGS += -DOSI_LINUX_PSDEBUG
 
+# Enable infinite loop detection.
+# QEMU_CFLAGS += -DOSI_MAX_PROC=256
+
+### Recipes.
 $(PLUGIN_OBJ_DIR)/kernelinfo_read.o: $(PLUGIN_SRC_DIR)/utils/kernelinfo/kernelinfo_read.c
 	@[ -d  $(dir $@) ] || mkdir -p $(dir $@)
 	$(call quiet-command,$(CC) $(QEMU_INCLUDES) $(QEMU_CFLAGS) -c -o $@ $^,"UTIL CC $(TARGET_DIR)$@")
 
-# We could implement a better search strategy here. Oh well!
 $(PLUGIN_OBJ_DIR)/kernelinfo.conf: $(PLUGIN_SRC_DIR)/kernelinfo.conf
 	$(call quiet-command,cp $< $@,"CP      $(TARGET_DIR)$@")
 
-# The main rule for your plugin. List all object-file dependencies.
 $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
 	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o \
 	$(PLUGIN_OBJ_FILES)

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -259,34 +259,8 @@ void on_get_processes(CPUState *env, OsiProcs **out_ps) {
 
 	// To avoid infinite loops, we need to actually start traversal from the next
 	// process after the thread group leader of the current task.
-#if 1
-	// ubuntu16-test: 0 inifinite loops - simpler code
 	ts_first = get_group_leader(env, ts_first);
 	ts_first = get_task_struct_next(env, ts_first);
-#endif
-#if 0
-	// ubuntu16-test: 0 inifinite loops - more complex code
-	while (get_pid(env, ts_first) != get_tgid(env, ts_first)) {
-		LOG_INFO("\t %d-%d", get_pid(env, ts_first), get_tgid(env, ts_first));
-		ts_first = get_thread_group(env, ts_first) - ki.task.thread_group_offset;
-	}
-	ts_first = get_task_struct_next(env, ts_first);
-#endif
-#if 0
-	// ubuntu16-test: 16 inifinite loops (manifests when traversal starts with process)
-	ts_first = get_group_leader(env, ts_first);
-#endif
-#if 0
-	// ubuntu16-test: 112 inifinite loops (manifests when traversal starts with thread)
-	ts_first = get_task_struct_next(env, ts_first);
-#endif
-#if 0
-	// ubuntu16-test: 112 + 16 inifinite loops (old code - this used to work for 3.x kernels)
-	if (ts_first + ki.task.thread_group_offset != get_thread_group(env, ts_first)) {
-		LOG_INFO("\t %d-%d", get_pid(env, ts_first), get_tgid(env, ts_first));
-		ts_first = get_task_struct_next(env, ts_first);
-	}
-#endif
 #endif
 
 	ts_first = ts_current;

--- a/panda/plugins/osi_linux/osi_linux.h
+++ b/panda/plugins/osi_linux/osi_linux.h
@@ -22,9 +22,21 @@
  *  @brief Debug macros.
  */
 #define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : __FILE__)
-#define LOG_ERROR(fmt, args...) fprintf(stderr, PANDA_MSG "(ERROR:%s:%s) " fmt "\n", __FILENAME__, __func__, ## args)
-#define LOG_WARN(fmt, args...)  fprintf(stderr, PANDA_MSG "(WARN:%s:%s) "  fmt "\n", __FILENAME__, __func__, ## args)
-#define LOG_INFO(fmt, args...)  fprintf(stderr, PANDA_MSG "(INFO:%s:%s) "  fmt "\n", __FILENAME__, __func__, ## args)
+#define LOG_ERROR(fmt, args...) fprintf(stderr, PANDA_MSG "ERROR:%s:%s() " fmt "\n", __FILENAME__, __func__, ## args)
+#define LOG_WARN(fmt, args...)  fprintf(stderr, PANDA_MSG "WARN:%s:%s() "  fmt "\n", __FILENAME__, __func__, ## args)
+#define LOG_INFO(fmt, args...)  fprintf(stderr, PANDA_MSG "INFO:%s:%s() "  fmt "\n", __FILENAME__, __func__, ## args)
+
+/**
+ * @brief Macros to check if a task_struct is a thread (T) or process (P).
+ */
+#define TS_THREAD(env, ts) ((ts + ki.task.thread_group_offset != get_thread_group(env, ts)) ? 1 : 0)
+#define TS_THREAD_CHR(env, ts) (TS_THREAD(env, ts_current) ? 'T' : 'P')
+
+/**
+ * @brief Macros to check if a task_struct is a thread group leader (L) or follower (F).
+ */
+#define TS_LEADER(env, ts) ((get_pid(env, ts) == get_tgid(env, ts)) ? 1 : 0)
+#define TS_LEADER_CHR(env, ts) (TS_LEADER(env, ts_current) ? 'L' : 'F')
 
 /**
  * @brief Pointer type of the guest VM.


### PR DESCRIPTION
Fix for the infinite loop issue during linux process enumeration. This is described in more detail in the [list](http://mailman.mit.edu/pipermail/panda-users/2018-August/000724.html).

The issue can reproduced using the trace here, after applying the temporary fix for #322:
https://surfdrive.surf.nl/files/index.php/s/Nk204ShtxQ3Q5FX

This PR changes the default order of the enumerated process. Previously enumeration started with the current task. Now enumeration starts with the init task. The old behaviour can be enabled with the `-DOSI_LINUX_LIST_FROM_CURRENT` flag.