### PR TITLE
Rewrite phys mem rw function to bypass DMA cbs.

### DIFF
--- a/panda/src/common.c
+++ b/panda/src/common.c
@@ -218,8 +218,21 @@ void panda_set_os_name(char *os_name) {
     fprintf(stderr, PANDA_MSG_FMT "os_familyno=%d bits=%d os_details=%s\n", PANDA_CORE_NAME, panda_os_familyno, panda_os_bits, panda_os_variant);
 }
 
+extern AddressSpace address_space_memory;
+
 int panda_physical_memory_rw(hwaddr addr, uint8_t *buf, int len, int is_write) {
-    return cpu_physical_memory_rw_ex(addr, buf, len, is_write, true);
+    hwaddr l = len;
+    hwaddr addr1;
+    MemoryRegion *mr = address_space_translate(&address_space_memory, addr,
+                                               &addr1, &l, is_write);
+    void *ram_ptr = qemu_map_ram_ptr(mr->ram_block, addr1);
+
+    if (is_write) {
+        memcpy(ram_ptr, buf, len);
+    } else {
+        memcpy(buf, ram_ptr, len);
+    }
+    return MEMTX_OK;
 }
 
 


### PR DESCRIPTION
Using the `cpu_physical_memory_rw_ex` in the panda_physical_memory_rw call can cause a segmentation fault when using taint and OSI plugins simultaneously. This is because of the newly introduced network taint capability which relies on DMA callbacks. Using `panda_physical_memory_rw` would trigger a DMA callback to run even though no device is actually accessing memory.

Rewriting this function to allows us to bypass the callbacks.