### PR TITLE
tainted_branch arg parsing fix, liveness pandalog

### DIFF
--- a/panda/plugins/tainted_branch/tainted_branch.proto
+++ b/panda/plugins/tainted_branch/tainted_branch.proto
@@ -10,8 +10,13 @@ message TaintedBranchSummary {
     required uint64 pc = 2;
 }
 
+message LabelLiveness {
+    required uint32 label = 1;
+    required uint64 count = 2;
+}
 
 optional TaintedBranch tainted_branch = 36;
 
 optional TaintedBranchSummary tainted_branch_summary = 72;
-    
+
+optional LabelLiveness label_liveness = 45;    


### PR DESCRIPTION
Fix an issue where the tainted_branch args aren't parsed correctly. Add ability to write the label liveness to the pandalog.