### PR TITLE
Only update tainted data in taint2

### DIFF
--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -16,7 +16,7 @@ PANDAENDCOMMENT */
  * Change Log:
  * dynamic check if there is a mul X 0 or mul X 1, for no taint prop or parallel
  * propagation respetively
- * 03-DEC-2018:  don't update masks on data that is not tainted; fix bug in
+ * 04-DEC-2018:  don't update masks on data that is not tainted; fix bug in
  *    taint2 deboug output for host memcpy
  */
 
@@ -553,8 +553,10 @@ static void update_cb(Shad *shad_dest, uint64_t dest, Shad *shad_src,
     // (eg. SHL puts 1s in lower bits of zero mask), and this would then
     // generate a spurious taint change report
     bool tainted = false;
-    for (unsigned int i = 0; i < size; i++) {
-    	if (shad_src->query(src + i) != NULL) tainted = true;
+    for (uint32_t i = 0; i < size; i++) {
+        if (shad_src->query(src + i) != NULL) {
+            tainted = true;
+        }
     }
 
     if (tainted) {

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -16,6 +16,8 @@ PANDAENDCOMMENT */
  * Change Log:
  * dynamic check if there is a mul X 0 or mul X 1, for no taint prop or parallel
  * propagation respetively
+ * 03-DEC-2018:  don't update masks on data that is not tainted; fix bug in
+ *    taint2 deboug output for host memcpy
  */
 
 #ifndef __STDC_FORMAT_MACROS
@@ -478,7 +480,7 @@ void taint_host_memcpy(uint64_t env_ptr, uint64_t dest, uint64_t src,
     taint_log("hostmemcpy: %s[%lx+%lx] <- %s[%lx] (offsets %lx <- %lx) ",
             shad_dest->name(), dest, size, shad_src->name(), src,
             dest_offset, src_offset);
-    taint_log_labels(shad_src, src, size);
+    taint_log_labels(shad_src, addr_src, size);
     Shad::copy(shad_dest, addr_dest, shad_src, addr_src, size);
 }
 
@@ -546,38 +548,52 @@ static void update_cb(Shad *shad_dest, uint64_t dest, Shad *shad_src,
 {
     if (!I) return;
 
-    CBMasks cb_masks = compile_cb_masks(shad_src, src, size);
-    uint64_t &cb_mask = cb_masks.cb_mask;
-    uint64_t &one_mask = cb_masks.one_mask;
-    uint64_t &zero_mask = cb_masks.zero_mask;
-
-    uint64_t orig_one_mask = one_mask, orig_zero_mask = zero_mask;
-    __attribute__((unused)) uint64_t orig_cb_mask = cb_mask;
-    std::vector<uint64_t> literals;
-    uint64_t last_literal = ~0UL; // last valid literal.
-    literals.reserve(I->getNumOperands());
-
-    for (auto it = I->value_op_begin(); it != I->value_op_end(); it++) {
-        const llvm::Value *arg = *it;
-        const llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(arg);
-        uint64_t literal = CI ? CI->getZExtValue() : ~0UL;
-        literals.push_back(literal);
-        if (literal != ~0UL) last_literal = literal;
+    // do not update masks on data that is not tainted (ie. has no labels)
+    // this is because some operations cause constants to be put in the masks
+    // (eg. SHL puts 1s in lower bits of zero mask), and this would then
+    // generate a spurious taint change report
+    bool tainted = false;
+    for (unsigned int i = 0; i < size; i++) {
+    	if (shad_src->query(src + i) != NULL) tainted = true;
     }
-    int log2 = 0;
 
-    unsigned int opcode = I->getOpcode();
+    if (tainted) {
+		CBMasks cb_masks = compile_cb_masks(shad_src, src, size);
+		uint64_t &cb_mask = cb_masks.cb_mask;
+		uint64_t &one_mask = cb_masks.one_mask;
+		uint64_t &zero_mask = cb_masks.zero_mask;
 
-    // guts of this function are in separate file so it can be more easily
-    // tested without calling a function (which would slow things down even more)
+		uint64_t orig_one_mask = one_mask, orig_zero_mask = zero_mask;
+		__attribute__((unused)) uint64_t orig_cb_mask = cb_mask;
+		std::vector<uint64_t> literals;
+		uint64_t last_literal = ~0UL; // last valid literal.
+		literals.reserve(I->getNumOperands());
+
+		for (auto it = I->value_op_begin(); it != I->value_op_end(); it++) {
+			const llvm::Value *arg = *it;
+			const llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(arg);
+			uint64_t literal = CI ? CI->getZExtValue() : ~0UL;
+			literals.push_back(literal);
+			if (literal != ~0UL) last_literal = literal;
+		}
+		int log2 = 0;
+
+		unsigned int opcode = I->getOpcode();
+
+		// guts of this function are in separate file so it can be more easily
+		// tested without calling a function (which would slow things down even more)
 #include "update_cb_switch.h"
 
-    taint_log("update_cb: %s[%lx+%lx] CB %#lx -> 0x%#lx, 0 %#lx -> %#lx, 1 %#lx -> %#lx\n",
-            shad_dest->name(), dest, size, orig_cb_mask, cb_mask,
-            orig_zero_mask, zero_mask, orig_one_mask, one_mask);
+		taint_log("update_cb: %s[%lx+%lx] CB %#lx -> 0x%#lx, 0 %#lx -> %#lx, 1 %#lx -> %#lx\n",
+				shad_dest->name(), dest, size, orig_cb_mask, cb_mask,
+				orig_zero_mask, zero_mask, orig_one_mask, one_mask);
 
-    write_cb_masks(shad_dest, dest, size, cb_masks);
+		write_cb_masks(shad_dest, dest, size, cb_masks);
+    }
 
+    // not sure it's possible to call update_cb with data that is unlabeled but
+    // still has non-0 masks leftover from previous processing, so just in case
+    // call detainter (if desired) even for unlabeled input
     if (detaint_cb0_bytes)
     {
         detaint_on_cb0(shad_dest, dest, size);

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -560,37 +560,37 @@ static void update_cb(Shad *shad_dest, uint64_t dest, Shad *shad_src,
     }
 
     if (tainted) {
-		CBMasks cb_masks = compile_cb_masks(shad_src, src, size);
-		uint64_t &cb_mask = cb_masks.cb_mask;
-		uint64_t &one_mask = cb_masks.one_mask;
-		uint64_t &zero_mask = cb_masks.zero_mask;
+        CBMasks cb_masks = compile_cb_masks(shad_src, src, size);
+        uint64_t &cb_mask = cb_masks.cb_mask;
+        uint64_t &one_mask = cb_masks.one_mask;
+        uint64_t &zero_mask = cb_masks.zero_mask;
 
-		uint64_t orig_one_mask = one_mask, orig_zero_mask = zero_mask;
-		__attribute__((unused)) uint64_t orig_cb_mask = cb_mask;
-		std::vector<uint64_t> literals;
-		uint64_t last_literal = ~0UL; // last valid literal.
-		literals.reserve(I->getNumOperands());
+        uint64_t orig_one_mask = one_mask, orig_zero_mask = zero_mask;
+        __attribute__((unused)) uint64_t orig_cb_mask = cb_mask;
+        std::vector<uint64_t> literals;
+        uint64_t last_literal = ~0UL; // last valid literal.
+        literals.reserve(I->getNumOperands());
 
-		for (auto it = I->value_op_begin(); it != I->value_op_end(); it++) {
-			const llvm::Value *arg = *it;
-			const llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(arg);
-			uint64_t literal = CI ? CI->getZExtValue() : ~0UL;
-			literals.push_back(literal);
-			if (literal != ~0UL) last_literal = literal;
-		}
-		int log2 = 0;
+        for (auto it = I->value_op_begin(); it != I->value_op_end(); it++) {
+            const llvm::Value *arg = *it;
+            const llvm::ConstantInt *CI = llvm::dyn_cast<llvm::ConstantInt>(arg);
+            uint64_t literal = CI ? CI->getZExtValue() : ~0UL;
+            literals.push_back(literal);
+            if (literal != ~0UL) last_literal = literal;
+        }
+        int log2 = 0;
 
-		unsigned int opcode = I->getOpcode();
+        unsigned int opcode = I->getOpcode();
 
-		// guts of this function are in separate file so it can be more easily
-		// tested without calling a function (which would slow things down even more)
+        // guts of this function are in separate file so it can be more easily
+        // tested without calling a function (which would slow things down even more)
 #include "update_cb_switch.h"
 
-		taint_log("update_cb: %s[%lx+%lx] CB %#lx -> 0x%#lx, 0 %#lx -> %#lx, 1 %#lx -> %#lx\n",
-				shad_dest->name(), dest, size, orig_cb_mask, cb_mask,
-				orig_zero_mask, zero_mask, orig_one_mask, one_mask);
+        taint_log("update_cb: %s[%lx+%lx] CB %#lx -> 0x%#lx, 0 %#lx -> %#lx, 1 %#lx -> %#lx\n",
+                shad_dest->name(), dest, size, orig_cb_mask, cb_mask,
+                orig_zero_mask, zero_mask, orig_one_mask, one_mask);
 
-		write_cb_masks(shad_dest, dest, size, cb_masks);
+        write_cb_masks(shad_dest, dest, size, cb_masks);
     }
 
     // not sure it's possible to call update_cb with data that is unlabeled but

--- a/panda/plugins/tainted_instr/USAGE.md
+++ b/panda/plugins/tainted_instr/USAGE.md
@@ -10,11 +10,12 @@ Arguments
 ---------
 
 * `summary`: boolean. Determines whether full or summary information will be produced. In summary mode, `tainted_instr` just produces information about what instructions were tainted in each address space seen. In full mode, a log entry is written every time an instruction handling tainted data is executed, along with the callstack at that point. The logs for full mode can get rather large.
+* `num`: uint64.  Number of tainted instructions to log or summarize.  The default (0) means there is no limit.  Note that if `tainted_instr` sees the same tainted block reported mutiple times in a row, that this is counted as only one 'instruction'.  For example, if taint change reports come in five times for tainted data in block 1, then three times for tainted data in block 2, then seven times for tainted data in block 1 again, and then four times for tainted data in block 3, then the number of tainted 'instructions' seen will be 4, as there were four distinct runs.
 
 Dependencies
 ------------
 
-`tainted_instr` uses `taint2` to track taint, and `callstack_instr` to provide callstack information whenever tainted branches are encountered.
+`tainted_instr` uses `taint2` to track taint, and `callstack_instr` to provide callstack information whenever tainted instructions are encountered.
 
 APIs and Callbacks
 ------------------

--- a/panda/plugins/tainted_instr/tainted_instr.cpp
+++ b/panda/plugins/tainted_instr/tainted_instr.cpp
@@ -127,9 +127,13 @@ void taint_change(Addr a, uint64_t size) {
             if (0 == (num_tainted_instr_observed % 1000))
                 printf ("%" PRId64 " tainted instr observed\n", num_tainted_instr_observed);
         }
+
+        // a taint delete on tainted data will cause a taint change event
+        // thus, do not say we've seen a tainted 'instruction' unless the data
+        // really was tainted
+        last_asid = asid;
+        last_pc = pc;
     }
-    last_asid = asid;
-    last_pc = pc;
 }
 
 bool init_plugin(void *self) {


### PR DESCRIPTION
Do not calculate taint masks on data that is not tainted in update_cb.  Also modify tainted_instr plugin so that a taint change due to a delete does not update the PC and ASID of the most recently seen tainted instruction.  (See issue #378.)
Also, send offset of address to taint log 'function' in taint2's taint_host_memcpy so don't seg fault when producing taint2 debug output.  (See issue #226.  Yeah, I know it's a totally separate issue, but it was getting in the way of debugging other problems.)