### PR TITLE
Don't exit QEMU when end of replay is requested by the user

### DIFF
--- a/panda/src/rr/rr_log.c
+++ b/panda/src/rr/rr_log.c
@@ -1508,7 +1508,7 @@ void rr_do_end_replay(int is_error)
     if (is_error) {
         panda_cleanup();
         abort();
-    } else {
+    } else if (!rr_end_replay_requested){
         qemu_system_shutdown_request();
     }
 #endif // CONFIG_SOFTMMU


### PR DESCRIPTION
A trivial fix to not shutdown QEMU when the end of a replay is requested by the user via hmp or qmp.
Although this typically rolls back the state of QEMU to the begin of replay, it is still useful,
as other replays and or plugins can be loaded programmatically without the need to restart QEMU/PANDA.