### PR TITLE
Build instructions & script for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ analysis development.
 It is currently being developed in collaboration with MIT Lincoln
 Laboratory, NYU, and Northeastern University.
 
-## Building on Debian 7/8, Ubuntu 14.04/16.04
+## Building
 
+###  Debian 7/8, Ubuntu 14.04 / 16.04
 Because PANDA has a few dependencies, we've encoded the build instructions into
 a script,, [panda/scripts/install\_ubuntu.sh](panda/scripts/install\_ubuntu.sh).
 The script should actually work on Debian 7/8 and Ubuntu 14.04, and it
@@ -47,12 +48,12 @@ mkdir -p build-panda && cd build-panda
 ../panda/build.sh
 ```
 
-## Building on Arch-linux
+### Arch-linux
 Because PANDA has a few dependencies, we've encoded the build instructions into
 a script, [panda/scripts/install\_arch.sh](panda/scripts/install\_arch.sh).
 The script has only been tested on Arch Linux 4.17.5-1-MANJARO
 
-### Dependencies
+#### Dependencies
 ```
 aur_install_pkg () {
 	local FNAME=$1
@@ -90,7 +91,7 @@ sudo pacman -U https://archive.archlinux.org/packages/w/wireshark-common/wiresha
 sudo pacman -U https://archive.archlinux.org/packages/w/wireshark-cli/wireshark-cli-2.4.4-1-x86_64.pkg.tar.xz
 sudo pacman -S python2-protobuf libelf dtc capstone libdwarf python2-pycparser
 ```
-### Build
+#### Build
 
 ```
 export PANDA_LLVM_ROOT=/opt/llvm33
@@ -98,12 +99,12 @@ export CFLAGS=-Wno-error
 ./build.sh
 ```
 
-## Building on Mac
+### Building on Mac
 
 Building on Mac is less well-tested, but has been known to work. There is a script,
 [panda/scripts/install\_osx.sh](panda/scripts/install\_osx.sh) to build under OS X.
 
-## Docker Image
+### Docker Image
 
 Finally, if you want to skip the build process altogether, there is a 
 [Docker image](https://hub.docker.com/r/pandare/panda). You can get it by running:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ analysis development.
 It is currently being developed in collaboration with MIT Lincoln
 Laboratory, NYU, and Northeastern University.
 
-## Building
+## Building on Debian 7/8, Ubuntu 14.04/16.04
 
 Because PANDA has a few dependencies, we've encoded the build instructions into
-a script, [panda/scripts/install\_ubuntu.sh](panda/scripts/install\_ubuntu.sh).
+a script,, [panda/scripts/install\_ubuntu.sh](panda/scripts/install\_ubuntu.sh).
 The script should actually work on Debian 7/8 and Ubuntu 14.04, and it
 shouldn't be hard to translate the `apt-get` commands into whatever package
 manager your distribution uses. We currently only vouch for buildability  on
@@ -47,8 +47,63 @@ mkdir -p build-panda && cd build-panda
 ../panda/build.sh
 ```
 
+## Building on Arch-linux
+Because PANDA has a few dependencies, we've encoded the build instructions into
+a script, [panda/scripts/install\_arch.sh](panda/scripts/install\_arch.sh).
+The script has only been tested on Arch Linux 4.17.5-1-MANJARO
+
+### Dependencies
+```
+aur_install_pkg () {
+	local FNAME=$1
+	wget -O /tmp/$FNAME https://aur.archlinux.org/cgit/aur.git/snapshot/$FNAME.tar.gz
+	cd /tmp
+	tar -xvf $FNAME.tar.gz
+	cd /tmp/$FNAME
+	makepkg -s
+	makepkg --install
+}
+
+gpg --receive-keys A2C794A986419D8A #
+aur_install_pkg "libc++"
+aur_install_pkg "llvm33"
+aur_install_pkg "libprotobuf2"
+
+# Protobuf for C language
+cd /tmp
+git clone https://github.com/protobuf-c/protobuf-c.git protobuf-c
+cd protobuf-c
+./autogen.sh
+./configure --prefix=/usr
+make
+sudo make install
+
+# We need to use an older version of wireshark, since 2.5.1 breaks the network plugin
+wget -O /tmp/wireshark.tar.xz https://2.na.dl.wireshark.org/src/wireshark-2.4.8.tar.xz
+cd /tmp
+tar -xvf wireshark-2.4.8.tar.xz
+mkdir wireshark-build
+cd wireshark-build
+cmake ../wireshark-2.4.8
+
+sudo pacman -U https://archive.archlinux.org/packages/w/wireshark-common/wireshark-common-2.4.4-1-x86_64.pkg.tar.xz
+sudo pacman -U https://archive.archlinux.org/packages/w/wireshark-cli/wireshark-cli-2.4.4-1-x86_64.pkg.tar.xz
+sudo pacman -S python2-protobuf libelf dtc capstone libdwarf python2-pycparser
+```
+### Build
+
+```
+export PANDA_LLVM_ROOT=/opt/llvm33
+export CFLAGS=-Wno-error
+./build.sh
+```
+
+## Building on Mac
+
 Building on Mac is less well-tested, but has been known to work. There is a script,
 [panda/scripts/install\_osx.sh](panda/scripts/install\_osx.sh) to build under OS X.
+
+## Docker Image
 
 Finally, if you want to skip the build process altogether, there is a 
 [Docker image](https://hub.docker.com/r/pandare/panda). You can get it by running:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ aur_install_pkg () {
 	makepkg --install
 }
 
-gpg --receive-keys A2C794A986419D8A #
+gpg --receive-keys A2C794A986419D8A
 aur_install_pkg "libc++"
 aur_install_pkg "llvm33"
 aur_install_pkg "libprotobuf2"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The script has only been tested on Arch Linux 4.17.5-1-MANJARO
 ```
 aur_install_pkg () {
 	local FNAME=$1
-	wget -O /tmp/$FNAME https://aur.archlinux.org/cgit/aur.git/snapshot/$FNAME.tar.gz
+	local FNAME_WEB=$(python2 -c "import urllib; print urllib.quote('''$FNAME''')")
+	wget -O /tmp/$FNAME.tar.gz https://aur.archlinux.org/cgit/aur.git/snapshot/$FNAME_WEB.tar.gz
 	cd /tmp
 	tar -xvf $FNAME.tar.gz
 	cd /tmp/$FNAME
@@ -80,15 +81,10 @@ make
 sudo make install
 
 # We need to use an older version of wireshark, since 2.5.1 breaks the network plugin
-wget -O /tmp/wireshark.tar.xz https://2.na.dl.wireshark.org/src/wireshark-2.4.8.tar.xz
-cd /tmp
-tar -xvf wireshark-2.4.8.tar.xz
-mkdir wireshark-build
-cd wireshark-build
-cmake ../wireshark-2.4.8
-
 sudo pacman -U https://archive.archlinux.org/packages/w/wireshark-common/wireshark-common-2.4.4-1-x86_64.pkg.tar.xz
 sudo pacman -U https://archive.archlinux.org/packages/w/wireshark-cli/wireshark-cli-2.4.4-1-x86_64.pkg.tar.xz
+
+# Other dependencies
 sudo pacman -S python2-protobuf libelf dtc capstone libdwarf python2-pycparser
 ```
 #### Build

--- a/hw/usb/host-libusb.c
+++ b/hw/usb/host-libusb.c
@@ -244,7 +244,7 @@ static int usb_host_init(void)
     if (rc != 0) {
         return -1;
     }
-    libusb_set_debug(ctx, loglevel);
+    libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, loglevel);
 #ifdef CONFIG_WIN32
     /* FIXME: add support for Windows. */
 #else

--- a/hw/usb/host-libusb.c
+++ b/hw/usb/host-libusb.c
@@ -244,7 +244,14 @@ static int usb_host_init(void)
     if (rc != 0) {
         return -1;
     }
+
+#if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000106)
     libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, loglevel);
+#else
+    libusb_set_debug(ctx, loglevel);
+#endif
+
+
 #ifdef CONFIG_WIN32
     /* FIXME: add support for Windows. */
 #else

--- a/panda/scripts/install_arch.sh
+++ b/panda/scripts/install_arch.sh
@@ -100,7 +100,7 @@ else
 fi
 
 
-sudo pacman -S python2-protobuf libelf dtc capstone libdwarf python2-pycparser
+sudo pacman -S libelf dtc capstone libdwarf python2-pycparser
 
 
 
@@ -108,7 +108,7 @@ sudo pacman -S python2-protobuf libelf dtc capstone libdwarf python2-pycparser
 progress "Building PANDA..."
 
 
-mkdir build
+mkdir build || true
 cd build
 
 export PANDA_LLVM_ROOT=/opt/llvm33

--- a/panda/scripts/install_arch.sh
+++ b/panda/scripts/install_arch.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+
+# This script installs all of PANDA after first taking care of current dependencies. 
+# Known to work on Arch Linux (Manjaro) 4.17.5-1-MANJARO
+
+progress() {
+  echo
+  echo -e "\e[32m[panda_install]\e[0m \e[1m$1\e[0m"
+}
+
+aur_install_pkg () {
+	local FNAME=$1
+	wget -O /tmp/$FNAME https://aur.archlinux.org/cgit/aur.git/snapshot/$FNAME.tar.gz
+	cd /tmp
+	tar -xvf $FNAME.tar.gz
+	cd /tmp/$FNAME
+	makepkg -s
+	makepkg --install
+}
+
+# Exit on error.
+set -e
+
+progress "Installing PANDA dependencies..."
+
+gpg --receive-keys A2C794A986419D8A #
+
+progress "Installing PANDA dependencies...libc++"
+aur_install_pkg "libc++"
+progress "Installing PANDA dependencies...llvm33"
+aur_install_pkg "llvm33"
+progress "Installing PANDA dependencies...libprotobuf2"
+aur_install_pkg "libprotobuf2"
+
+progress "Installing PANDA dependencies...protobuf-c"
+
+cd /tmp
+git clone https://github.com/protobuf-c/protobuf-c.git protobuf-c
+cd protobuf-c
+./autogen.sh
+./configure --prefix=/usr
+make
+sudo make install
+
+progress "Building PANDA..."
+
+
+mkdir build
+cd build
+
+export PANDA_LLVM_ROOT=/opt/llvm33
+export CFLAGS=-Wno-error
+
+../build.sh "$@"

--- a/panda/scripts/install_arch.sh
+++ b/panda/scripts/install_arch.sh
@@ -11,7 +11,8 @@ progress() {
 
 aur_install_pkg () {
 	local FNAME=$1
-	wget -O /tmp/$FNAME https://aur.archlinux.org/cgit/aur.git/snapshot/$FNAME.tar.gz
+	local FNAME_WEB=$(python2 -c "import urllib; print urllib.quote('''$FNAME''')")
+	wget -O /tmp/$FNAME.tar.gz https://aur.archlinux.org/cgit/aur.git/snapshot/$FNAME_WEB.tar.gz
 	cd /tmp
 	tar -xvf $FNAME.tar.gz
 	cd /tmp/$FNAME
@@ -19,29 +20,90 @@ aur_install_pkg () {
 	makepkg --install
 }
 
+
+check_libcxx () {
+	printf "#include <ciso646>\nint main () {}" | clang -E -stdlib=libc++ -x c++ -dM - | grep _LIBCPP_VERSION
+}
+
+
+
+check_llvm () {
+	/opt/llvm33/bin/llc --version | grep "LLVM version 3\.3"
+}
+
+check_protobuf2 () {
+	pkg-config --modversion protobuf | grep 2\.[[:digit:]]\\+\.[[:digit:]]\\+
+}
+
+check_protobufc () {
+	pkg-config --modversion libprotobuf-c | grep [[:digit:]]\.[[:digit:]]\\+\.[[:digit:]]\\+
+}
+
+check_wireshark () {
+	pkg-config --modversion wireshark | grep 2\.4\.4
+}
+
+
 # Exit on error.
 set -e
 
 progress "Installing PANDA dependencies..."
 
-gpg --receive-keys A2C794A986419D8A #
 
-progress "Installing PANDA dependencies...libc++"
-aur_install_pkg "libc++"
-progress "Installing PANDA dependencies...llvm33"
-aur_install_pkg "llvm33"
-progress "Installing PANDA dependencies...libprotobuf2"
-aur_install_pkg "libprotobuf2"
+if check_libcxx; then
+    echo "Libc++ is already installed"
+else
+    progress "Installing PANDA dependencies...libc++"
+    gpg --receive-keys A2C794A986419D8A #
+    aur_install_pkg "libc++"
+fi
 
-progress "Installing PANDA dependencies...protobuf-c"
 
-cd /tmp
-git clone https://github.com/protobuf-c/protobuf-c.git protobuf-c
-cd protobuf-c
-./autogen.sh
-./configure --prefix=/usr
-make
-sudo make install
+if check_llvm; then
+    echo "LLVM33 is already installed"
+else
+    progress "Installing PANDA dependencies...llvm33"
+    aur_install_pkg "llvm33"
+fi
+
+if check_protobuf2; then
+    echo "libprotobuf2 is already installed"
+else
+	progress "Installing PANDA dependencies...libprotobuf2"
+	aur_install_pkg "libprotobuf2"
+fi
+
+
+if check_protobufc; then
+    echo "protobuf-c is already installed"
+else
+
+	progress "Installing PANDA dependencies...protobuf-c"
+
+	cd /tmp
+	git clone https://github.com/protobuf-c/protobuf-c.git protobuf-c
+	cd protobuf-c
+	./autogen.sh
+	./configure --prefix=/usr
+	make
+	sudo make install
+
+fi
+
+
+if check_wireshark; then
+    echo "wireshark 2.4.4 is already installed"
+else
+	# We need to use an older version of wireshark, since 2.5.1 breaks the network plugin
+	sudo pacman -U https://archive.archlinux.org/packages/w/wireshark-common/wireshark-common-2.4.4-1-x86_64.pkg.tar.xz
+	sudo pacman -U https://archive.archlinux.org/packages/w/wireshark-cli/wireshark-cli-2.4.4-1-x86_64.pkg.tar.xz
+fi
+
+
+sudo pacman -S python2-protobuf libelf dtc capstone libdwarf python2-pycparser
+
+
+
 
 progress "Building PANDA..."
 


### PR DESCRIPTION
I have spent a bit of time making PANDA compile on Arch Linux.

This could potentially be useful for other people, so I created this PR with 3 files changed.

- `README.md` - Separate the different build instructions a little with headings
- `install_arch.sh` - An installation script to setup the dependencies and build PANDA
- `host-libusb.c` - A very small change to correct the use of a deprecated function call
