### PR TITLE
fix to the register frame base value at function entry

### DIFF
--- a/panda/plugins/pri_dwarf/pri_dwarf.cpp
+++ b/panda/plugins/pri_dwarf/pri_dwarf.cpp
@@ -1860,6 +1860,7 @@ target_ulong get_cur_fp(CPUState *cpu, target_ulong pc){
         printf("loc_cnt: Could not properly determine fp\n");
         return -1;
     }
+    CPUArchState *env = (CPUArchState*)cpu->env_ptr;
     target_ulong fp_loc;
     int i;
     for (i = 0; i < loc_cnt; i++){
@@ -1869,7 +1870,7 @@ target_ulong get_cur_fp(CPUState *cpu, target_ulong pc){
             switch (loc_type){
                 case LocReg:
                     //printf(" VAR %s in REG %d\n", var_name.c_str(), var_loc);
-                    return 0;
+                    return env->regs[fp_loc];
                 case LocMem:
                     return fp_loc;
                 case LocConst:

--- a/panda/plugins/pri_dwarf/pri_dwarf.cpp
+++ b/panda/plugins/pri_dwarf/pri_dwarf.cpp
@@ -1860,7 +1860,6 @@ target_ulong get_cur_fp(CPUState *cpu, target_ulong pc){
         printf("loc_cnt: Could not properly determine fp\n");
         return -1;
     }
-    CPUArchState *env = (CPUArchState*)cpu->env_ptr;
     target_ulong fp_loc;
     int i;
     for (i = 0; i < loc_cnt; i++){
@@ -1870,7 +1869,7 @@ target_ulong get_cur_fp(CPUState *cpu, target_ulong pc){
             switch (loc_type){
                 case LocReg:
                     //printf(" VAR %s in REG %d\n", var_name.c_str(), var_loc);
-                    return env->regs[fp_loc];
+                    return 0;
                 case LocMem:
                     return fp_loc;
                 case LocConst:

--- a/panda/plugins/pri_dwarf/pri_dwarf_int_fns.h
+++ b/panda/plugins/pri_dwarf/pri_dwarf_int_fns.h
@@ -9,5 +9,7 @@ void dwarf_type_iter (CPUState *env, target_ulong base_addr, LocType loc_t, Dwar
 // to create this type of function for a custom var data type
 const char *dwarf_type_to_string(DwarfVarType *var_ty);
 
+target_ulong get_cur_fp(CPUState *env, target_ulong pc);
+
 #endif
 /* vim:set tabstop=4 softabstop=4 noexpandtab */


### PR DESCRIPTION
So here's the issue. At the entry of a function, there are code like 
```
push ebp;
mov ebp, esp;
...
```
When parsing the DWARF info in `pri_dwarf`, if the `DW_AT_frame_base` is the `ebp` register, we could actually access the frame base of the caller function instead of the current function.

This is a temporary fix that return 0 for all the frame base if it's a register. Haven't come up with better ways to deal with it...