### PR TITLE
fix get_callers callstack ordering

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -393,7 +393,7 @@ Panda__CallStack *pandalog_callstack_create() {
     cs->n_addr = std::min((uint32_t)v.size(), (uint32_t)CALLSTACK_MAX_SIZE);
     cs->addr = (uint64_t *)malloc(cs->n_addr * sizeof(uint64_t));
 
-    for (uint32_t i=0; i<cs->n_addr; i++) { cs->addr[i] = v[cs->n_addr-1-i].pc; }
+    for (uint32_t i=0; i<cs->n_addr; i++) { cs->addr[i] = v[v.size()-1-i].pc; }
 
     return cs;
 }

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -416,7 +416,7 @@ uint32_t get_functions(target_ulong functions[], uint32_t n, CPUState* cpu) {
     std::vector<target_ulong> &v = function_stacks[get_stackid(env)];
 
     n = std::min((uint32_t)v.size(), n);
-    for (uint32_t i=0; i<n; i++) { functions[i] = v[n-1-i]; }
+    for (uint32_t i=0; i<n; i++) { functions[i] = v[v.size()-1-i]; }
     return n;
 }
 

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -374,7 +374,7 @@ uint32_t get_callers(target_ulong callers[], uint32_t n, CPUState* cpu) {
     std::vector<stack_entry> &v = callstacks[get_stackid(env)];
 
     n = std::min((uint32_t)v.size(), n);
-    for (uint32_t i=0; i<n; i++) { callers[i] = v[n-1-i].pc; }
+    for (uint32_t i=0; i<n; i++) { callers[i] = v[v.size()-1-i].pc; }
     return n;
 }
 


### PR DESCRIPTION
Guess **get_callers()** is intended to get callstack in reversed order?
According to the usage here:
https://github.com/panda-re/panda/blob/f2ba5a27880bebce47034c68d2f6d1f5eb1c2c32/panda/plugins/pri_dwarf/pri_dwarf.cpp#L1897