### PR TITLE
Remove documentation of legacy functions

### DIFF
--- a/panda/plugins/taint2/USAGE.md
+++ b/panda/plugins/taint2/USAGE.md
@@ -114,9 +114,6 @@ Description: Called whenever the state of taint changes; i.e. when taint is prop
     // delete taint from this io addr
     void taint2_delete_io(uint64_t ia) ;
     
-    // print out a labelset.
-    void taint2_labelset_spit(LabelSetP ls) ; 
-
     // apply this fn to each of the labels associated with this pa
     // fn should return 0 to continue iteration
     void taint2_labelset_ram_iter(uint64_t pa, int (*app)(uint32_t el, void *stuff1), void *stuff2);
@@ -131,9 +128,6 @@ Description: Called whenever the state of taint changes; i.e. when taint is prop
     
     // ditto, but for llvm regs.  dunno where you are getting that number
     void taint2_labelset_llvm_iter(int reg_num, int offset, int (*app)(uint32_t el, void *stuff1), void *stuff2);
-
-    // ditto, but someone handed you the ls, e.g. a callback like tainted branch
-    void taint2_labelset_iter(LabelSetP ls,  int (*app)(uint32_t el, void *stuff1), void *stuff2) ;
 
     // returns set of so-far applied labels as a sorted array
     // NB: This allocates memory. Caller frees.


### PR DESCRIPTION
Just a small PR to remove the documentation of functions which are not exposed anymore in taint2/USAGE.md.