### PR TITLE
ida taint undo

### DIFF
--- a/panda/plugins/ida_taint2/USAGE.md
+++ b/panda/plugins/ida_taint2/USAGE.md
@@ -27,6 +27,15 @@ address. For 32-bit Linux and Windows guests, this script should just work
 (tested with IDA 7.1). The base address and/or segment may need to be adjusted
 manually for DOS operating systems.
 
+To undo the changes made by the ida_taint2.py script, an undo_ida_taint2.py
+script is included. However, because IDA doesn't have a change tracking
+or undo capability, this undo script makes a best attempt at removing changes
+made by ida_taint2.py. If you've changed comments or colors after running
+the ida_taint2.py script, the undo script may undo some of your changes.
+This is unfortunately unpredictable. However, in each script, an IDA database
+snapshot is made before actually modifying anything. In the worst case scenario
+you may have to restore a snapshot.
+
 Arguments
 ---------
 filename - The name of the file to output (default: ida_taint2.csv).

--- a/panda/plugins/ida_taint2/ida_taint2.py
+++ b/panda/plugins/ida_taint2/ida_taint2.py
@@ -3,6 +3,10 @@ IDAPython Script to ingest an ida_taint2 report.
 """
 
 import csv
+import datetime
+
+import ida_kernwin
+import ida_loader
 
 from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
@@ -83,6 +87,10 @@ def main():
     selected_pid = ProcessSelectDialog.selectProcess(processes)
     if not selected_pid:
         return
+
+    snapshot = ida_loader.snapshot_t()
+    snapshot.desc = "Before ida_taint2.py @ %s" % (datetime.datetime.now())
+    ida_kernwin.take_database_snapshot(snapshot)
 
     input_file = open(filename, "r")
     reader = csv.reader(input_file)

--- a/panda/plugins/ida_taint2/undo_ida_taint2.py
+++ b/panda/plugins/ida_taint2/undo_ida_taint2.py
@@ -1,0 +1,39 @@
+"""
+IDAPython Script to attempt undo of ida_taint2 changes.
+"""
+
+import datetime
+import re
+
+import ida_loader
+import ida_kernwin
+
+from PyQt5.QtWidgets import *
+
+UNDO_COLOR = 0xFFFFFF
+label_regex = re.compile(r"(,\s)*taint labels = \[([0-9]+,*\s*)+\]")
+
+def main():
+    button_result = QMessageBox.warning(None, "Warning", "This script will attempt to undo ida_taint2.py changes. It is not perfect and will unpredictably change comments if you've made changes to comments since running ida_taint2.py. Do you want to continue?", QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+    if button_result == QMessageBox.No:
+        return
+
+    snapshot = ida_loader.snapshot_t()
+    snapshot.desc = "Before undo_ida_taint2.py @ %s" % (datetime.datetime.now())
+    ida_kernwin.take_database_snapshot(snapshot)
+
+    for segea in Segments():
+        for funcea in Functions(segea, SegEnd(segea)):
+            function_name = GetFunctionName(funcea)
+            if function_name.startswith("TAINTED_"):
+                MakeName(funcea, function_name.replace("TAINTED_", ""))
+                SetColor(funcea, CIC_FUNC, UNDO_COLOR)
+                for (startea, endea) in Chunks(funcea):
+                    for head in Heads(startea, endea):
+                        comment = str(Comment(head))
+                        print(comment)
+                        if "taint labels" in comment:
+                            SetColor(head, CIC_ITEM, UNDO_COLOR)
+                            MakeComm(head, label_regex.sub("", comment))
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A couple more usability changes for ida taint:

- Add undo script that scans for changes that ida taint may have made and remove them. This won't work if you've changed the comments after the fact but.

- Another solution is to just make use of IDA database snapshots. ida_taint2.py now adds a snapshot before it makes any annotations and undo_ida_taint2.py now takes a snapshot before making any changes.