### PR TITLE
Clear LLVM frames before reusing them

### DIFF
--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -1366,13 +1366,13 @@ void PandaTaintVisitor::visitCallInst(CallInst &I) {
     // of maximum frame size as can't calculate using PandaSlotTracker
     uint64_t clrBytes = MAXREGSIZE * (shad->num_vals);
     if (calledF) {
-        SubframePST.reset(new PandaSlotTracker(calledF));
-        SubframePST->initialize();
-        clrBytes = MAXREGSIZE * (SubframePST->getMaxSlot());
+        subframePST.reset(new PandaSlotTracker(calledF));
+        subframePST->initialize();
+        clrBytes = MAXREGSIZE * (subframePST->getMaxSlot());
     }
-    auto clr_dest = const_uint64(ctx, (shad->num_vals)*MAXREGSIZE);
-    auto clr_bytes = const_uint64(ctx, clrBytes);
-    vector<Value *> clearArgs { llvConst, clr_dest, clr_bytes };
+    Constant *clrDestC = const_uint64(ctx, (shad->num_vals)*MAXREGSIZE);
+    Constant *clrBytesC = const_uint64(ctx, clrBytes);
+    vector<Value *> clearArgs { llvConst, clrDestC, clrBytesC };
     inlineCallBefore(I, deleteF, clearArgs);
 
     // And now copy taint for the arguments into the new frame

--- a/panda/plugins/taint2/llvm_taint_lib.h
+++ b/panda/plugins/taint2/llvm_taint_lib.h
@@ -87,7 +87,7 @@ private:
     taint2_memlog *taint_memlog; // same.
 
     // for counting up slots used by called subroutines
-    std::unique_ptr<PandaSlotTracker> SubframePST;
+    std::unique_ptr<PandaSlotTracker> subframePST;
 
     Constant *constSlot(Value *value);
     Constant *constWeakSlot(Value *value);

--- a/panda/plugins/taint2/llvm_taint_lib.h
+++ b/panda/plugins/taint2/llvm_taint_lib.h
@@ -11,6 +11,9 @@
  * See the COPYING file in the top-level directory.
  *
 PANDAENDCOMMENT */
+//
+// Change Log:
+// 14-FEB-2019:  ensure LLVM frames cleared before they are reused
 
 #ifndef LLVM_TAINT_LIB_H
 #define LLVM_TAINT_LIB_H
@@ -82,6 +85,9 @@ private:
     std::unique_ptr<PandaSlotTracker> PST;
     ShadowState *shad; // no ownership. weak ptr.
     taint2_memlog *taint_memlog; // same.
+
+    // for counting up slots used by called subroutines
+    std::unique_ptr<PandaSlotTracker> SubframePST;
 
     Constant *constSlot(Value *value);
     Constant *constWeakSlot(Value *value);


### PR DESCRIPTION
The LLVM code generated by the taint2 plugin wasn't clearing the LLVM frames before using them.  This can result in spurious taint reports (when the old taint just happens to be in a destination that is assumed to be 0 and so isn't cleared), or in lost taint reports (when the old taint just happens to be the same value as the new taint being placed there, and so no change report is generated).
This occurred in the block prologues when the previous block did not execute taint_pop_frame (such as after calling a function that doesn't return), because taint_reset_frame was executed AFTER taint_delete on the frame (so the wrong frame was being cleared).
This occurs in the block bodies because there was no attempt to clear out the LLVM frame before taint_push_frame (except for the slots used for the arguments to the function, if they were untainted).
This fix also seems to fix the problem noted in issue #381 - at least it did for one example.  (I didn't look for them all.)