### PR TITLE
Change mask in detecting mode

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -180,7 +180,7 @@ instr_type disas_block(CPUArchState* env, target_ulong pc, int size) {
     instr_type res = INSTR_UNKNOWN;
 
 #if defined(TARGET_I386)
-    csh handle = (env->hflags & HF_LMA_MASK) ? cs_handle_64 : cs_handle_32;
+    csh handle = (env->hflags & HF_CS64_MASK) ? cs_handle_64 : cs_handle_32;
 #if !defined(TARGET_X86_64)
     // not every block in i386 is necessary executing in the same processor mode
     // need to make capstone match current mode or may miss call statements


### PR DESCRIPTION
The mask used to detect mode should be `HF_CS64_MASK` (instead of `HF_LMA_MASK`), as [used](https://github.com/qemu/qemu/blob/master/target/i386/cpu.c#L5459) in qemu upstream