### PR TITLE
Fix bug with callstack putting uncalled function on stack

### DIFF
--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -158,6 +158,7 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
     uintptr_t ret;
     TranslationBlock *last_tb;
     int tb_exit;
+    uint8_t exitCode;
     uint8_t *tb_ptr = itb->tc_ptr;
 
     qemu_log_mask_and_addr(CPU_LOG_EXEC, itb->pc,
@@ -199,9 +200,12 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
     cpu->can_do_io = 1;
     last_tb = (TranslationBlock *)(ret & ~TB_EXIT_MASK);
 
-    panda_callbacks_after_block_exec(cpu, itb);
-
     tb_exit = ret & TB_EXIT_MASK;
+
+    /* force into variable of known size */
+    exitCode = (uint8_t)tb_exit;
+    panda_callbacks_after_block_exec(cpu, itb, exitCode);
+
     trace_exec_tb_exit(last_tb, tb_exit);
 
     if (tb_exit > TB_EXIT_IDX1) {

--- a/panda/docs/PANDA.md
+++ b/panda/docs/PANDA.md
@@ -55,15 +55,19 @@ int (*before_block_exec)(CPUState *env, TranslationBlock *tb);
 
 * `CPUState *env`: the current CPU state
 * `TranslationBlock *tb`: the TB we just executed
-* `TranslationBlock *next_tb`: the TB we will execute next (may be `NULL`)
+* `uint8_t exitCode`: one of the `TB_EXIT_` constants found in `tcg.h`
 
 **Return value**:
 
 unused
 
-**Signature:**:
- ```C
-int (*after_block_exec)(CPUState *env, TranslationBlock *tb, TranslationBlock *next_tb);
+**Notes**:
+
+The `exitCode` can be used to determine if the `tb` was executed to completion, or was interrupted due to an exit request.  If `exitCode <= TB_EXIT_IDX1` then the block ran to completion; otherwise it did not, and will be retried later.
+
+**Signature**:
+```C
+int (*after_block_exec)(CPUState *env, TranslationBlock *tb, uint8_t exitCode);
 ```
 ---
 
@@ -317,7 +321,7 @@ int (*replay_before_cpu_physical_mem_rw_ram)(
 ```
 ---
 
-**replay_handle_packet**: TODO: This will be used for network packet replay.
+**replay_handle_packet**: used for network packet replay
 
 **Callback ID**:   PANDA_CB_REPLAY_HANDLE_PACKET
 
@@ -326,8 +330,8 @@ int (*replay_before_cpu_physical_mem_rw_ram)(
 * `CPUState *env`: pointer to CPUState
 * `uint8_t *buf`: buffer containing packet data
 * `int size`: num bytes in buffer
-* `uint8_t direction`: XXX read or write.  not sure which is which.
-* `uint64_t old_buf_addr`: XXX this is a mystery
+* `uint8_t direction`: `PANDA_NET_RX` for receive, `PANDA_NET_TX` for transmit
+* `uint64_t old_buf_addr`: the address that the buffer had when the recording was taken
 
 **Signature**:
 ```C

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -1275,14 +1275,19 @@ bool (*before_block_exec_invalidate_opt)(CPUState *env, TranslationBlock *tb);
 
 * `CPUState *env`: the current CPU state
 * `TranslationBlock *tb`: the TB we just executed
+* `uint8_t exitCode`: one of the `TB_EXIT_` constants from `tcg.h`
 
 **Return value**:
 
 unused
 
+**Notes**:
+
+The `exitCode` can be used to determine if the block was executed to completion, or if it was interrupted by an exit request and execution must be retried later.  When `exitCode <= TB_EXIT_IDX1`, then execution completed normally; otherwise, it was stopped and will be retried later.
+
 **Signature:**:
 ```C
-int (*after_block_exec)(CPUState *env, TranslationBlock *tb);
+int (*after_block_exec)(CPUState *env, TranslationBlock *tb, uint8_t exitCode);
 ```
 ---
 

--- a/panda/include/panda/callback_support.h
+++ b/panda/include/panda/callback_support.h
@@ -9,7 +9,7 @@ void panda_callbacks_after_dma(CPUState *cpu, hwaddr addr1, const uint8_t *buf, 
 
 // cpu-exec.c
 void panda_callbacks_before_block_exec(CPUState *cpu, TranslationBlock *tb);
-void panda_callbacks_after_block_exec(CPUState *cpu, TranslationBlock *tb);
+void panda_callbacks_after_block_exec(CPUState *cpu, TranslationBlock *tb, uint8_t exitCode);
 void panda_callbacks_before_block_translate(CPUState *cpu, target_ulong pc);
 void panda_callbacks_after_block_translate(CPUState *cpu, TranslationBlock *tb);
 bool panda_callbacks_after_find_fast(CPUState *cpu, TranslationBlock *tb, bool panda_bb_invalidate_done, bool *invalidate);

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -123,7 +123,6 @@ typedef union panda_cb {
        Arguments:
         CPUState *env: the current CPU state
         TranslationBlock *tb: the TB we just executed
-        TranslationBlock *next_tb: the TB we will execute next (may be NULL)
         uint8_t exitCode:  why the block execution exited
 
        Return value:

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -117,17 +117,19 @@ typedef union panda_cb {
 
     /* Callback ID: PANDA_CB_AFTER_BLOCK_EXEC
 
-       after_block_exec: called after execution of every basic block
+       after_block_exec: called after execution of every basic block, although
+       if exitCode > TB_EXIT_IDX1, then the block exited early
 
        Arguments:
         CPUState *env: the current CPU state
         TranslationBlock *tb: the TB we just executed
         TranslationBlock *next_tb: the TB we will execute next (may be NULL)
+        uint8_t exitCode:  why the block execution exited
 
        Return value:
         unused
     */
-    int (*after_block_exec)(CPUState *env, TranslationBlock *tb);
+    int (*after_block_exec)(CPUState *env, TranslationBlock *tb, uint8_t exitCode);
 
     /* Callback ID: PANDA_CB_BEFORE_BLOCK_TRANSLATE
 

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -6,12 +6,12 @@ Summary
 
 The `callstack_instr` plugin keeps track of function calls and returns as they occur in the guest. These are tracked using a shadow call stack, so it should be more reliable than trying to do a stack walk. The plugin makes this information available through an exposed plugin-plugin interaction API, and offers callbacks to let other plugins be notified.
 
-`callstack_instr` currently requires `distorm` to be installed so it can disassemble instructions and identify `call`s and `ret`s.
+`callstack_instr` currently requires `Capstone` to be installed so it can disassemble instructions and identify `call`s and `ret`s.
 
 Arguments
 ---------
 
-None.
+* `verbose`: boolean, defaults to false. Whether to output debugging messages.
 
 Dependencies
 ------------
@@ -65,9 +65,6 @@ void get_prog_point(CPUState *env, prog_point *p);
 There are also functions available for getting callstack information in [pandalog format](docs/pandalog.md):
 
 ```C
-// Create pandalog message for callstack info
-Panda__CallStack *pandalog_callstack_create(void);
-
 // Create pandalog message for callstack info
 Panda__CallStack *pandalog_callstack_create(void);
 

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -14,6 +14,8 @@ PANDAENDCOMMENT */
 /* Change Log: */
 /* 2018-MAY-29   move where mode bit calculated as requested */
 /* 2018-APR-13   watch for x86 processor mode changing in i386 build */
+/* 2019-JAN-29   do not put an entry in the callstack if the block was stopped */
+/*               before the call at the end was made */
 #define __STDC_FORMAT_MACROS
 
 #include <cstdio>
@@ -45,7 +47,7 @@ extern "C" {
 bool translate_callback(CPUState* cpu, target_ulong pc);
 int exec_callback(CPUState* cpu, target_ulong pc);
 int before_block_exec(CPUState* cpu, TranslationBlock *tb);
-int after_block_exec(CPUState* cpu, TranslationBlock *tb);
+int after_block_exec(CPUState* cpu, TranslationBlock *tb, uint8_t exitCode);
 int after_block_translate(CPUState* cpu, TranslationBlock *tb);
 
 bool init_plugin(void *);
@@ -57,6 +59,9 @@ PPP_PROT_REG_CB(on_ret);
 
 PPP_CB_BOILERPLATE(on_call);
 PPP_CB_BOILERPLATE(on_ret);
+
+// callstack_instr arguments
+static bool verbose = false;
 
 enum instr_type {
   INSTR_UNKNOWN = 0,
@@ -100,7 +105,28 @@ std::map<stackid, std::vector<stack_entry>> callstacks;
 std::map<stackid, std::vector<target_ulong>> function_stacks;
 // EIP -> instr_type
 std::map<target_ulong, instr_type> call_cache;
+// stackid -> address of Stopped block
+std::map<stackid, target_ulong> stoppedInfo;
+
 int last_ret_size = 0;
+
+void verbose_log(const char *msg, TranslationBlock *tb, stackid curStackid,
+        bool logReturn) {
+    if (verbose) {
+        printf("%s:  asid=0x", msg);
+#ifdef USE_STACK_HEURISTIC
+        printf(TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx, curStackid.first,
+                curStackid.second);
+#else
+        printf(TARGET_FMT_lx, curStackid);
+#endif
+        printf(", block pc=0x" TARGET_FMT_lx, tb->pc);
+        if (logReturn) {
+            printf(", returns to 0x" TARGET_FMT_lx, (tb->pc+tb->size));
+        }
+        printf("\n");
+    }
+} // end of function verbose_log
 
 static inline bool in_kernelspace(CPUArchState* env) {
 #if defined(TARGET_I386)
@@ -242,47 +268,96 @@ int after_block_translate(CPUState *cpu, TranslationBlock *tb) {
 
 int before_block_exec(CPUState *cpu, TranslationBlock *tb) {
     CPUArchState* env = (CPUArchState*)cpu->env_ptr;
-    std::vector<stack_entry> &v = callstacks[get_stackid(env)];
-    std::vector<target_ulong> &w = function_stacks[get_stackid(env)];
-    if (v.empty()) return 1;
 
-    // Search up to 10 down
-    for (int i = v.size()-1; i > ((int)(v.size()-10)) && i >= 0; i--) {
-        if (tb->pc == v[i].pc) {
-            //printf("Matched at depth %d\n", v.size()-i);
-            //v.erase(v.begin()+i, v.end());
-
-            PPP_RUN_CB(on_ret, cpu, w[i]);
-            v.erase(v.begin()+i, v.end());
-            w.erase(w.begin()+i, w.end());
-
-            break;
+    // if the block a call returns to was interrupted before it completed, this
+    // function will be called twice - only want to remove the return value from
+    // the stack once
+    // the return value will have been removed before the attempt to run which
+    // was stopped (as we didn't know it would be stopped then), so skip it on
+    // the retry
+    bool needToCheck = true;
+    stackid curStackid = get_stackid(env);
+    std::map<stackid, target_ulong>::const_iterator it;
+    it = stoppedInfo.find(curStackid);
+    if (it != stoppedInfo.end()) {
+        target_ulong stoppedPC = stoppedInfo[curStackid];
+        if (stoppedPC == tb->pc) {
+            stoppedInfo.erase(it);
+            needToCheck = false;
+            verbose_log("callstack_instr skipping return check", tb, curStackid,
+                    false);
         }
     }
+
+    if (needToCheck) {
+        std::vector<stack_entry> &v = callstacks[get_stackid(env)];
+        std::vector<target_ulong> &w = function_stacks[get_stackid(env)];
+        if (v.empty()) return 1;
+
+        // Search up to 10 down
+        for (int i = v.size()-1; i > ((int)(v.size()-10)) && i >= 0; i--) {
+            if (tb->pc == v[i].pc) {
+                //printf("Matched at depth %d\n", v.size()-i);
+                //v.erase(v.begin()+i, v.end());
+
+                PPP_RUN_CB(on_ret, cpu, w[i]);
+                v.erase(v.begin()+i, v.end());
+                w.erase(w.begin()+i, w.end());
+
+                break;
+            }
+        }
+    }
+
 
     return 0;
 }
 
-int after_block_exec(CPUState* cpu, TranslationBlock *tb) {
+int after_block_exec(CPUState* cpu, TranslationBlock *tb, uint8_t exitCode) {
+    target_ulong pc;
+    target_ulong cs_base;
+    uint32_t flags;
+
     CPUArchState* env = (CPUArchState*)cpu->env_ptr;
     instr_type tb_type = call_cache[tb->pc];
+    stackid curStackid = get_stackid(env);
 
-    if (tb_type == INSTR_CALL) {
-        stack_entry se = {tb->pc+tb->size,tb_type};
-        callstacks[get_stackid(env)].push_back(se);
+    // sometimes an attempt to run a block is interrupted, but this callback is
+    // still made - only update the callstack if the block ran to completion
+    if (exitCode <= TB_EXIT_IDX1) {
+        // this attempt is OK, so remove it from the Stopped list, if there
+        stoppedInfo.erase(curStackid);
 
-        // Also track the function that gets called
-        target_ulong pc, cs_base;
-        uint32_t flags;
-        // This retrieves the pc in an architecture-neutral way
-        cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
-        function_stacks[get_stackid(env)].push_back(pc);
+        if (tb_type == INSTR_CALL) {
+            stack_entry se = {tb->pc+tb->size,tb_type};
+            callstacks[curStackid].push_back(se);
 
-        PPP_RUN_CB(on_call, cpu, pc);
+            // Also track the function that gets called
+            // This retrieves the pc in an architecture-neutral way
+            cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
+            function_stacks[curStackid].push_back(pc);
+
+            PPP_RUN_CB(on_call, cpu, pc);
+        }
+        else if (tb_type == INSTR_RET) {
+            //printf("Just executed a RET in TB " TARGET_FMT_lx "\n", tb->pc);
+            //if (next) printf("Next TB: " TARGET_FMT_lx "\n", next->pc);
+        }
     }
-    else if (tb_type == INSTR_RET) {
-        //printf("Just executed a RET in TB " TARGET_FMT_lx "\n", tb->pc);
-        //if (next) printf("Next TB: " TARGET_FMT_lx "\n", next->pc);
+    // in case this block is one that a call returns to, need to note that its
+    // execution was interrupted, so don't try to remove it from the callstack
+    // when retry (as already removed it before this attempt)
+    else {
+        // verbose output is helpful in regression testing
+        if (tb_type == INSTR_CALL) {
+            verbose_log("callstack_instr not adding Stopped caller to stack",
+                    tb, curStackid, true);
+        }
+
+        cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
+        // C++ maps don't let you replace value of an existing key (grr)
+        stoppedInfo.erase(curStackid);  // nicely does nothing if key DNE
+        stoppedInfo[curStackid] = pc;
     }
 
     return 1;
@@ -376,6 +451,11 @@ void get_prog_point(CPUState* cpu, prog_point *p) {
 
 
 bool init_plugin(void *self) {
+
+    // get arguments to this plugin
+    panda_arg_list *args = panda_get_args("callstack_instr");
+    verbose = panda_parse_bool_opt(args, "verbose", "enable verbose output");
+
 #if defined(TARGET_I386)
     if (cs_open(CS_ARCH_X86, CS_MODE_32, &cs_handle_32) != CS_ERR_OK)
         return false;
@@ -389,6 +469,13 @@ bool init_plugin(void *self) {
 #elif defined(TARGET_PPC)
     if (cs_open(CS_ARCH_PPC, CS_MODE_32, &cs_handle_32) != CS_ERR_OK)
         return false;
+#endif
+
+    // note which build was used, as it is useful in analyzing the results
+#ifdef USE_STACK_HEURISTIC
+    printf("callstack_instr:  using USE_STACK_HEURISTIC build\n");
+#else
+    printf("callstack_instr:  using standard build\n");
 #endif
 
     // Need details in capstone to have instruction groupings

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -11,11 +11,11 @@
  * See the COPYING file in the top-level directory.
  *
 PANDAENDCOMMENT */
-/* Change Log: */
-/* 2018-MAY-29   move where mode bit calculated as requested */
-/* 2018-APR-13   watch for x86 processor mode changing in i386 build */
-/* 2019-JAN-29   do not put an entry in the callstack if the block was stopped */
-/*               before the call at the end was made */
+// Change Log
+// 2018-MAY-29   move where mode bit calculated as requested
+// 2018-APR-13   watch for x86 processor mode changing in i386 build
+// 2019-JAN-29   do not put an entry in the callstack if the block was stopped
+//               before the call at the end was made
 #define __STDC_FORMAT_MACROS
 
 #include <cstdio>
@@ -126,7 +126,8 @@ void verbose_log(const char *msg, TranslationBlock *tb, stackid curStackid,
         }
         printf("\n");
     }
-} // end of function verbose_log
+    // end of function verbose_log
+}
 
 static inline bool in_kernelspace(CPUArchState* env) {
 #if defined(TARGET_I386)
@@ -356,7 +357,8 @@ int after_block_exec(CPUState* cpu, TranslationBlock *tb, uint8_t exitCode) {
 
         cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
         // C++ maps don't let you replace value of an existing key (grr)
-        stoppedInfo.erase(curStackid);  // nicely does nothing if key DNE
+        // erase nicely does nothing if key DNE
+        stoppedInfo.erase(curStackid);
         stoppedInfo[curStackid] = pc;
     }
 

--- a/panda/plugins/osi_test/osi_test.c
+++ b/panda/plugins/osi_test/osi_test.c
@@ -29,7 +29,7 @@ void uninit_plugin(void *);
 
 int asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd);
 int before_block_exec(CPUState *cpu, TranslationBlock *tb);
-int after_block_exec(CPUState *cpu, TranslationBlock *tb);
+int after_block_exec(CPUState *cpu, TranslationBlock *tb, uint8_t exitCode);
 
 int before_block_exec(CPUState *cpu, TranslationBlock *tb) {
     OsiProc *current = get_current_process(cpu);
@@ -61,7 +61,7 @@ int before_block_exec(CPUState *cpu, TranslationBlock *tb) {
     return 0;
 }
 
-int after_block_exec(CPUState *cpu, TranslationBlock *tb) {
+int after_block_exec(CPUState *cpu, TranslationBlock *tb, uint8_t exitCode) {
     OsiProc *current = get_current_process(cpu);
     GArray *ms = get_libraries(cpu, current);
     if (ms == NULL) {
@@ -100,7 +100,7 @@ int after_block_exec(CPUState *cpu, TranslationBlock *tb) {
 int asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd) {
     // tb argument is not used by before_block_exec()
     before_block_exec(cpu, NULL);
-    after_block_exec(cpu, NULL);
+    after_block_exec(cpu, NULL, TB_EXIT_IDX0);
     return 0;
 }
 

--- a/panda/plugins/taint2/taint2.cpp
+++ b/panda/plugins/taint2/taint2.cpp
@@ -63,7 +63,6 @@ bool init_plugin(void *);
 void uninit_plugin(void *);
 int after_block_translate(CPUState *cpu, TranslationBlock *tb);
 bool before_block_exec_invalidate_opt(CPUState *cpu, TranslationBlock *tb);
-int after_block_exec(CPUState *cpu, TranslationBlock *tb);
 
 int phys_mem_write_callback(CPUState *cpu, target_ulong pc, target_ulong addr, target_ulong size, void *buf);
 int phys_mem_read_callback(CPUState *cpu, target_ulong pc, target_ulong addr, target_ulong size, void *buf);
@@ -317,18 +316,6 @@ void taint2_enable_taint(void) {
 #endif
 
     std::cerr << "Done verifying module. Running..." << std::endl;
-}
-
-// Execute taint ops
-int after_block_exec(CPUState *cpu, TranslationBlock *tb) {
-    if (taintJustDisabled){
-        taintJustDisabled = false;
-        execute_llvm = 0;
-        generate_llvm = 0;
-        panda_do_flush_tb();
-        panda_disable_memcb();
-    }
-    return 0;
 }
 
 __attribute__((unused)) static void print_labels(uint32_t el, void *stuff) {

--- a/panda/src/callback_support.c
+++ b/panda/src/callback_support.c
@@ -74,11 +74,11 @@ void panda_callbacks_before_block_exec(CPUState *cpu, TranslationBlock *tb) {
 }
 
 
-void panda_callbacks_after_block_exec(CPUState *cpu, TranslationBlock *tb) {
+void panda_callbacks_after_block_exec(CPUState *cpu, TranslationBlock *tb, uint8_t exitCode) {
     panda_cb_list *plist;
     for (plist = panda_cbs[PANDA_CB_AFTER_BLOCK_EXEC];
          plist != NULL; plist = panda_cb_list_next(plist)) {
-        plist->entry.after_block_exec(cpu, tb);
+        plist->entry.after_block_exec(cpu, tb, exitCode);
     }
 }
 


### PR DESCRIPTION
If a block ending in a calls statement is Stopped (because of an exit request or such), the callstack plugin was putting the return address of the call on the stack.  Then when the block successfully run, it was put on the stack again.  Of course, as it was rather unlikely that the block starting with the return address was also Stopped and then run successfully, this left misleading leftovers in the stack.  This has been fixed by adjusting the after_block_exec callback to provide information on the exit status for the block, which callstack makes use of.
This required adjustments in the osi_test plugin, as it also uses after_block_exec.
The taint2 plugin had an implementation of after_block_exec that was really dead code as it never registered for that callback, so it was wiped out.
Updated all related documentation I could find (and also updated some documentation in PANDA.md for the replay_handle_packet that I missed on on earlier task, as I was already in PANDA.md for this task).