### PR TITLE
Fix LLVM Codegen for 64-bit Guests

### DIFF
--- a/panda/llvm/tcg-llvm.cpp
+++ b/panda/llvm/tcg-llvm.cpp
@@ -1003,6 +1003,7 @@ int TCGLLVMContextPrivate::generateOperation(int opc, const TCGOp *op,
         assert(!m_tcgContext->temps[args[1]].name                   \
                 || !strcmp(m_tcgContext->temps[args[1]].name, "env"));\
         v = getEnvOffsetPtr(args[2], temp);                         \
+        v = m_builder.CreatePointerCast(v, intPtrType(memBits)); \
         v = m_builder.CreateLoad(v);                                \
         setValue(args[0], m_builder.Create ## signE ## Ext(         \
                     v, intType(regBits)));                          \
@@ -1016,6 +1017,7 @@ int TCGLLVMContextPrivate::generateOperation(int opc, const TCGOp *op,
                 || !strcmp(m_tcgContext->temps[args[1]].name, "env"));\
         Value* valueToStore = getValue(args[0]);                    \
         Value* storePtr = getEnvOffsetPtr(args[2], temp);           \
+        storePtr = m_builder.CreatePointerCast(storePtr, intPtrType(memBits)); \
         m_builder.CreateStore(m_builder.CreateTrunc(                \
                 valueToStore, intType(memBits)), storePtr);         \
     } break;

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -623,9 +623,10 @@ void PandaTaintVisitor::insertTaintMul(Instruction &I, Value *dest, Value *src1,
     LLVMContext &ctx = I.getContext();
     if (!dest) dest = &I;
 
+    const uint64_t maxBitWidth = 64;
     unsigned src1BitWidth = src1->getType()->getPrimitiveSizeInBits();
     unsigned src2BitWidth = src1->getType()->getPrimitiveSizeInBits();
-    if (src1BitWidth > 64 || src2BitWidth > 64) {
+    if ((src1BitWidth > maxBitWidth) || (src2BitWidth > maxBitWidth)) {
         printf("warning: encountered a value greater than 64 bits - not "
                "attempting to propagate taint through mul instruction\n");
         return;

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -623,6 +623,14 @@ void PandaTaintVisitor::insertTaintMul(Instruction &I, Value *dest, Value *src1,
     LLVMContext &ctx = I.getContext();
     if (!dest) dest = &I;
 
+    unsigned src1BitWidth = src1->getType()->getPrimitiveSizeInBits();
+    unsigned src2BitWidth = src1->getType()->getPrimitiveSizeInBits();
+    if (src1BitWidth > 64 || src2BitWidth > 64) {
+        printf("warning: encountered a value greater than 64 bits - not "
+               "attempting to propagate taint through mul instruction\n");
+        return;
+    }
+
     if (isa<Constant>(src1) && isa<Constant>(src2)) {
         return; // do nothing, should not happen in optimized code
     } else if (isa<Constant>(src1)) {


### PR DESCRIPTION
This PR fixes issue #382. The load\store TCG ops were broken when loading\storing between 32-bit and 64-bit values. By adding an explicit cast, the issue has been corrected.

Tested with:

* Debian 9 (amd64)
* Windows Server 2008 R2 (amd64)

There is an issue with Taint however, with 64-bit guests there can be mul instructions that operate on 128-bit values. Since the control bits and other parts of taint2 assumed 64-bit, this isn't an easy fix. So for now I've added a warning when a mul that involves a 128-bit value that taint is not propagated. I'm not sure how much under-tainting this can introduce, but a long term solution will be needed. With some simple test binaries, I was able to see the taint reports I expected within my binary. However, I don't know what I'm missing. The alternative (ignoring the issue) results in an assertion error when compiled against a debug build of LLVM.