### PR TITLE
add linux version info to kernelinfo module

### DIFF
--- a/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo.c
+++ b/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo.c
@@ -153,6 +153,9 @@ int init_module(void)
 
 	printk(KERN_INFO "--KERNELINFO-BEGIN--\n");
 	printk(KERN_INFO "name = %s|%s|%s\n", utsname()->release, utsname()->version, utsname()->machine);
+	printk(KERN_INFO "version.a = %d\n", LINUX_VERSION_CODE >> 16);
+	printk(KERN_INFO "version.b = %d\n", (LINUX_VERSION_CODE >> 8) & 0xFF);
+	printk(KERN_INFO "version.c = %d\n", LINUX_VERSION_CODE & 0xFF);
 	printk(KERN_INFO "task.init_addr = %llu\n", (u64)(uintptr_t)(task_struct__p));
 	printk(KERN_INFO "#task.init_addr = 0x%08llX\n", (u64)(uintptr_t)task_struct__p);
 


### PR DESCRIPTION
When I added Linux 2.4.x support, I forgot to add the version output to the `kernelinfo` module.