### PR TITLE
Allow recording of register writes via GDB

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -3322,7 +3322,7 @@ void address_space_unmap(AddressSpace *as, void *buffer, hwaddr len,
         if (is_write) {
             //bdg Save addr1,access_len,buffer contents
             if (rr_in_record()) {
-                rr_device_mem_rw_call_record(addr1, buffer, access_len, is_write);
+                rr_device_mem_unmap_call_record(addr1, buffer, access_len, is_write);
             }
             invalidate_and_set_dirty(mr, addr1, access_len);
         }

--- a/include/exec/gdbstub.h
+++ b/include/exec/gdbstub.h
@@ -54,6 +54,7 @@ void gdbserver_fork(CPUState *);
 #endif
 /* Get or set a register.  Returns the size of the register.  */
 typedef int (*gdb_reg_cb)(CPUArchState *env, uint8_t *buf, int reg);
+int gdb_write_register(CPUState *cpu, uint8_t *mem_buf, int reg);
 void gdb_register_coprocessor(CPUState *cpu,
                               gdb_reg_cb get_reg, gdb_reg_cb set_reg,
                               int num_regs, const char *xml, int g_pos);

--- a/panda/include/panda/rr/rr_log.h
+++ b/panda/include/panda/rr/rr_log.h
@@ -43,6 +43,14 @@ typedef struct {
     hwaddr len;
 } RR_cpu_mem_unmap;
 
+// structure for arguments to gdb_write_register
+typedef struct {
+    int cpu_index;
+    uint8_t* buf;
+    int reg;
+    int len;
+} RR_cpu_reg_write_args;
+
 typedef struct RR_MapList {
     void *ptr;
     hwaddr addr;
@@ -53,6 +61,8 @@ typedef struct RR_MapList {
 
 void rr_cpu_physical_memory_unmap_record(hwaddr addr, uint8_t* buf,
                                          hwaddr len, int is_write);
+void rr_cpu_reg_write_call_record(int cpu_index, const uint8_t* buf,
+                                  int reg, int len);
 void rr_device_mem_rw_call_record(hwaddr addr, const uint8_t* buf,
                                   int len, int is_write);
 void rr_device_mem_unmap_call_record(hwaddr addr, const uint8_t* buf,
@@ -86,6 +96,7 @@ typedef struct {
         RR_serial_read_args serial_read_args;
         RR_serial_send_args serial_send_args;
         RR_serial_write_args serial_write_args;
+        RR_cpu_reg_write_args cpu_reg_write_args;
     } variant;
     // mz XXX HACK
     uint64_t old_buf_addr;

--- a/panda/include/panda/rr/rr_log.h
+++ b/panda/include/panda/rr/rr_log.h
@@ -55,6 +55,8 @@ void rr_cpu_physical_memory_unmap_record(hwaddr addr, uint8_t* buf,
                                          hwaddr len, int is_write);
 void rr_device_mem_rw_call_record(hwaddr addr, const uint8_t* buf,
                                   int len, int is_write);
+void rr_device_mem_unmap_call_record(hwaddr addr, const uint8_t* buf,
+                                  int len, int is_write);
 void rr_mem_region_change_record(hwaddr start_addr, uint64_t size,
                                  const char *name, RR_mem_type mtype, bool added);
 void rr_mem_region_transaction_record(bool begin);

--- a/panda/include/panda/rr/rr_log_all.h
+++ b/panda/include/panda/rr/rr_log_all.h
@@ -121,6 +121,7 @@ extern void rr_signal_disagreement(RR_prog_point current,
         ACTION(RR_CALL_SERIAL_READ),    /* read byte from serial rx fifo */    \
         ACTION(RR_CALL_SERIAL_SEND),    /* send byte on serial port */         \
         ACTION(RR_CALL_SERIAL_WRITE),   /* write byte to serial tx fifo */     \
+        ACTION(RR_CALL_CPU_REG_WRITE),   /* */     \
         ACTION(RR_CALL_LAST)
 
 typedef enum {

--- a/panda/src/rr/rr_log.c
+++ b/panda/src/rr/rr_log.c
@@ -481,9 +481,21 @@ static inline void rr_record_skipped_call(RR_skipped_call_args args) {
     });
 }
 
+void rr_device_mem_rw_call_record(hwaddr addr, const uint8_t* buf,
+                                  int len, int is_write) {
+    rr_record_skipped_call((RR_skipped_call_args) {
+        .kind = RR_CALL_CPU_MEM_RW,
+        .variant.cpu_mem_rw_args = {
+            .addr = addr,
+            .buf = (uint8_t *)buf,
+            .len = len
+        }
+    });
+}
+
 // bdg Record the memory modified during a call to
 // address_space_map/unmap.
-void rr_device_mem_rw_call_record(hwaddr addr, const uint8_t* buf,
+void rr_device_mem_unmap_call_record(hwaddr addr, const uint8_t* buf,
                                   int len, int is_write) {
     rr_record_skipped_call((RR_skipped_call_args) {
         .kind = RR_CALL_CPU_MEM_UNMAP,
@@ -494,6 +506,7 @@ void rr_device_mem_rw_call_record(hwaddr addr, const uint8_t* buf,
         }
     });
 }
+
 
 static inline uint32_t rr_chunked_crc32(void *ptr, size_t len) {
     uint32_t crc = crc32(0, Z_NULL, 0);


### PR DESCRIPTION
This PR introduces a new SKIPPED_CALL variant `RR_CPU_REG_WRITE` and various code additions to record and handle it. The idea is, that when the analyst changes register values during a record, that those are reflected in the log as well. As a result, interactive "fiddling" from outside the guest can be recorded and replayed as well.

Memory writes from a gdb-session are already handled by `rr_device_mem_rw_call_record`.
However, while digging into this, I discovered that this function would set the SKIPPED_CALL kind always to RR_CPU_MEM_UNMAP. While this has the same signature as RR_CPU_MEM_RW, it's handled different during replay; I included a patch which cleans this up and provides a new `rr_device_mem_unmap_call_record` function, which is called during `address_space_unmap` in `exec.c`. All other calls to `rr_device_mem_rw_call_record` seemed to actually just record a memory write.

Please note that I couldn't test this thoroughly yet and are not sure, whether it breaks any other parts of the code. However, small tests with a uboot-binary on the versatilepb board didn't result in any failure and provided the desired functionality.