### PR TITLE
OSI Thread ID Support

### DIFF
--- a/panda/plugins/osi/USAGE.md
+++ b/panda/plugins/osi/USAGE.md
@@ -53,6 +53,16 @@ typedef void (*on_get_current_process_t)(CPUState *, OsiProc **)
 
 Description: Called to get the currently running process in the guest OS. The implementation should allocate memory and fill in the pointer to an `OsiProc` struct. The returned `OsiProc` can be freed with `on_free_osiproc`.
 
+Name: **on_get_current_thread_id**
+
+Signature:
+
+```C
+typedef void (*on_get_current_thread_id_t)(CPUState *, OsiThreadId *)
+```
+
+Description: Called to retrieve the current thread id from the guest OS. OsiThreadId's memory is presumed to be managed by the caller.
+
 Name: **on_get_modules**
 
 Signature:
@@ -157,6 +167,9 @@ Data structures used by OSI:
         OsiProc *proc;
     } OsiProcs;
 
+    // Represents a thread id.
+    typedef uint64_t OsiThreadId;
+
     // Represents a single module (userspace library or kernel module)
     typedef struct osi_module_struct {
         target_ulong offset;
@@ -171,6 +184,7 @@ Data structures used by OSI:
         uint32_t num;
         OsiModule *module;
     } OsiModules;
+
 ```
 
 Example

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -42,6 +42,7 @@ PPP_PROT_REG_CB(on_get_processes)
 PPP_PROT_REG_CB(on_get_current_process)
 PPP_PROT_REG_CB(on_get_modules)
 PPP_PROT_REG_CB(on_get_libraries)
+PPP_PROT_REG_CB(on_get_current_thread_id)
 PPP_PROT_REG_CB(on_free_osiproc)
 PPP_PROT_REG_CB(on_free_osiprocs)
 PPP_PROT_REG_CB(on_free_osimodules)
@@ -54,6 +55,7 @@ PPP_CB_BOILERPLATE(on_get_processes)
 PPP_CB_BOILERPLATE(on_get_current_process)
 PPP_CB_BOILERPLATE(on_get_modules)
 PPP_CB_BOILERPLATE(on_get_libraries)
+PPP_CB_BOILERPLATE(on_get_current_thread_id)
 PPP_CB_BOILERPLATE(on_free_osiproc)
 PPP_CB_BOILERPLATE(on_free_osiprocs)
 PPP_CB_BOILERPLATE(on_free_osimodules)
@@ -88,6 +90,13 @@ OsiModules *get_libraries(CPUState *cpu, OsiProc *p) {
     OsiModules *m = NULL;
     PPP_RUN_CB(on_get_libraries, cpu, p, &m);
     return m;
+}
+
+OsiThreadId get_current_thread_id(CPUState *cpu)
+{
+    OsiThreadId tid;
+    PPP_RUN_CB(on_get_current_thread_id, cpu, &tid);
+    return tid;
 }
 
 void free_osiproc(OsiProc *p) {

--- a/panda/plugins/osi/os_intro.h
+++ b/panda/plugins/osi/os_intro.h
@@ -5,6 +5,7 @@ typedef void (*on_get_processes_t)(CPUState *, OsiProcs **);
 typedef void (*on_get_current_process_t)(CPUState *, OsiProc **);
 typedef void (*on_get_modules_t)(CPUState *, OsiModules **);
 typedef void (*on_get_libraries_t)(CPUState *, OsiProc *, OsiModules**);
+typedef void (*on_get_current_thread_id_t)(CPUState *, OsiThreadId *);
 typedef void (*on_free_osiproc_t)(OsiProc *p);
 typedef void (*on_free_osiprocs_t)(OsiProcs *ps);
 typedef void (*on_free_osimodules_t)(OsiModules *ms);

--- a/panda/plugins/osi/osi_int.h
+++ b/panda/plugins/osi/osi_int.h
@@ -21,6 +21,7 @@ typedef void OsiProc;
 typedef void OsiProcs;
 typedef void OsiModules;
 typedef void CPUState;
+typedef void OsiThreadId;
 
 #include "osi_int_fns.h"
 

--- a/panda/plugins/osi/osi_int_fns.h
+++ b/panda/plugins/osi/osi_int_fns.h
@@ -14,6 +14,9 @@ OsiModules *get_modules(CPUState *env);
 // returns the same type as get_modules
 OsiModules *get_libraries(CPUState *env, OsiProc *p);
 
+// returns the current thread id
+OsiThreadId get_current_thread_id(CPUState *env);
+
 // Free memory allocated by other library functions
 void free_osiproc(OsiProc *p);
 void free_osiprocs(OsiProcs *ps);

--- a/panda/plugins/osi/osi_types.h
+++ b/panda/plugins/osi/osi_types.h
@@ -35,7 +35,7 @@ typedef struct osi_modules_struct {
     OsiModule *module;
 } OsiModules;
 
-
+typedef uint64_t OsiThreadId;
 
 /*
  * Generic inlines for handling OsiProc, OsiProcs structs.

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -38,6 +38,7 @@ void uninit_plugin(void *);
 
 void on_get_current_process(CPUState *env, OsiProc **out_p);
 void on_get_processes(CPUState *env, OsiProcs **out_ps);
+void on_get_current_thread_id(CPUState *env, OsiThreadId *tid);
 void on_free_osiproc(OsiProc *p);
 void on_free_osiprocs(OsiProcs *ps);
 void on_get_libraries(CPUState *env, OsiProc *p, OsiModules **out_ms);
@@ -120,15 +121,16 @@ static uint64_t get_fd_pos(CPUState *env, target_ptr_t task_struct, int fd) {
  * @brief Fills an OsiProc struct. Any existing contents are overwritten.
  */
 static void fill_osiproc(CPUState *env, OsiProc *p, target_ptr_t task_addr) {
-	memset(p, 0, sizeof(OsiProc));
+    memset(p, 0, sizeof(OsiProc));
 
-	p->offset = task_addr;	// XXX: Not sure what this is. Storing task_addr here seems logical.
-	p->name = get_name(env, task_addr, p->name);
-	p->pid = get_pid(env, task_addr);
-	p->ppid = get_real_parent_pid(env, task_addr);
-	p->pages = NULL;		// OsiPage - TODO
+    p->offset = task_addr; // XXX: Not sure what this is. Storing task_addr here
+                           // seems logical.
+    p->name = get_name(env, task_addr, p->name);
+    p->pid = get_tgid(env, task_addr);
+    p->ppid = get_real_parent_pid(env, task_addr);
+    p->pages = NULL; // OsiPage - TODO
 
-	p->asid = get_pgd(env, task_addr);
+    p->asid = get_pgd(env, task_addr);
 }
 
 /**
@@ -297,6 +299,22 @@ error1:
 error0:
 	*out_ps = NULL;
 	return;
+}
+
+/**
+ * @brief PPP callback to retrieve current thread id
+ */
+void on_get_current_thread_id(CPUState *env, OsiThreadId *tid)
+{
+    target_ptr_t kernel_esp = panda_current_sp(env);
+    target_ptr_t ts = get_task_struct(env, (kernel_esp & THREADINFO_MASK));
+
+    if (ts) {
+        // valid task struct
+        // got a reasonable looking process.
+        // return it and save in cache
+        *tid = get_pid(env, ts);
+    }
 }
 
 /**
@@ -558,14 +576,15 @@ bool init_plugin(void *self) {
 	g_free(kconf_file);
 	g_free(kconf_group);
 
-	PPP_REG_CB("osi", on_get_current_process, on_get_current_process);
-	PPP_REG_CB("osi", on_get_processes, on_get_processes);
-	PPP_REG_CB("osi", on_free_osiproc, on_free_osiproc);
-	PPP_REG_CB("osi", on_free_osiprocs, on_free_osiprocs);
-	PPP_REG_CB("osi", on_get_libraries, on_get_libraries);
-	PPP_REG_CB("osi", on_free_osimodules, on_free_osimodules);
-	LOG_INFO(PLUGIN_NAME " initialization complete.");
-	return true;
+        PPP_REG_CB("osi", on_get_current_process, on_get_current_process);
+        PPP_REG_CB("osi", on_get_processes, on_get_processes);
+        PPP_REG_CB("osi", on_get_current_thread_id, on_get_current_thread_id);
+        PPP_REG_CB("osi", on_free_osiproc, on_free_osiproc);
+        PPP_REG_CB("osi", on_free_osiprocs, on_free_osiprocs);
+        PPP_REG_CB("osi", on_get_libraries, on_get_libraries);
+        PPP_REG_CB("osi", on_free_osimodules, on_free_osimodules);
+        LOG_INFO(PLUGIN_NAME " initialization complete.");
+        return true;
 #else
 	goto error;
 #endif

--- a/panda/plugins/wintrospection/wintrospection.c
+++ b/panda/plugins/wintrospection/wintrospection.c
@@ -197,6 +197,18 @@ void on_get_processes(CPUState *cpu, OsiProcs **out_ps) {
     *out_ps = ps;
 }
 
+void on_get_current_thread_id(CPUState *cpu, OsiThreadId *tid)
+{
+    CPUArchState *env = (CPUArchState *)first_cpu->env_ptr;
+    target_ulong ptib;
+    panda_virtual_memory_read(first_cpu, env->segs[R_FS].base + 0x18,
+                              (uint8_t *)&ptib, sizeof(ptib));
+
+    uint32_t thread_id;
+    panda_virtual_memory_read(first_cpu, ptib + 0x24, (uint8_t *)&thread_id,
+                              sizeof(thread_id));
+    *tid = thread_id;
+}
 
 uint32_t get_ntreadfile_esp_off(void) { return ntreadfile_esp_off; }
 
@@ -567,6 +579,7 @@ bool init_plugin(void *self) {
     PPP_REG_CB("osi", on_free_osiproc, on_free_osiproc);
     PPP_REG_CB("osi", on_free_osiprocs, on_free_osiprocs);
     PPP_REG_CB("osi", on_free_osimodules, on_free_osimodules);
+    PPP_REG_CB("osi", on_get_current_thread_id, on_get_current_thread_id);
 
     return true;
 #else

--- a/panda/plugins/wintrospection/wintrospection_int.h
+++ b/panda/plugins/wintrospection/wintrospection_int.h
@@ -9,6 +9,7 @@ typedef void OsiProc;
 typedef void OsiProcs;
 typedef void OsiModule;
 typedef void OsiModules;
+typedef void OsiThreadId;
 
 #include "wintrospection_int_fns.h"
 

--- a/panda/plugins/wintrospection/wintrospection_int_fns.h
+++ b/panda/plugins/wintrospection/wintrospection_int_fns.h
@@ -59,6 +59,8 @@ void on_get_current_process(CPUState *cpu, OsiProc **out_p);
 
 void on_get_processes(CPUState *cpu, OsiProcs **out_ps);
 
+void on_get_current_thread_id(CPUState *cpu, OsiThreadId *tid);
+
 // Getters for os-specific constants
 uint32_t get_ntreadfile_esp_off(void);
 


### PR DESCRIPTION
This PR adds support for thread id retrieval in OSI. Implementations for Windows and Linux are also provided.

Re-running my test case as mentioned in #360 reports the PID and TID as I would expect.