### PR TITLE
Callfunc plugin features (ARM)

### DIFF
--- a/panda/plugins/callfunc/USAGE.md
+++ b/panda/plugins/callfunc/USAGE.md
@@ -29,11 +29,11 @@ None
 Example
 -------
 
-Call the function `kmalloc` to allocate 64KB of kernel memory whenever `do_execve` is called. Note that these addresses are specific to the Debian ARM image used by PANDA's `run_debian.py`; you will have to adjust them if you want to use them on another target.
+Call the function `kmalloc` to allocate 64KB of kernel memory whenever `do_execve` is called. Note that these addresses are specific to the Debian ARM image used by PANDA's `run_debian.py --arch arm`; you will have to adjust them if you want to use them on another target.
 
 ```
 arm-softmmu/qemu-system-arm -M versatilepb -kernel ~/.panda/vmlinuz-3.2.0-4-versatile \
     -initrd ~/.panda/initrd.img-3.2.0-4-versatile -hda ~/.panda/arm_wheezy.qcow \
     -serial stdio -loadvm root -display none \
-    -panda callfunc:when=0xc00ca05c,func=0xc00bb0cc,arg1=65536,arg2=0xd0
+    -panda callfunc:when=0xc00ca05c,func=0xc00bb0cc,args="0x10000-0xd0"
 ```

--- a/panda/plugins/callfunc/USAGE.md
+++ b/panda/plugins/callfunc/USAGE.md
@@ -9,12 +9,12 @@ Call a function in the guest (currently ARM only)
 Arguments
 ---------
 
-* when: the PC at which to call our function
-* func: the function to call
-* arg1: the first function argument (optional)
-* arg2: the second function argument (optional)
-* arg3: the third function argument (optional)
-* arg4: the fourth function argument (optional)
+* when (ulong): PC at which to call our function
+* func (ulong): Function to call
+* args (string): Hexidecimal, dash delimited arguments for the function to call (optional)
+* mm_file (string): File to memory map (optional)
+* mm_dst (ulong): Memory location to map file (optional)
+* rev_push (bool): Push stack arguments in reverse order, if any (optional)
 
 Dependencies
 ------------
@@ -26,8 +26,8 @@ APIs and Callbacks
 
 None
 
-Example
--------
+Example 1
+---------
 
 Call the function `kmalloc` to allocate 64KB of kernel memory whenever `do_execve` is called. Note that these addresses are specific to the Debian ARM image used by PANDA's `run_debian.py --arch arm`; you will have to adjust them if you want to use them on another target.
 
@@ -36,4 +36,19 @@ arm-softmmu/qemu-system-arm -M versatilepb -kernel ~/.panda/vmlinuz-3.2.0-4-vers
     -initrd ~/.panda/initrd.img-3.2.0-4-versatile -hda ~/.panda/arm_wheezy.qcow \
     -serial stdio -loadvm root -display none \
     -panda callfunc:when=0xc00ca05c,func=0xc00bb0cc,args="0x10000-0xd0"
+```
+
+Example 2
+---------
+
+Write a `null` terminated string to a file, map that file into guest memory to use it's contents as the format string for a call to the kernel's `printk` function, again triggered whenever `do_execve` is called.
+
+```
+echo -ne "Hello from kernel's printk! %d %d %d %d %d %d %d\n\0" > fmt_str.txt
+
+arm-softmmu/qemu-system-arm -M versatilepb -kernel ~/.panda/vmlinuz-3.2.0-4-versatile \
+    -initrd ~/.panda/initrd.img-3.2.0-4-versatile -hda ~/.panda/arm_wheezy.qcow \
+    -serial stdio -loadvm root -display none \
+    -panda callfunc:when=0xc00ca05c,func=0xc026feb4,mm_file="fmt_str.txt",mm_dst=0xc0000000,args="0xc0000000-0x1-0x2-0x3-0x4-0x5-0x6-0x7"
+
 ```

--- a/panda/plugins/callfunc/USAGE.md
+++ b/panda/plugins/callfunc/USAGE.md
@@ -31,7 +31,9 @@ Example
 
 Call the function `kmalloc` to allocate 64KB of kernel memory whenever `do_execve` is called. Note that these addresses are specific to the Debian ARM image used by PANDA's `run_debian.py`; you will have to adjust them if you want to use them on another target.
 
-```arm-softmmu/qemu-system-arm -M versatilepb -kernel ~/.panda/vmlinuz-3.2.0-4-versatile \
+```
+arm-softmmu/qemu-system-arm -M versatilepb -kernel ~/.panda/vmlinuz-3.2.0-4-versatile \
     -initrd ~/.panda/initrd.img-3.2.0-4-versatile -hda ~/.panda/arm_wheezy.qcow \
     -serial stdio -loadvm root -display none \
     -panda callfunc:when=0xc00ca05c,func=0xc00bb0cc,arg1=65536,arg2=0xd0
+```

--- a/panda/plugins/callfunc/callfunc.cpp
+++ b/panda/plugins/callfunc/callfunc.cpp
@@ -1,11 +1,8 @@
 /* PANDABEGINCOMMENT
  *
- * Authors:
- *  Tim Leek               tleek@ll.mit.edu
- *  Ryan Whelan            rwhelan@ll.mit.edu
- *  Joshua Hodosh          josh.hodosh@ll.mit.edu
- *  Michael Zhivich        mzhivich@ll.mit.edu
- *  Brendan Dolan-Gavitt   brendandg@gatech.edu
+ *  Authors:
+ *  Brendan Dolan-Gavitt    brendandg@gatech.edu
+ *  tnballo                 N/A
  *
  * This work is licensed under the terms of the GNU GPL, version 2.
  * See the COPYING file in the top-level directory.
@@ -15,7 +12,11 @@ PANDAENDCOMMENT */
 // the PRIx64 macro
 #define __STDC_FORMAT_MACROS
 
+#include<vector>
+#include<iostream>
+#include<string>
 #include "panda/plugin.h"
+#include "panda/common.h"
 
 // These need to be extern "C" so that the ABI is compatible with
 // QEMU/PANDA, which is written in C
@@ -26,20 +27,100 @@ void uninit_plugin(void *);
 
 }
 
+#ifdef TARGET_ARM
+#define REG_ARG_CNT 4
+#define SP_REG_NUM  13
+#else   // TODO: support all archs
+#define REG_ARG_CNT 0
+#define SP_REG_NUM  0
+#endif
+
+// TODO: Use  panda_virtual_memory_rw and incrementfor injection instead of qemu's mem map from file
+std::vector<target_ulong> func_args_vec;
 target_ulong when;
 target_ulong target_func;
-target_ulong func_args[4];
 bool in_call = false;
 
-static bool call_function(CPUState *env, TranslationBlock *tb) {
+// Parse string of delimited arguments to vector
+void args_to_vec(const char *arg_list_str, std::vector<target_ulong> & out)
+{
+    size_t pos_start;
+    size_t pos_end;
+    std::string s(arg_list_str);
+    std::string delim("-");
+    size_t len = 0;
+
+    out.clear();
+    if (!arg_list_str) {
+        return;
+    }
+
+    pos_start = 0;
+    pos_end = s.find(delim);
+
+    // 1 arg, no delim
+    if (pos_end == std::string::npos) {
+        out.push_back((target_ulong)std::stoul(s, nullptr, 16));
+        return;
+    }
+
+    // Delimited args
+    while (pos_end != std::string::npos) {
+        len = (pos_end - pos_start);
+        out.push_back((target_ulong)std::stoul(s.substr(pos_start, len), nullptr, 16));
+        pos_start = (pos_end + delim.size());
+        pos_end = s.find(delim, pos_start);
+    }
+
+    // No delim after last arg
+    if (pos_start < (s.size() - 1)) {
+        out.push_back((target_ulong)std::stoul(s.substr(pos_start), nullptr, 16));
+    }
+}
+
+// Pass first n args via registers, remainder via stack in reverse order
+void init_args(CPUState *env, int reg_arg_cnt, int sp_reg_num, const std::vector<target_ulong> & args) {
+#ifdef TARGET_ARM
+
+    CPUArchState *envp = (CPUArchState *)env->env_ptr;
+    auto it = args.begin();
+    target_ulong sp = envp->regs[sp_reg_num];
+    target_ulong val = 0;
+    int reg_max = (args.size() < reg_arg_cnt) ? args.size() : reg_arg_cnt;
+    int err_ret = 0;
+
+    // Register load initial args
+    for (int i = 0; i <= reg_max; i = std::distance(args.begin(), it)) {
+        val = *it;
+        std::cout << std::hex << "[TEMP DEBUG] Loading 0x" << val << " in reg 0x" << i << std::endl;
+        envp->regs[i] = val;
+        it++;
+    }
+
+    // Stack write/push remaining args
+    for (auto rev_it = --args.end(); rev_it >= it; rev_it--) {
+        val = *rev_it;
+        std::cout << std::hex << "[TEMP DEBUG] Pushing 0x" << val << " @ stack addr 0x" << sp << std::endl;
+        err_ret = panda_virtual_memory_rw(env, sp, (uint8_t*)&val, sizeof(val), true);
+        if (err_ret) {
+            std::cerr << std::hex << "Failed to write 0x" << val << " @ stack addr 0x" << sp << std::endl;
+        } else {
+            sp += sizeof(val);
+            envp->regs[sp_reg_num] = sp;
+        }
+    }
+#endif
+}
+
+// Make a function call (arbitrary callsite, callee, params)
+bool call_function(CPUState *env, TranslationBlock *tb) {
 #ifdef TARGET_ARM
     CPUArchState *envp = (CPUArchState *)env->env_ptr;
     static char pre_call_state[offsetof(CPUArchState, end_reset_fields)];
     if (in_call) {
         if (tb->pc == when) {
             // print out R0 (return value)
-            printf("Called function " TARGET_FMT_lx " returned " TARGET_FMT_lx "\n",
-                    target_func, envp->regs[0]);
+            std::cout << std::hex << "Called function 0x" << target_func << " returned 0x" << envp->regs[0] << std::endl;
             // restore pre-call CPU state
             memcpy(envp, pre_call_state, sizeof(pre_call_state));
             in_call = false;
@@ -55,10 +136,7 @@ static bool call_function(CPUState *env, TranslationBlock *tb) {
             // save pre-call CPU state
             memcpy(pre_call_state, envp, sizeof(pre_call_state));
             // set up args
-            envp->regs[0] = func_args[0];
-            envp->regs[1] = func_args[1];
-            envp->regs[2] = func_args[2];
-            envp->regs[3] = func_args[3];
+            init_args(env, REG_ARG_CNT, SP_REG_NUM, func_args_vec);
             // set LR = when
             envp->regs[14] = when;
             // set PC = target_func
@@ -78,19 +156,22 @@ static bool call_function(CPUState *env, TranslationBlock *tb) {
 //  - What if target_func tries to call "when"
 //  - What about recursive calls
 //  - What if when is not the start of a basic block
-//  - What if we have more than 4 parameters
-bool init_plugin(void *self) {
+//  - Guest and host have opposite endianess
+bool init_plugin(void* self) {
+
     panda_cb pcb;
+    panda_arg_list* panda_args = nullptr;
+    const char* func_args_str = nullptr;
+
     pcb.before_block_exec_invalidate_opt = call_function;
     panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC_INVALIDATE_OPT, pcb);
 
-    panda_arg_list *args = panda_get_args("callfunc");
-    when = panda_parse_ulong_req(args, "when", "the PC at which to call our function");
-    target_func = panda_parse_ulong_req(args, "func", "the function to call");
-    func_args[0] = panda_parse_ulong_opt(args, "arg1", 0, "the first function argument");
-    func_args[1] = panda_parse_ulong_opt(args, "arg2", 0, "the second function argument");
-    func_args[2] = panda_parse_ulong_opt(args, "arg3", 0, "the third function argument");
-    func_args[3] = panda_parse_ulong_opt(args, "arg4", 0, "the fourth function argument");
+    panda_args = panda_get_args("callfunc");
+    when = panda_parse_ulong_req(panda_args, "when", "PC at which to call our function.");
+    target_func = panda_parse_ulong_req(panda_args, "func", "Function to call.");
+    func_args_str = panda_parse_string_req(panda_args, "args", "Hexidecimal, dash delimited arguments for the function to call.");
+
+    args_to_vec(func_args_str, func_args_vec);
 
     return true;
 }

--- a/panda/plugins/callfunc/callfunc.cpp
+++ b/panda/plugins/callfunc/callfunc.cpp
@@ -2,7 +2,7 @@
  *
  *  Authors:
  *  Brendan Dolan-Gavitt    brendandg@gatech.edu
- *  tnballo                 N/A
+ *  Tiemoko Ballo           N/A
  *
  * This work is licensed under the terms of the GNU GPL, version 2.
  * See the COPYING file in the top-level directory.
@@ -14,7 +14,10 @@ PANDAENDCOMMENT */
 
 #include<vector>
 #include<iostream>
+#include<iomanip>
+#include<fstream>
 #include<string>
+#include<algorithm>
 #include "panda/plugin.h"
 #include "panda/common.h"
 
@@ -35,15 +38,18 @@ void uninit_plugin(void *);
 #define SP_REG_NUM  0
 #endif
 
-// TODO: Use  panda_virtual_memory_rw and incrementfor injection instead of qemu's mem map from file
 std::vector<target_ulong> func_args_vec;
 target_ulong when;
 target_ulong target_func;
-bool in_call = false;
+bool rev_push;
+target_ulong mm_dst;
+const char* mm_fn_str;
 
 // Parse string of delimited arguments to vector
-void args_to_vec(const char *arg_list_str, std::vector<target_ulong> & out)
-{
+void args_to_vec(const char *arg_list_str, std::vector<target_ulong> & out) {
+
+    if ((!arg_list_str)) { return; }    // Pre-condition
+
     size_t pos_start;
     size_t pos_end;
     std::string s(arg_list_str);
@@ -51,10 +57,6 @@ void args_to_vec(const char *arg_list_str, std::vector<target_ulong> & out)
     size_t len = 0;
 
     out.clear();
-    if (!arg_list_str) {
-        return;
-    }
-
     pos_start = 0;
     pos_end = s.find(delim);
 
@@ -78,72 +80,111 @@ void args_to_vec(const char *arg_list_str, std::vector<target_ulong> & out)
     }
 }
 
-// Pass first n args via registers, remainder via stack in reverse order
-void init_args(CPUState *env, int reg_arg_cnt, int sp_reg_num, const std::vector<target_ulong> & args) {
+// Pass first n args via registers, remainder via stack, optionally in reverse order
+void init_args(CPUState *env, int reg_arg_cnt, int sp_reg_num, bool rev_push, const std::vector<target_ulong> & args) {
 #ifdef TARGET_ARM
 
+    if (args.empty()) { return; }   // Pre-condition
+
+    std::vector<target_ulong> remaining_args;
     CPUArchState *envp = (CPUArchState *)env->env_ptr;
     auto it = args.begin();
     target_ulong sp = envp->regs[sp_reg_num];
-    target_ulong val = 0;
     int reg_max = (args.size() < reg_arg_cnt) ? args.size() : reg_arg_cnt;
     int err_ret = 0;
 
     // Register load initial args
     for (int i = 0; i <= reg_max; i = std::distance(args.begin(), it)) {
-        val = *it;
-        std::cout << std::hex << "[TEMP DEBUG] Loading 0x" << val << " in reg 0x" << i << std::endl;
-        envp->regs[i] = val;
+        envp->regs[i] = *it;
         it++;
     }
 
+    // Optionally reverse stack arg order
+    remaining_args = {--it, args.end()};
+    if (rev_push) {
+        std::reverse(remaining_args.begin(), remaining_args.end());
+    }
+
     // Stack write/push remaining args
-    for (auto rev_it = --args.end(); rev_it >= it; rev_it--) {
-        val = *rev_it;
-        std::cout << std::hex << "[TEMP DEBUG] Pushing 0x" << val << " @ stack addr 0x" << sp << std::endl;
+    for (auto val : remaining_args) {
         err_ret = panda_virtual_memory_rw(env, sp, (uint8_t*)&val, sizeof(val), true);
         if (err_ret) {
             std::cerr << std::hex << "Failed to write 0x" << val << " @ stack addr 0x" << sp << std::endl;
         } else {
             sp += sizeof(val);
-            envp->regs[sp_reg_num] = sp;
+            //envp->regs[sp_reg_num] = sp; // Testing kernel prink() implies SP update isn't required?
         }
     }
 #endif
 }
 
+// Write file contents to guest virtual memory location
+void mm_file(CPUState *env, target_ulong dst, const char* fn) {
+
+    if (!(mm_fn_str && mm_dst)) { return; } // Pre-condition
+
+    std::ifstream data(fn, std::ios::binary);
+    std::vector<char> vec_buf(std::istreambuf_iterator<char>(data), {});
+    std::string s(fn);
+    int err_ret;
+
+    if (!data.good()) {
+        std::cerr << "Couldn't read " << s << std::endl;
+        return;
+    }
+
+    err_ret = panda_virtual_memory_rw(env, dst, (uint8_t*)vec_buf.data(), vec_buf.size(), true);
+    if (err_ret) {
+        std::cerr << std::hex << "Failed to write contents of " << s << " @ 0x" << dst << std::endl;
+    }
+}
+
 // Make a function call (arbitrary callsite, callee, params)
 bool call_function(CPUState *env, TranslationBlock *tb) {
 #ifdef TARGET_ARM
+
     CPUArchState *envp = (CPUArchState *)env->env_ptr;
     static char pre_call_state[offsetof(CPUArchState, end_reset_fields)];
+    static bool in_call = false;
+
     if (in_call) {
+
         if (tb->pc == when) {
+
             // print out R0 (return value)
-            std::cout << std::hex << "Called function 0x" << target_func << " returned 0x" << envp->regs[0] << std::endl;
+            std::cout << std::hex << std::setw(sizeof(target_ulong) * 2)
+                << "Called function 0x" << target_func << " returned 0x" << envp->regs[0] << std::endl;
+
             // restore pre-call CPU state
             memcpy(envp, pre_call_state, sizeof(pre_call_state));
             in_call = false;
+
+            return false;
+        } else {
             return false;
         }
-        else {
-            return false;
-        }
-    }
-    else {
+
+    } else {
+
         if (tb->pc == when) {
+
             in_call = true;
+
             // save pre-call CPU state
             memcpy(pre_call_state, envp, sizeof(pre_call_state));
-            // set up args
-            init_args(env, REG_ARG_CNT, SP_REG_NUM, func_args_vec);
+
+            // set up args (if any)
+            init_args(env, REG_ARG_CNT, SP_REG_NUM, rev_push, func_args_vec);
+            mm_file(env, mm_dst, mm_fn_str);
+
             // set LR = when
             envp->regs[14] = when;
+
             // set PC = target_func
             envp->regs[15] = target_func;
+
             return true;
-        }
-        else {
+        } else {
             return false;
         }
     }
@@ -165,13 +206,25 @@ bool init_plugin(void* self) {
 
     pcb.before_block_exec_invalidate_opt = call_function;
     panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC_INVALIDATE_OPT, pcb);
-
     panda_args = panda_get_args("callfunc");
+
+    // Required args
     when = panda_parse_ulong_req(panda_args, "when", "PC at which to call our function.");
     target_func = panda_parse_ulong_req(panda_args, "func", "Function to call.");
-    func_args_str = panda_parse_string_req(panda_args, "args", "Hexidecimal, dash delimited arguments for the function to call.");
 
-    args_to_vec(func_args_str, func_args_vec);
+    // Optional args
+    func_args_str = panda_parse_string_opt(panda_args, "args", nullptr, "Hexidecimal, dash delimited arguments for the function to call.");
+    rev_push = panda_parse_bool_opt(panda_args, "rev_push", "Push stack arguments in reverse order, if any.");
+    mm_fn_str = panda_parse_string_opt(panda_args, "mm_file", nullptr, "File to memory map.");
+    mm_dst = panda_parse_ulong_opt(panda_args, "mm_dst", 0, "Memory location to map file.");
+
+    if (func_args_str) {
+        args_to_vec(func_args_str, func_args_vec);
+    }
+
+    if ((!mm_fn_str) != (!mm_dst)) {
+        std::cerr << "Mapping a file in memory requires both \'mm_file\' and \'mm_dst\' args" << std::endl;
+    }
 
     return true;
 }


### PR DESCRIPTION
3 improvements to the callfunc plugin:

* Save/restore all ARM CPU state before/after the injected call
* Support arbitrary parameter count
* Support injection of arbitrary file into guest memory

Output from Example 1 in `USAGE.md` (slightly revised):

```
root@debian-armel:~# ls
Called function 0xc00bb0cc returned 0xc7970000
```

Output from Example 2 in `USAGE.md` (new):
```
root@debian-armel:~# ls
[  121.175748] Hello from kernel's printk! 1 2 3 4 5 6 7
```