### PR TITLE
add check for zero length strings

### DIFF
--- a/panda/plugins/wintrospection/wintrospection.c
+++ b/panda/plugins/wintrospection/wintrospection.c
@@ -108,6 +108,12 @@ char *get_unicode_str(CPUState *cpu, PTR ustr) {
         return make_pagedstr();
     }
 
+    // Unicode Strings can be zero length. In this case, just return an empty
+    // string.
+    if (size == 0) {
+        return g_strdup("");
+    }
+
     // Clamp size
     if (size > 1024) size = 1024;
     if (-1 == panda_virtual_memory_rw(cpu, ustr+4, (uint8_t *)&str_ptr, 4, false)) {


### PR DESCRIPTION
Not sure why I didn't notice this before with my file taint testing, but this fixes an issue where the Windows unicode strings can be empty.

The Windows docs seem to indicate this would be expected: https://docs.microsoft.com/en-us/windows/desktop/api/subauth/ns-subauth-_unicode_string