### PR TITLE
fix for panda-re/lava#11

### DIFF
--- a/panda/plugins/syscalls2/gen_syscall_switch_enter_linux_arm.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_enter_linux_arm.cpp
@@ -20,7 +20,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc) {
 	ctx.no = env->regs[7];
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
-	const syscall_info_t *call = (ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
 	switch (ctx.no) {
 		// 0 long sys_restart_syscall ['void']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_enter_linux_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_enter_linux_x86.cpp
@@ -20,7 +20,7 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc) {
 	ctx.no = env->regs[R_EAX];
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
-	const syscall_info_t *call = (ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
 	switch (ctx.no) {
 		// 0 long sys_restart_syscall ['void']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_enter_windows_2000_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_enter_windows_2000_x86.cpp
@@ -20,7 +20,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc) {
 	ctx.no = env->regs[R_EAX];
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
-	const syscall_info_t *call = (ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
 	switch (ctx.no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', ' PVOID PortContext', ' PPORT_MESSAGE ConnectionRequest', ' BOOLEAN AcceptConnection', ' PPORT_VIEW ServerView', ' PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_enter_windows_7_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_enter_windows_7_x86.cpp
@@ -20,7 +20,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc) {
 	ctx.no = env->regs[R_EAX];
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
-	const syscall_info_t *call = (ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
 	switch (ctx.no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', ' PVOID PortContext', ' PPORT_MESSAGE ConnectionRequest', ' BOOLEAN AcceptConnection', ' PPORT_VIEW ServerView', ' PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_enter_windows_xpsp2_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_enter_windows_xpsp2_x86.cpp
@@ -20,7 +20,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc) {
 	ctx.no = env->regs[R_EAX];
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
-	const syscall_info_t *call = (ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
 	switch (ctx.no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', ' PVOID PortContext', ' PPORT_MESSAGE ConnectionRequest', ' BOOLEAN AcceptConnection', ' PPORT_VIEW ServerView', ' PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_enter_windows_xpsp3_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_enter_windows_xpsp3_x86.cpp
@@ -20,7 +20,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc) {
 	ctx.no = env->regs[R_EAX];
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
-	const syscall_info_t *call = (ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
 	switch (ctx.no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', ' PVOID PortContext', ' PPORT_MESSAGE ConnectionRequest', ' BOOLEAN AcceptConnection', ' PPORT_VIEW ServerView', ' PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_return_linux_arm.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_return_linux_arm.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 void syscall_return_switch_linux_arm(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #ifdef TARGET_ARM
-	const syscall_info_t *call = (ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
 	switch (ctx->no) {
 		// 0 long sys_restart_syscall ['void']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_return_linux_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_return_linux_x86.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 void syscall_return_switch_linux_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #ifdef TARGET_I386
-	const syscall_info_t *call = (ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
 	switch (ctx->no) {
 		// 0 long sys_restart_syscall ['void']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_return_windows_2000_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_return_windows_2000_x86.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 void syscall_return_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #ifdef TARGET_I386
-	const syscall_info_t *call = (ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
 	switch (ctx->no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', ' PVOID PortContext', ' PPORT_MESSAGE ConnectionRequest', ' BOOLEAN AcceptConnection', ' PPORT_VIEW ServerView', ' PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_return_windows_7_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_return_windows_7_x86.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 void syscall_return_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #ifdef TARGET_I386
-	const syscall_info_t *call = (ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
 	switch (ctx->no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', ' PVOID PortContext', ' PPORT_MESSAGE ConnectionRequest', ' BOOLEAN AcceptConnection', ' PPORT_VIEW ServerView', ' PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_return_windows_xpsp2_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_return_windows_xpsp2_x86.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 void syscall_return_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #ifdef TARGET_I386
-	const syscall_info_t *call = (ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
 	switch (ctx->no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', ' PVOID PortContext', ' PPORT_MESSAGE ConnectionRequest', ' BOOLEAN AcceptConnection', ' PPORT_VIEW ServerView', ' PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/gen_syscall_switch_return_windows_xpsp3_x86.cpp
+++ b/panda/plugins/syscalls2/gen_syscall_switch_return_windows_xpsp3_x86.cpp
@@ -14,7 +14,7 @@ extern "C" {
 
 void syscall_return_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #ifdef TARGET_I386
-	const syscall_info_t *call = (ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
 	switch (ctx->no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', ' PVOID PortContext', ' PPORT_MESSAGE ConnectionRequest', ' BOOLEAN AcceptConnection', ' PPORT_VIEW ServerView', ' PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/templates/syscall_switch_enter.tpl
+++ b/panda/plugins/syscalls2/templates/syscall_switch_enter.tpl
@@ -20,7 +20,7 @@ void syscall_enter_switch_{{os}}_{{arch}}(CPUState *cpu, target_ptr_t pc) {
 	ctx.no = {{arch_conf.rt_callno_reg}};
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
-	const syscall_info_t *call = (ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
 	switch (ctx.no) {
 		{%- for syscall in syscalls %}
 		// {{syscall.no}} {{syscall.rettype}} {{syscall.name}} {{syscall.args_raw}}

--- a/panda/plugins/syscalls2/templates/syscall_switch_return.tpl
+++ b/panda/plugins/syscalls2/templates/syscall_switch_return.tpl
@@ -14,7 +14,7 @@ extern "C" {
 
 void syscall_return_switch_{{os}}_{{arch}}(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #ifdef {{arch_conf.qemu_target}}
-	const syscall_info_t *call = (ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
 	switch (ctx->no) {
 		{%- for syscall in syscalls %}
 		// {{syscall.no}} {{syscall.rettype}} {{syscall.name}} {{syscall.args_raw}}


### PR DESCRIPTION
A simple check to avoid invalid dereference when system call info have not been loaded. Fixes panda-re/lava#11.