### PR TITLE
Callbacks and Plugin for MMIO Tracing

### DIFF
--- a/cputlb.c
+++ b/cputlb.c
@@ -811,6 +811,8 @@ static uint64_t io_readx(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
         /* replay= */ rr_input_8(&val),
         /* location= */ RR_CALLSITE_IO_READ_ALL);
 
+    panda_callbacks_after_mmio_read((CPUState*)env, physaddr, size, val);
+
     return val;
 }
 
@@ -829,7 +831,7 @@ static void io_writex(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
 
     cpu->mem_io_vaddr = addr;
     cpu->mem_io_pc = retaddr;
-    
+
     if (mr->name && !strcmp(mr->name, "watch")){
         memory_region_dispatch_write(mr, physaddr, val, size, iotlbentry->attrs);
         return;
@@ -845,6 +847,8 @@ static void io_writex(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
     } else {
         memory_region_dispatch_write(mr, physaddr, val, size, iotlbentry->attrs);
     }
+
+    panda_callbacks_after_mmio_write((CPUState*)env, physaddr, size, val);
 }
 
 /* Return true if ADDR is present in the victim tlb, and has been copied

--- a/cputlb.c
+++ b/cputlb.c
@@ -811,7 +811,7 @@ static uint64_t io_readx(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
         /* replay= */ rr_input_8(&val),
         /* location= */ RR_CALLSITE_IO_READ_ALL);
 
-    panda_callbacks_after_mmio_read((CPUState*)env, physaddr, size, val);
+    panda_callbacks_after_mmio_read(cpu, physaddr, size, val);
 
     return val;
 }
@@ -848,7 +848,7 @@ static void io_writex(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
         memory_region_dispatch_write(mr, physaddr, val, size, iotlbentry->attrs);
     }
 
-    panda_callbacks_after_mmio_write((CPUState*)env, physaddr, size, val);
+    panda_callbacks_after_mmio_write(cpu, physaddr, size, val);
 }
 
 /* Return true if ADDR is present in the victim tlb, and has been copied

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -80,8 +80,10 @@ system level.
 
 ## Quickstart
 
-To build PANDA, use `panda_install.bash`, which installs all the dependencies
-and builds PANDA. Don't worry; it won't actually install PANDA to a system
+To build PANDA and it's dependencies, use the install script for your OS,
+`panda/scripts/install_*.sh`. See
+[our main README](https://github.com/panda-re/panda#building) for more detail.
+Don't worry; it won't actually install PANDA to a system
 directory, despite the name. If you already have the dependencies you can just
 run `qemu/build.sh`. Once it's built, you will find the QEMU binaries in
 `i386-softmmu/qemu-system-i386`, `x86_64-softmmu/qemu-system-x86_64`, and
@@ -135,7 +137,7 @@ You can also attach a GDB client to replay, allowing you to debug the guest syst
 
 In order to use PANDA, you will need to understand at least some things about
 the underlying emulator, QEMU.  In truth, the more you know about QEMU the
-better, but that it is a complicated beast
+better, but that it is a complicated beast.
 
 ### QEMU's Monitor
 
@@ -146,8 +148,8 @@ details on what you do with the monitor, consult the QEMU manual.
 The most common way of interacting with the monitor is just via `stdio` in the
 terminal from which you originally entered the commandline that started up
 PANDA.  To get this to work, just add the following to the end of your
-commandline: `--monitor stdio`.  There are also ways to connect to the monitor
-over a telnet port etc -- refer to ethe QEMU manual for details.
+commandline: `-monitor stdio`.  There are also ways to connect to the monitor
+over a telnet port etc - refer to the QEMU manual for details.
 
 Here are few monitor functions we commonly need with PANDA.
 
@@ -204,8 +206,9 @@ Here is how some of the plugins fit into that emulation sequence.
   executes, but only exists if `INSN_TRANSLATE` callback returned true.
 
 NOTE. Although it is a little out of date, the explanation of emulation in
-Fabrice Bellard's original USENIX paper on QEMU is quite a good read.  "QEMU, a
-Fast and Portable Dynamic Translator", USENIX 2005 Annual Technical Conference.
+Fabrice Bellard's original USENIX paper on QEMU is quite a good read.  ["QEMU, a
+Fast and Portable Dynamic Translator"](https://www.usenix.org/legacy/publications/library/proceedings/usenix05/tech/freenix/full_papers/bellard/bellard.pdf),
+USENIX 2005 Annual Technical Conference.
 
 NOTE: QEMU has an additional cute optimization called `chaining` that links up
 cached translated blocks of code in such a way that they emulation can
@@ -222,7 +225,7 @@ that the *actual* type for an emulated CPU is made more specific in the
 For instance, in `qemu/target-i386/cpu.h`, we find it redefined as `CPUX86State`,
 where we also find convenient definitions such as `EAX`, `EBX`, and `EIP`.
 Other information of interest such as hidden flags, segment registers, `idt`,
-and `gdt` are all available via `env.
+and `gdt` are all available via `env`.
 
 ### Useful PANDA functions
 
@@ -247,7 +250,7 @@ makes changes to the way code is translated.  For example, by using
 **WARNING**: failing to flush the TB before turning on something that alters
 code translation may cause QEMU to crash! This is because QEMU's interrupt
 handling mechanism relies on translation being deterministic (see the
-`search_pc` stuff in translate-all.c for details).
+`search_pc` stuff in `translate-all.c` for details).
 ```C
 void panda_disable_tb_chaining(void);
 void panda_enable_tb_chaining(void);
@@ -335,7 +338,7 @@ address `code` of `size` bytes.
 ### Introduction
 
 PANDA supports whole system deterministic record and replay in whole
-system mode on the i386, x86_64, and arm targets. We hope to add more
+system mode on the `i386`, `x86_64`, and `arm` targets. We hope to add more
 soon; for example, partial SPARC support exists but is not yet reliable.
 
 ### Background
@@ -1033,7 +1036,7 @@ if (pandalog){
     std::unique_ptr<panda::LogEntry> ple (new panda::LogEntry());
     ple->mutable_llvmentry()->set_type(FunctionCode::FUNC_CODE_INST_CALL);
     ple->mutable_llvmentry()->set_address(addr);
-    
+
     globalLog.write_entry(std::move(ple));
 }
 ```
@@ -1183,7 +1186,7 @@ PANDA does not enable you to continue the system after a replay.
 * So, what can I do with PANDA?
 
 You can use custom or prebuilt plugins to analyze a replay at the full OS level. See [plugins](#plugins) for examples.
- 
+
 * How do I trim my replay to include the executed parts of interest?
 
 That's what the [`scissors`](../plugins/scissors/USAGE.md) plugin is for!

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -551,13 +551,15 @@ Registers a callback with PANDA. The `type` parameter specifies what type of
 callback, and `cb` is used for the callback itself (`panda_cb` is a union of all
 possible callback signatures).
 ```C
-PANDA_CB_BEFORE_BLOCK_TRANSLATE,    // Before translating each basic block
-PANDA_CB_AFTER_BLOCK_TRANSLATE,     // After translating each basic block
+PANDA_CB_BEFORE_BLOCK_TRANSLATE,// Before translating each basic block
+PANDA_CB_AFTER_BLOCK_TRANSLATE, // After translating each basic block
 PANDA_CB_BEFORE_BLOCK_EXEC_INVALIDATE_OPT,    // Before executing each basic block (with option to invalidate, may trigger retranslation)
-PANDA_CB_BEFORE_BLOCK_EXEC,         // Before executing each basic block
-PANDA_CB_AFTER_BLOCK_EXEC,          // After executing each basic block
-PANDA_CB_INSN_TRANSLATE,    // Before an instruction is translated
-PANDA_CB_INSN_EXEC,         // Before an instruction is executed
+PANDA_CB_BEFORE_BLOCK_EXEC,     // Before executing each basic block
+PANDA_CB_AFTER_BLOCK_EXEC,      // After executing each basic block
+PANDA_CB_INSN_TRANSLATE,        // Before an instruction is translated
+PANDA_CB_INSN_EXEC,             // Before an instruction is executed
+PANDA_CB_AFTER_INSN_TRANSLATE,  // After an insn is translated
+PANDA_CB_AFTER_INSN_EXEC,       // After an insn is executed
 PANDA_CB_VIRT_MEM_BEFORE_READ,  // Before read of virtual memory
 PANDA_CB_VIRT_MEM_BEFORE_WRITE, // Before write to virtual memory
 PANDA_CB_PHYS_MEM_BEFORE_READ,  // Before read of physical memory
@@ -566,21 +568,28 @@ PANDA_CB_VIRT_MEM_AFTER_READ,   // After read of virtual memory
 PANDA_CB_VIRT_MEM_AFTER_WRITE,  // After write to virtual memory
 PANDA_CB_PHYS_MEM_AFTER_READ,   // After read of physical memory
 PANDA_CB_PHYS_MEM_AFTER_WRITE,  // After write to physical memory
-PANDA_CB_HD_READ,           // Each HDD read
-PANDA_CB_HD_WRITE,          // Each HDD write
-PANDA_CB_GUEST_HYPERCALL,   // Hypercall from the guest (e.g. CPUID)
-PANDA_CB_MONITOR,           // Monitor callback
-PANDA_CB_CPU_RESTORE_STATE,  // In cpu_restore_state() (fault/exception)
-PANDA_CB_BEFORE_REPLAY_LOADVM,  // at start of replay, before loadvm
-PANDA_CB_ASID_CHANGED,          // after an ASID (address space identifier - aka PGD) write
-PANDA_CB_REPLAY_HD_TRANSFER,    // in replay, hd transfer
-PANDA_CB_REPLAY_NET_TRANSFER,   // in replay, transfers within network card (currently only E1000)
-PANDA_CB_REPLAY_BEFORE_CPU_PHYSICAL_MEM_RW_RAM,  // in replay, just before RAM case of cpu_physical_mem_rw
-PANDA_CB_REPLAY_AFTER_CPU_PHYSICAL_MEM_RW_RAM,   // in replay, just after RAM case of cpu_physical_mem_rw
-PANDA_CB_REPLAY_HANDLE_PACKET,    // in replay, packet in / out
-PANDA_CB_AFTER_CPU_EXEC_ENTER,    // just after cpu_exec_enter is called
-PANDA_CB_BEFORE_CPU_EXEC_EXIT,    // just before cpu_exec_exit is called
-PANDA_CB_AFTER_MACHINE_INIT,     // Right after the machine is initialized, before any code runs
+PANDA_CB_MMIO_AFTER_READ,       // After each MMIO read
+PANDA_CB_MMIO_AFTER_WRITE,      // After each MMIO write
+PANDA_CB_HD_READ,               // Each HDD read
+PANDA_CB_HD_WRITE,              // Each HDD write
+PANDA_CB_GUEST_HYPERCALL,       // Hypercall from the guest (e.g. CPUID)
+PANDA_CB_MONITOR,               // Monitor callback
+PANDA_CB_CPU_RESTORE_STATE,     // In cpu_restore_state() (fault/exception)
+PANDA_CB_BEFORE_REPLAY_LOADVM,  // At start of replay, before loadvm
+PANDA_CB_ASID_CHANGED,          // After an ASID (address space identifier - aka PGD) write
+PANDA_CB_REPLAY_HD_TRANSFER,    // In replay, hd transfer
+PANDA_CB_REPLAY_NET_TRANSFER,   // In replay, transfers within network card (currently only E1000)
+PANDA_CB_REPLAY_SERIAL_RECEIVE, // In replay, right after data is pushed into the serial RX FIFO
+PANDA_CB_REPLAY_SERIAL_READ,    // In replay, right after a value is read from the serial RX FIFO.
+PANDA_CB_REPLAY_SERIAL_SEND,    // In replay, right after data is popped from the serial TX FIFO
+PANDA_CB_REPLAY_SERIAL_WRITE,   // In replay, right after data is pushed into the serial TX FIFO.
+PANDA_CB_REPLAY_BEFORE_DMA,     // In replay, just before RAM case of cpu_physical_mem_rw
+PANDA_CB_REPLAY_AFTER_DMA,      // In replay, just after RAM case of cpu_physical_mem_rw
+PANDA_CB_REPLAY_HANDLE_PACKET,  // In replay, packet in / out
+PANDA_CB_AFTER_CPU_EXEC_ENTER,  // Just after cpu_exec_enter is called
+PANDA_CB_BEFORE_CPU_EXEC_EXIT,  // Just before cpu_exec_exit is called
+PANDA_CB_AFTER_MACHINE_INIT,    // Right after the machine is initialized, before any code runs
+PANDA_CB_TOP_LOOP,              // At top of loop that manages emulation.  good place to take a snapshot
 ```
 For more information on each callback, see the "Callbacks" section.
 ```C

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -71,7 +71,7 @@
 ## Overview
 
 PANDA (Platform for Architecture-Neutral Dynamic Analysis) is a whole-system
-dynamic analysis engine based on QEMU 1.0.1. Its strengths lie in rapid reverse
+dynamic analysis engine currently based on QEMU 2.9.1. Its strengths lie in rapid reverse
 engineering of software. PANDA includes a system for recording and replaying
 execution, a framework for running LLVM analysis on executing code, and an
 easily extensible plugin architecture. Together, these basic tools let you

--- a/panda/include/panda/callback_support.h
+++ b/panda/include/panda/callback_support.h
@@ -26,6 +26,10 @@ void panda_callbacks_before_mem_write(CPUState *env, target_ulong pc, target_ulo
                                       uint32_t data_size, uint64_t result, void *ram_ptr);
 void panda_callbacks_after_mem_write(CPUState *env, target_ulong pc, target_ulong addr,
                                      uint32_t data_size, uint64_t val, void *ram_ptr);
+// cputlb.c
+void panda_callbacks_after_mmio_read(CPUState *env, target_ulong addr, int size, uint64_t val);
+void panda_callbacks_after_mmio_write(CPUState *env, target_ulong addr, int size, uint64_t val);
+
 // target-i386/misc_helper.c
 void panda_callbacks_cpuid(CPUState *env);
 // translate-all.c

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -53,6 +53,9 @@ typedef enum panda_cb_type {
     PANDA_CB_PHYS_MEM_AFTER_READ,
     PANDA_CB_PHYS_MEM_AFTER_WRITE,
 
+    PANDA_CB_MMIO_AFTER_READ,       // After each MMIO read
+    PANDA_CB_MMIO_AFTER_WRITE,      // After each MMIO write
+
     PANDA_CB_HD_READ,              // Each HDD read
     PANDA_CB_HD_WRITE,             // Each HDD write
     PANDA_CB_GUEST_HYPERCALL,      // Hypercall from the guest (e.g. CPUID)
@@ -215,7 +218,7 @@ typedef union panda_cb {
         false otherwise
 
        Notes:
-        See `insn_translate`, callbacks are registered via PANDA_CB_AFTER_INSN_EXEC 
+        See `insn_translate`, callbacks are registered via PANDA_CB_AFTER_INSN_EXEC
     */
     bool (*after_insn_translate)(CPUState *env, target_ulong pc);
 
@@ -420,6 +423,36 @@ typedef union panda_cb {
         unused
     */
     int (*phys_mem_after_write)(CPUState *env, target_ulong pc, target_ulong addr, target_ulong size, void *buf);
+
+    /* Callback ID: PANDA_CB_MMIO_AFTER_READ
+
+       after_mmio_read: called after MMIO memory is read
+
+       Arguments:
+        CPUState *env: the current CPU state
+        target_ulong addr: the (physical) address being read from
+        target_ulong size: the size of the read
+        uin64_t val: the value being read
+
+       Return value:
+        unused
+    */
+    int (*after_mmio_read)(CPUState *env, target_ulong addr, int size, uint64_t val);
+
+    /* Callback ID: PANDA_CB_MMIO_AFTER_WRITE
+
+       after_mmio_write: called after MMIO memory is written to
+
+       Arguments:
+        CPUState *env: the current CPU state
+        target_ulong addr: the (physical) address being written to
+        target_ulong size: the size of the write
+        uin64_t val: the value being written
+
+       Return value:
+        unused
+    */
+    int (*after_mmio_write)(CPUState *env, target_ulong addr, int size, uint64_t val);
 
     /* Callback ID: PANDA_CB_CPU_RESTORE_STATE
 

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -30,61 +30,61 @@ extern "C" {
 #endif
 
 typedef enum panda_cb_type {
-    PANDA_CB_BEFORE_BLOCK_TRANSLATE, // Before translating each basic block
-    PANDA_CB_AFTER_BLOCK_TRANSLATE,  // After translating each basic block
+    PANDA_CB_BEFORE_BLOCK_TRANSLATE,    // Before translating each basic block
+    PANDA_CB_AFTER_BLOCK_TRANSLATE,     // After translating each basic block
     PANDA_CB_BEFORE_BLOCK_EXEC_INVALIDATE_OPT, // Before executing each basic
                                                // block (with option to
                                                // invalidate, may trigger
                                                // retranslation)
-    PANDA_CB_BEFORE_BLOCK_EXEC, // Before executing each basic block
-    PANDA_CB_AFTER_BLOCK_EXEC,  // After executing each basic block
-    PANDA_CB_INSN_TRANSLATE,    // Before an insn is translated
-    PANDA_CB_INSN_EXEC,         // Before an insn is executed
+    PANDA_CB_BEFORE_BLOCK_EXEC,     // Before executing each basic block
+    PANDA_CB_AFTER_BLOCK_EXEC,      // After executing each basic block
+    PANDA_CB_INSN_TRANSLATE,        // Before an insn is translated
+    PANDA_CB_INSN_EXEC,             // Before an insn is executed
     PANDA_CB_AFTER_INSN_TRANSLATE,  // After an insn is translated
-    PANDA_CB_AFTER_INSN_EXEC,   // After an insn is executed
+    PANDA_CB_AFTER_INSN_EXEC,       // After an insn is executed
 
-    PANDA_CB_VIRT_MEM_BEFORE_READ,
-    PANDA_CB_VIRT_MEM_BEFORE_WRITE,
-    PANDA_CB_PHYS_MEM_BEFORE_READ,
-    PANDA_CB_PHYS_MEM_BEFORE_WRITE,
+    PANDA_CB_VIRT_MEM_BEFORE_READ,  // Before read of virtual memory
+    PANDA_CB_VIRT_MEM_BEFORE_WRITE, // Before write of virtual memory
+    PANDA_CB_PHYS_MEM_BEFORE_READ,  // Before read of physical memory
+    PANDA_CB_PHYS_MEM_BEFORE_WRITE, // Before write of physical memory
 
-    PANDA_CB_VIRT_MEM_AFTER_READ,
-    PANDA_CB_VIRT_MEM_AFTER_WRITE,
-    PANDA_CB_PHYS_MEM_AFTER_READ,
-    PANDA_CB_PHYS_MEM_AFTER_WRITE,
+    PANDA_CB_VIRT_MEM_AFTER_READ,   // After read of virtual memory
+    PANDA_CB_VIRT_MEM_AFTER_WRITE,  // After write of virtual memory
+    PANDA_CB_PHYS_MEM_AFTER_READ,   // After read of physical memory
+    PANDA_CB_PHYS_MEM_AFTER_WRITE,  // After write of physical memory
 
     PANDA_CB_MMIO_AFTER_READ,       // After each MMIO read
     PANDA_CB_MMIO_AFTER_WRITE,      // After each MMIO write
 
-    PANDA_CB_HD_READ,              // Each HDD read
-    PANDA_CB_HD_WRITE,             // Each HDD write
-    PANDA_CB_GUEST_HYPERCALL,      // Hypercall from the guest (e.g. CPUID)
-    PANDA_CB_MONITOR,              // Monitor callback
-    PANDA_CB_CPU_RESTORE_STATE,    // In cpu_restore_state() (fault/exception)
-    PANDA_CB_BEFORE_REPLAY_LOADVM, // at start of replay, before loadvm
-    PANDA_CB_ASID_CHANGED, // When CPU asid (address space identifier) changes
-    PANDA_CB_REPLAY_HD_TRANSFER,    // in replay, hd transfer
-    PANDA_CB_REPLAY_NET_TRANSFER,   // in replay, transfers within network card
+    PANDA_CB_HD_READ,               // Each HDD read
+    PANDA_CB_HD_WRITE,              // Each HDD write
+    PANDA_CB_GUEST_HYPERCALL,       // Hypercall from the guest (e.g. CPUID)
+    PANDA_CB_MONITOR,               // Monitor callback
+    PANDA_CB_CPU_RESTORE_STATE,     // In cpu_restore_state() (fault/exception)
+    PANDA_CB_BEFORE_REPLAY_LOADVM,  // at start of replay, before loadvm
+    PANDA_CB_ASID_CHANGED,          // When CPU asid (address space identifier) changes
+    PANDA_CB_REPLAY_HD_TRANSFER,    // In replay, hd transfer
+    PANDA_CB_REPLAY_NET_TRANSFER,   // In replay, transfers within network card
                                     // (currently only E1000)
-    PANDA_CB_REPLAY_SERIAL_RECEIVE, // in replay, right after data is pushed
+    PANDA_CB_REPLAY_SERIAL_RECEIVE, // In replay, right after data is pushed
                                     // into the serial RX FIFO
-    PANDA_CB_REPLAY_SERIAL_READ,  // in replay, right after a value is read from
-                                  // the serial RX FIFO.
-    PANDA_CB_REPLAY_SERIAL_SEND,  // in replay, right after data is popped from
-                                  // the serial TX FIFO
-    PANDA_CB_REPLAY_SERIAL_WRITE, // in replay, right after data is pushed into
-                                  // the serial TX FIFO.
-    PANDA_CB_REPLAY_BEFORE_DMA,   // in replay, just before RAM case of
-                                  // cpu_physical_mem_rw
-    PANDA_CB_REPLAY_AFTER_DMA,    // in replay, just after RAM case of
-                                  // cpu_physical_mem_rw
-    PANDA_CB_REPLAY_HANDLE_PACKET, // in replay, packet in / out
-    PANDA_CB_AFTER_CPU_EXEC_ENTER, // just after cpu_exec_enter is called
-    PANDA_CB_BEFORE_CPU_EXEC_EXIT, // just before cpu_exec_exit is called
-    PANDA_CB_AFTER_MACHINE_INIT,   // Right after the machine is initialized,
-                                   // before any code runs
+    PANDA_CB_REPLAY_SERIAL_READ,    // In replay, right after a value is read from
+                                    // the serial RX FIFO.
+    PANDA_CB_REPLAY_SERIAL_SEND,    // In replay, right after data is popped from
+                                    // the serial TX FIFO
+    PANDA_CB_REPLAY_SERIAL_WRITE,   // In replay, right after data is pushed into
+                                    // the serial TX FIFO.
+    PANDA_CB_REPLAY_BEFORE_DMA,     // In replay, just before RAM case of
+                                    // cpu_physical_mem_rw
+    PANDA_CB_REPLAY_AFTER_DMA,      // In replay, just after RAM case of
+                                    // cpu_physical_mem_rw
+    PANDA_CB_REPLAY_HANDLE_PACKET,  // In replay, packet in / out
+    PANDA_CB_AFTER_CPU_EXEC_ENTER,  // Just after cpu_exec_enter is called
+    PANDA_CB_BEFORE_CPU_EXEC_EXIT,  // Just before cpu_exec_exit is called
+    PANDA_CB_AFTER_MACHINE_INIT,    // Right after the machine is initialized,
+                                    // before any code runs
 
-    PANDA_CB_TOP_LOOP, // at top of loop that manages emulation.  good place to
+    PANDA_CB_TOP_LOOP, // At top of loop that manages emulation.  good place to
                        // take a snapshot
 
     PANDA_CB_LAST

--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -24,3 +24,4 @@ net
 network
 filereadmon
 callfunc
+mmio_trace

--- a/panda/plugins/mmio_trace/Makefile
+++ b/panda/plugins/mmio_trace/Makefile
@@ -1,0 +1,9 @@
+# Don't forget to add your plugin to config.panda!
+
+# If you need custom CFLAGS or LIBS, set them up here
+# CFLAGS+=
+# LIBS+=
+
+# The main rule for your plugin. List all object-file dependencies.
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
+	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o

--- a/panda/plugins/mmio_trace/USAGE.md
+++ b/panda/plugins/mmio_trace/USAGE.md
@@ -1,0 +1,34 @@
+Plugin: mmio_trace
+===========
+
+Summary
+-------
+
+Log MMIO interactions within the guest.
+
+Arguments
+---------
+
+* out_log (string): File to log MMIO R/Ws to (optional)
+
+Dependencies
+------------
+
+None
+
+APIs and Callbacks
+------------------
+
+None
+
+Example
+-------
+
+Testing with the Debian ARM image used by PANDA's `run_debian.py --arch arm`, log all MMIO accesses to `mmio.log`:
+
+```
+arm-softmmu/qemu-system-arm -M versatilepb -kernel ~/.panda/vmlinuz-3.2.0-4-versatile \
+    -initrd ~/.panda/initrd.img-3.2.0-4-versatile -hda ~/.panda/arm_wheezy.qcow \
+    -serial stdio -loadvm root -display none \
+    -panda mmio_trace:out_log="mmio.log"
+```

--- a/panda/plugins/mmio_trace/USAGE.md
+++ b/panda/plugins/mmio_trace/USAGE.md
@@ -19,7 +19,13 @@ None
 APIs and Callbacks
 ------------------
 
-None
+As an alternative to the optional log file output in `uninit_plugin`, API for retrieval of sequential MMIO event tuples (`access_type`, `prog_counter`, `phys_addr`, `size`, `value`).
+
+
+```c
+// Get heap-allocated array of mmio_event_t structs and it's size
+mmio_event_t* get_mmio_events(int* arr_size_ret);
+```
 
 Example
 -------

--- a/panda/plugins/mmio_trace/mmio_trace.cpp
+++ b/panda/plugins/mmio_trace/mmio_trace.cpp
@@ -31,13 +31,13 @@ void uninit_plugin(void *);
 }
 
 int buffer_mmio_read(CPUState *env, target_ulong addr, int size, uint64_t val) {
-    mmio_event_t new_event{'W', addr, size, val};
+    mmio_event_t new_event{'W', env->panda_guest_pc, addr, size, val};
     mmio_events.push_back(new_event);
     return 0;
 }
 
 int buffer_mmio_write(CPUState *env, target_ulong addr, int size, uint64_t val) {
-    mmio_event_t new_event{'R', addr, size, val};
+    mmio_event_t new_event{'R', env->panda_guest_pc, addr, size, val};
     mmio_events.push_back(new_event);
     return 0;
 }
@@ -50,15 +50,16 @@ void flush_to_mmio_log_file() {
     std::ofstream out_log_file(fn_str);
     int hex_width = (sizeof(target_ulong) << 1);
 
-    for (auto const& entry : mmio_events) {
+    for (auto const& event : mmio_events) {
 
         // Write log line
         out_log_file
             << std::hex << std::setfill('0')
-            << entry.access_type << ":"                                     // R or W
-            << "0x" << std::setw(hex_width) << entry.phys_addr << ":"       // Physical Address
-            << "0x" << std::setw(hex_width) << entry.size << ":"            // Size
-            << "0x" << std::setw(hex_width) << entry.value                  // Value
+            << event.access_type << ":"                                     // R or W
+            << "0x" << std::setw(hex_width) << event.prog_counter << ":"    // Guest PC
+            << "0x" << std::setw(hex_width) << event.phys_addr << ":"       // Physical Address
+            << "0x" << std::setw(hex_width) << event.size << ":"            // Size
+            << "0x" << std::setw(hex_width) << event.value                  // Value
             << std::endl;
 
         // Validate write
@@ -72,11 +73,11 @@ void flush_to_mmio_log_file() {
 // C-compatible external API, caller responsible for freeing memory
 mmio_event_t* get_mmio_events(int* arr_size_ret) {
 
-    // Note: mmio_events might be added to asynchronously as this function is executing!
+    // Note: mmio_events might be added to asynchronously as this function is executing! (but is never subtracted from)
     //  - We cannot use mmio_events.end() as a race may cause heap overflow
     //  - Instead (mmio_events.begin() + num_structs) ensures we only copy the amount present when this func read size
 
-    // Copy vector data to newly allocated heap array
+    // Convert and copy vector data to newly allocated heap array
     int num_structs = mmio_events.size();
     mmio_event_t* heap_arr = new mmio_event_t[num_structs];
     std::copy(mmio_events.begin(), (mmio_events.begin() + num_structs), heap_arr);
@@ -95,6 +96,8 @@ bool init_plugin(void* self) {
     if (!fn_str) {
         std::cerr << "No \'out_log\' specified, MMIO R/W will not be logged!" << std::endl;
     }
+
+    panda_enable_precise_pc();
 
     pcb.after_mmio_read = buffer_mmio_read;
     panda_register_callback(self, PANDA_CB_MMIO_AFTER_READ, pcb);

--- a/panda/plugins/mmio_trace/mmio_trace.cpp
+++ b/panda/plugins/mmio_trace/mmio_trace.cpp
@@ -1,0 +1,94 @@
+/* PANDABEGINCOMMENT
+ *
+ *  Authors:
+ *  Tiemoko Ballo           N/A
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
+ *
+PANDAENDCOMMENT */
+// This needs to be defined before anything is included in order to get
+// the PRIx64 macro
+#define __STDC_FORMAT_MACROS
+
+#include "panda/plugin.h"
+#include "panda/common.h"
+#include <tuple>
+#include <vector>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+
+const char* fn_str;
+std::vector<std::tuple<char,target_ulong, int, uint64_t>> mmio_events;
+
+// These need to be extern "C" so that the ABI is compatible with
+// QEMU/PANDA, which is written in C
+extern "C" {
+
+bool init_plugin(void *);
+void uninit_plugin(void *);
+
+}
+
+int buffer_mmio_read(CPUState *env, target_ulong addr, int size, uint64_t val) {
+    mmio_events.push_back(std::make_tuple('R', addr, size, val));
+    return 0;
+}
+
+int buffer_mmio_write(CPUState *env, target_ulong addr, int size, uint64_t val) {
+    mmio_events.push_back(std::make_tuple('W', addr, size, val));
+    return 0;
+}
+
+// File I/O inside of a callback would be horridly slow, so we delay log flush until uninit_plugin()
+void flush_to_mmio_log_file() {
+
+    if (!fn_str) { return; }    // Pre-condition
+
+    std::ofstream out_log_file(fn_str);
+    int hex_width = (sizeof(target_ulong) << 1);
+
+    for (auto const& entry : mmio_events) {
+
+        // Write log line
+        out_log_file
+            << std::hex << std::setfill('0')
+            << std::get<0>(entry) << ":"                                    // R or W
+            << "0x" << std::setw(hex_width) << std::get<1>(entry) << ":"    // Physical Address
+            << "0x" << std::setw(hex_width) << std::get<2>(entry) << ":"    // Size
+            << "0x" << std::setw(hex_width) << std::get<3>(entry)           // Value
+            << std::endl;
+
+        // Validate write
+        if (!out_log_file.good()) {
+            std::cerr << "Error writing to " << fn_str << std::endl;
+            return;
+        }
+    }
+}
+
+bool init_plugin(void* self) {
+
+    panda_cb pcb;
+    panda_arg_list* panda_args = panda_get_args("mmio_trace");
+
+    fn_str = panda_parse_string_opt(panda_args, "out_log", nullptr, "File to write MMIO trace log to.");
+
+    // TODO: make logging to file optional and expose MMIO data via inter-plugin API
+    if (!fn_str) {
+        std::cerr << "No \'out_log\' specified, MMIO R/W will not be logged!" << std::endl;
+    }
+
+    pcb.after_mmio_read = buffer_mmio_read;
+    panda_register_callback(self, PANDA_CB_MMIO_AFTER_READ, pcb);
+
+    pcb.after_mmio_write = buffer_mmio_write;
+    panda_register_callback(self, PANDA_CB_MMIO_AFTER_WRITE, pcb);
+
+    return true;
+}
+
+void uninit_plugin(void *self) {
+    flush_to_mmio_log_file();
+}

--- a/panda/plugins/mmio_trace/mmio_trace.h
+++ b/panda/plugins/mmio_trace/mmio_trace.h
@@ -1,0 +1,10 @@
+#include "panda/plugin.h"
+#include "panda/common.h"
+
+// Struct instead of std::tuple for C-compatible API
+typedef struct mmio_event_t {
+    char access_type;
+    target_ulong phys_addr;
+    int size;
+    uint64_t value;
+} mmio_event_t;

--- a/panda/plugins/mmio_trace/mmio_trace.h
+++ b/panda/plugins/mmio_trace/mmio_trace.h
@@ -4,6 +4,7 @@
 // Struct instead of std::tuple for C-compatible API
 typedef struct mmio_event_t {
     char access_type;
+    uint64_t prog_counter;
     target_ulong phys_addr;
     int size;
     uint64_t value;

--- a/panda/plugins/mmio_trace/mmio_trace_int.h
+++ b/panda/plugins/mmio_trace/mmio_trace_int.h
@@ -1,0 +1,3 @@
+typedef void mmio_event_t;
+
+#include "mmio_trace_int_fns.h"

--- a/panda/plugins/mmio_trace/mmio_trace_int_fns.h
+++ b/panda/plugins/mmio_trace/mmio_trace_int_fns.h
@@ -1,0 +1,6 @@
+#ifndef __MMIO_TRACE_INT_FNS_H__
+#define __MMIO_TRACE_INT_FNS_H__
+
+mmio_event_t* get_mmio_events(int* arr_size_ret);
+
+#endif // __MMIO_TRACE_INT_FNS_H__

--- a/panda/plugins/mmio_trace/mmio_trace_int_fns.h
+++ b/panda/plugins/mmio_trace/mmio_trace_int_fns.h
@@ -1,6 +1,7 @@
 #ifndef __MMIO_TRACE_INT_FNS_H__
 #define __MMIO_TRACE_INT_FNS_H__
 
+// Get heap-allocated array of mmio_event_t structs and it's size
 mmio_event_t* get_mmio_events(int* arr_size_ret);
 
 #endif // __MMIO_TRACE_INT_FNS_H__

--- a/panda/src/callback_support.c
+++ b/panda/src/callback_support.c
@@ -248,6 +248,24 @@ void panda_callbacks_after_mem_write(CPUState *env, target_ulong pc,
     }
 }
 
+// These are used in cputlb.c
+void panda_callbacks_after_mmio_read(CPUState *env, target_ulong addr, int size, uint64_t val) {
+
+    panda_cb_list *plist;
+    for(plist = panda_cbs[PANDA_CB_MMIO_AFTER_READ]; plist != NULL;
+        plist = panda_cb_list_next(plist)) {
+        plist->entry.after_mmio_read(env, addr, size, val);
+    }
+}
+
+void panda_callbacks_after_mmio_write(CPUState *env, target_ulong addr, int size, uint64_t val) {
+
+    panda_cb_list *plist;
+    for(plist = panda_cbs[PANDA_CB_MMIO_AFTER_WRITE]; plist != NULL;
+        plist = panda_cb_list_next(plist)) {
+        plist->entry.after_mmio_write(env, addr, size, val);
+    }
+}
 
 // vl.c
 void panda_callbacks_after_machine_init(void) {


### PR DESCRIPTION
In this PR:

* Two new callbacks: `PANDA_CB_MMIO_AFTER_READ` and `PANDA_CB_MMIO_AFTER_WRITE`
* New plugin `mmio_trace` to log MMIO events (to file or retrieve via API)
* Minor updates to `manual.md`

Excerpt from `mmio.log` (format: `access_type:guest_pc:phys_addr:size:value`), from the [usage example](https://github.com/tnballo/panda/blob/mmio_trace/panda/plugins/mmio_trace/USAGE.md#example):


```
....
W:0xc01d9578:0x00000024:0x00000004:0xf8fc77e8
W:0xc001f540:0x0000005c:0x00000004:0xac048e2d
R:0xc001c850:0x00000010:0x00000004:0x00000010
W:0xc0012074:0x00000000:0x00000004:0x00000000
W:0xc001f540:0x0000005c:0x00000004:0xac054dfc
R:0xc00123f8:0x07fffff0:0x00000004:0xb6f0f6d0
W:0xc001f540:0x0000005c:0x00000004:0xac064334
W:0xc001f540:0x0000005c:0x00000004:0xac071a0c
R:0xc00123f8:0x07fffff0:0x00000004:0x00000000
W:0xc001f540:0x0000005c:0x00000004:0xac073518
R:0xc00123f8:0x07fffff0:0x00000004:0xb6f0f6d0
W:0xc0012238:0x00000000:0x00000004:0x00000010
R:0xc001c834:0x00000014:0x00000004:0x00000010
R:0xc001c814:0x00000014:0x00000004:0x00000010
R:0xc001c818:0x0000001c:0x00000004:0x00000010
R:0xc001cb54:0x0000000c:0x00000004:0x00000001
W:0xc01d9578:0x00000024:0x00000004:0xf8fc5103
W:0xc001f540:0x0000005c:0x00000004:0xac08338b
....
```