### PR TITLE
ida_taint2 improvements

### DIFF
--- a/panda/plugins/ida_taint2/USAGE.md
+++ b/panda/plugins/ida_taint2/USAGE.md
@@ -4,21 +4,28 @@ Plugin: ida_taint2
 Summary
 -------
 This plugin is intended to be used with the included `ida_taint2.py` script in
-IDAPython. `ida_taint2.py` colorizes the dissasembly in IDA Pro using a CSV
-file produced by this plugin. The PANDA plugin produces a CSV file of process
-IDs and program counter values. There should be no duplicate rows in the file.
+IDAPython. `ida_taint2.py` colorizes  and renames functions in IDA based on the
+output CSV file from this plugin. This plugin produces a CSV file of process IDs
+and program counter values. There should be no duplicate rows in the file.
 An entry in the CSV file indicates that the instruction at the PC manipulated
 tainted data. The PID is needed because the reported addresses are virtual
-addresses. A process ID of 0 indicates the system is in kernel mode.
+addresses and so one address may be in two different processes. A process ID of
+0 indicates the system is in kernel mode.
+
+The `ida_taint2.py` script reads the CSV file and highlights functions and
+instructions that manipulate tainted data. Functions are highlighted green and
+individual instructions are highlighted in orange. Additionally, function names
+are updated with a prefix of "TAINTED_" so that it becomes possible to search
+for functions that manipulated tainted data.
 
 To use the ida_taint2.py script, open your target binary in IDA Pro, import
 the script in the File -> Script Command window, click run, and when prompted
 supply the path to the CSV file and the process ID you are analyzing.
 
 Note, this script assumes IDA has loaded your binary with the correct base
-address. For 32-bit Linux and Windows guests, this script should just work. The
-base address and/or segment may need to be adjusted manually for DOS operating
-systems.
+address. For 32-bit Linux and Windows guests, this script should just work
+(tested with IDA 7.1). The base address and/or segment may need to be adjusted
+manually for DOS operating systems.
 
 Arguments
 ---------

--- a/panda/plugins/ida_taint2/ida_taint2.cpp
+++ b/panda/plugins/ida_taint2/ida_taint2.cpp
@@ -31,50 +31,56 @@ void uninit_plugin(void *);
 
 FILE *pidpclog;
 
-struct PidPcPair {
+struct IDATaintReport {
     target_ulong pid;
     target_ulong pc;
+    uint32_t label;
 };
+
+template <typename T> inline void hash_combine(std::size_t &seed, const T &v)
+{
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
 
 // Inject the hash function for PidPcPair into the std namespace, allows us to
 // store PidPcPair in an unordered set.
 namespace std
 {
-template <> struct hash<PidPcPair> {
-    using argument_type = PidPcPair;
+template <> struct hash<IDATaintReport> {
+    using argument_type = IDATaintReport;
     using result_type = size_t;
     result_type operator()(argument_type const &s) const noexcept
     {
-        // Combining hashes, see C++ reference:
-        // https://en.cppreference.com/w/cpp/utility/hash
-        result_type const h1 = std::hash<target_ulong>{}(s.pid);
-        result_type const h2 = std::hash<target_ulong>{}(s.pc);
-        return h1 ^ (h2 << 1);
+        std::size_t h = 0;
+        hash_combine(h, s.pid);
+        hash_combine(h, s.pc);
+        hash_combine(h, s.label);
+        return h;
     }
 };
 } // namespace std
 
 // Also needed to use an unordered set (probably in case there is a hash
 // collision).
-bool operator==(const PidPcPair &lhs, const PidPcPair &rhs)
+bool operator==(const IDATaintReport &lhs, const IDATaintReport &rhs)
 {
-    return lhs.pid == rhs.pid && lhs.pc == rhs.pc;
+    return lhs.pid == rhs.pid && lhs.pc == rhs.pc && lhs.label == rhs.label;
 }
 
 void taint_state_changed(Addr a, uint64_t size)
 {
-    // We keep track of pairs of PIDs and PCs that we've already seen since we
-    // only need to write out distinct pairs once.
-    static std::unordered_set<PidPcPair> seen;
+    // Keep track of reports that we've already seen.
+    static std::unordered_set<IDATaintReport> seen;
 
     // Get current PID (if in user-mode and OSI gave us a process) and PC.
-    PidPcPair p;
-    p.pc = first_cpu->panda_guest_pc;
-    p.pid = 0;
+    IDATaintReport report;
+    report.pc = first_cpu->panda_guest_pc;
+    report.pid = 0;
     char *process_name = NULL;
     if (false == panda_in_kernel(first_cpu)) {
         OsiProc *proc = get_current_process(first_cpu);
-        p.pid = proc ? proc->pid : 0;
+        report.pid = proc ? proc->pid : 0;
 
         process_name = g_strdup(proc->name);
 
@@ -85,24 +91,23 @@ void taint_state_changed(Addr a, uint64_t size)
         process_name = g_strdup("(kernel)");
     }
 
-    // Figure out which entries are tainted.
-    uint32_t num_tainted = 0;
     for (int i = 0; i < size; i++) {
         a.off = i;
-        num_tainted += (taint2_query(a) != 0);
-    }
+        uint32_t label_count = taint2_query(a);
+        std::vector<uint32_t> labels(label_count);
+        taint2_query_set(a, labels.data());
 
-    // If its tainted and we haven't seen this PID\PC pair before, write to the
-    // file.
-    if (num_tainted && seen.find(p) == seen.end()) {
-        seen.insert(p);
-
-        fprintf(pidpclog, "%s,%lu,0x%lX\n", process_name, (uint64_t)p.pid,
-                (uint64_t)p.pc);
-    }
-
-    if (NULL != process_name) {
-        g_free(process_name);
+        if (label_count > 0) {
+            for (int j = 0; j < label_count; j++) {
+                report.label = labels[j];
+                if (seen.find(report) == seen.end()) {
+                    seen.insert(report);
+                    fprintf(pidpclog, "%s,%lu,0x%lX,0x%X\n", process_name,
+                            (uint64_t)report.pid, (uint64_t)report.pc,
+                            report.label);
+                }
+            }
+        }
     }
 }
 
@@ -129,7 +134,7 @@ bool init_plugin(void *self)
 
     // Open up a CSV file and write the header.
     pidpclog = fopen(filename, "w");
-    fprintf(pidpclog, "process name,pid,pc\n");
+    fprintf(pidpclog, "process name,pid,pc,label\n");
 
     return true;
 }

--- a/panda/plugins/ida_taint2/ida_taint2.cpp
+++ b/panda/plugins/ida_taint2/ida_taint2.cpp
@@ -102,7 +102,7 @@ void taint_state_changed(Addr a, uint64_t size)
                 report.label = labels[j];
                 if (seen.find(report) == seen.end()) {
                     seen.insert(report);
-                    fprintf(pidpclog, "%s,%lu,0x%lX,0x%X\n", process_name,
+                    fprintf(pidpclog, "%s,%lu,0x%lX,%u\n", process_name,
                             (uint64_t)report.pid, (uint64_t)report.pc,
                             report.label);
                 }

--- a/panda/plugins/ida_taint2/ida_taint2.py
+++ b/panda/plugins/ida_taint2/ida_taint2.py
@@ -108,5 +108,9 @@ for pc, labels in labels_for_pc.iteritems():
     comment = Comment(pc)
     if not comment:
         comment = ""
-    comment = "taint labels = {}".format(list(labels)) + "" if comment == "" else ", " + comment
+    label_portion = "taint labels = {}".format(list(labels))
+    if comment == "":
+        comment = label_portion
+    else:
+        comment += ", " + label_portion
     MakeComm(pc, comment)

--- a/panda/plugins/ida_taint2/ida_taint2.py
+++ b/panda/plugins/ida_taint2/ida_taint2.py
@@ -35,7 +35,7 @@ for row in reader:
     fn_start = fn.startEA
     fn_name = GetFunctionName(fn_start)
     if "TAINTED" not in fn_name:
-        MakeName(fn_start, fn_name + "_TAINTED")
+        MakeName(fn_start, "TAINTED_" + fn_name)
     SetColor(pc, CIC_FUNC, FUNC_COLOR)
     SetColor(pc, CIC_ITEM, INST_COLOR)
 input_file.close()

--- a/panda/plugins/ida_taint2/ida_taint2.py
+++ b/panda/plugins/ida_taint2/ida_taint2.py
@@ -5,28 +5,88 @@ maninpulate tainted data.
 
 import csv
 
-from PyQt5.QtWidgets import (QFileDialog, QInputDialog)
+from PyQt5.QtWidgets import *
 
 FUNC_COLOR = 0x90EE90
 INST_COLOR = 0x55AAFF
 
-filename, _ = QFileDialog.getOpenFileName(None, "Open file", ".",
-    "CSV Files(*.csv)")
+class ProcessSelectDialog(QDialog):
+    def __init__(self, processes):
+        super(ProcessSelectDialog, self).__init__()
+        
+        self.setWindowTitle("Select Process")
+        
+        btn_ok = QPushButton("OK")
+        btn_ok.clicked.connect(self.accept)
+        btn_cancel = QPushButton("Cancel")
+        btn_cancel.clicked.connect(self.reject)
+        
+        self.process_table = QTableWidget()
+        self.process_table.setColumnCount(2)
+        self.process_table.setHorizontalHeaderLabels(("Process Name", "PID"))
+        self.process_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.process_table.setRowCount(len(processes))
+        self.process_table.verticalHeader().setVisible(False)
+        self.process_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.process_table.setSelectionMode(QAbstractItemView.SingleSelection)
+        i = 0
+        for p in processes:
+            self.process_table.setItem(i, 0, QTableWidgetItem(p[0]))
+            self.process_table.setItem(i, 1, QTableWidgetItem(p[1]))
+            i += 1
+
+        hbox = QHBoxLayout()
+        hbox.addStretch(1)
+        hbox.addWidget(btn_ok)
+        hbox.addWidget(btn_cancel)
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(self.process_table)
+        vbox.addLayout(hbox)
+
+        self.setLayout(vbox)
+
+    def selectedProcess(self):
+        selectionModel = self.process_table.selectionModel()
+        if not selectionModel.hasSelection():
+            return None
+        if len(selectionModel.selectedRows()) > 1:
+            print("should not be possible")
+            exit(1)
+        row = selectionModel.selectedRows()[0].row()
+        return int(self.process_table.item(row, 1).data(0))
+        
+
+    @classmethod
+    def selectProcess(cls, processes):
+        psd = cls(processes)
+        if QDialog.Accepted == psd.exec_():
+            return psd.selectedProcess()
+        return None
+
+filename, _ = QFileDialog.getOpenFileName(None, "Open file", ".", "CSV Files(*.csv)")
 if filename == "":
     exit(0)
+    
+processes = set()
+input_file = open(filename, "r")
+reader = csv.reader(input_file)
+next(reader, None)
+for row in reader:
+    processes.add((row[0], row[1]))
+input_file.close()
 
-selected_pid, ok = QInputDialog.getInt(None, "Process ID", "Enter Process ID")
-if not ok:
+selected_pid = ProcessSelectDialog.selectProcess(processes)
+if not selected_pid:
     exit(0)
 
 input_file = open(filename, "r")
-
 reader = csv.reader(input_file)
 # skip header
 next(reader, None)
 for row in reader:
-    pid = int(row[0])
-    pc = int(row[1], 16)
+    pid = int(row[1])
+    pc = int(row[2], 16)
     if pid != selected_pid:
         continue
     fn = idaapi.get_func(pc)

--- a/panda/plugins/ida_taint2/ida_taint2.py
+++ b/panda/plugins/ida_taint2/ida_taint2.py
@@ -1,6 +1,6 @@
 """
-IDAPython Script to load ida_taint2 data and colorize basic blocks that contain
-instructions that maninpulate tainted data.
+IDAPython Script to load ida_taint2 data and colorize instructiions that
+maninpulate tainted data.
 """
 
 import csv
@@ -25,12 +25,8 @@ reader = csv.reader(input_file)
 next(reader, None)
 for row in reader:
     pid = int(row[0])
-    tb_pc = int(row[1])
-    tb_size = int(row[2])
+    pc = int(row[1], 16)
     if pid != selected_pid:
         continue
-    i = 0
-    while tb_pc+i < tb_pc+tb_size:
-        SetColor(tb_pc+i, CIC_ITEM, COLOR)
-        i += 1
+    SetColor(pc, CIC_ITEM, COLOR)
 input_file.close()

--- a/panda/plugins/ida_taint2/ida_taint2.py
+++ b/panda/plugins/ida_taint2/ida_taint2.py
@@ -87,7 +87,7 @@ next(reader, None)
 for row in reader:
     pid = int(row[1])
     pc = int(row[2], 16)
-    label = int(row[3], 16)
+    label = int(row[3])
     if pid != selected_pid:
         continue
     fn = idaapi.get_func(pc)

--- a/panda/plugins/ida_taint2/ida_taint2.py
+++ b/panda/plugins/ida_taint2/ida_taint2.py
@@ -7,7 +7,8 @@ import csv
 
 from PyQt5.QtWidgets import (QFileDialog, QInputDialog)
 
-COLOR = 0x55AAFF
+FUNC_COLOR = 0x90EE90
+INST_COLOR = 0x55AAFF
 
 filename, _ = QFileDialog.getOpenFileName(None, "Open file", ".",
     "CSV Files(*.csv)")
@@ -28,5 +29,13 @@ for row in reader:
     pc = int(row[1], 16)
     if pid != selected_pid:
         continue
-    SetColor(pc, CIC_ITEM, COLOR)
+    fn = idaapi.get_func(pc)
+    if not fn:
+        continue
+    fn_start = fn.startEA
+    fn_name = GetFunctionName(fn_start)
+    if "TAINTED" not in fn_name:
+        MakeName(fn_start, fn_name + "_TAINTED")
+    SetColor(pc, CIC_FUNC, FUNC_COLOR)
+    SetColor(pc, CIC_ITEM, INST_COLOR)
 input_file.close()


### PR DESCRIPTION
A few `ida_taint2` improvements:

- Report precise program counter instead of basic blocks.
- Colorize functions AND instructions that depend on\change tainted data (functions = green, instructions = orange).
- Prepend "TAINTED_" to function names if the function depends on\changes tainted data.
- Presents the user with a process selection dialog after selecting an ida_taint2 CSV file instead of requiring the user to type in the process ID.
- Add taint labels to comments.