### PR TITLE
Removing reference to removed plugin dead_data

### DIFF
--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -799,7 +799,6 @@ one has a USAGE.md file linked here for further explanation.
 
 #### Taint-related plugins
 * [`taint2`](../plugins/taint2/USAGE.md) - Modern taint plugin. Required by most other taint plugins. `Already ported from panda1`
-* [`dead_data`](../plugins/dead_data/USAGE.md) - Track dead data (tainted, but not used in branches). `Already ported from panda1`
 * [`ida_taint2`](../../../panda1/qemu/panda_plugins/ida_taint2/USAGE.md) - IDA taint
   integration.
 * [`file_taint`](../plugins/file_taint/USAGE.md) - Syscall and

--- a/panda/plugins/taint2/USAGE.md
+++ b/panda/plugins/taint2/USAGE.md
@@ -6,7 +6,7 @@ Summary
 
 The `taint2` plugin tracks the flow of data through a running program. One can apply taint labels to some data, follow the flow of labeled data through the program execution, and later query data to find out what labels it has.
 
-`taint2` provides APIs and callbacks for labeling and querying data, and does the work of propagating taint. This means it is not generally useful by itself. To introduce taint into the system, you can use plugins like `file_taint`, `tstringsearch` and `tainted_net`; to query taint you can use plugins like `tainted_instr`, `dead_data`, `taint_compute_numbers` or `tainted_net`.
+`taint2` provides APIs and callbacks for labeling and querying data, and does the work of propagating taint. This means it is not generally useful by itself. To introduce taint into the system, you can use plugins like `file_taint`, `tstringsearch` and `tainted_net`; to query taint you can use plugins like `tainted_instr`, `taint_compute_numbers` or `tainted_net`.
 
 Note that since this notion of taint supports an arbitrary number of *labels*, the taint on a particular piece of data will typically be a *label set* rather than a single label. For example, if some quantities `a` and `b` have labels `1` and `2` respectively, then an operation such as `c = a + b` will result in `c` being tainted with the label set `{1, 2}`.
 


### PR DESCRIPTION
According to [this commit](https://github.com/panda-re/panda/commit/8d72cbecc7a93b56cd8357730b5b8618356d0da4), the dead_data plugin was removed from panda. There were still reference to it in the manual.