### PR TITLE
rmvpaic: save buf address in handle packet calls

### DIFF
--- a/panda/src/rr/rr_rmvapic.c
+++ b/panda/src/rr/rr_rmvapic.c
@@ -282,11 +282,13 @@ static inline void rr_write_item(RR_log_entry item)
         case RR_CALL_NET_TRANSFER:
             RR_WRITE_ITEM(args->variant.net_transfer_args);
             break;
-        case RR_CALL_HANDLE_PACKET:
+        case RR_CALL_HANDLE_PACKET: {
+            uint8_t *buf = args->variant.handle_packet_args.buf;
+            args->variant.handle_packet_args.buf =
+                (uint8_t *)args->old_buf_addr;
             RR_WRITE_ITEM(args->variant.handle_packet_args);
-            rr_fwrite(args->variant.handle_packet_args.buf,
-                      args->variant.handle_packet_args.size, 1);
-            break;
+            rr_fwrite(buf, args->variant.handle_packet_args.size, 1);
+        } break;
         default:
             // mz unimplemented
             assert(0 && "Unimplemented skipped call!");


### PR DESCRIPTION
This fixes an issue where the network buffer address wasn't properly copied in the `rr_rmvapic` utility.