### PR TITLE
use weak slots in port output propagation rules

### DIFF
--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -1326,7 +1326,7 @@ void PandaTaintVisitor::visitCallInst(CallInst &I) {
             vector<Value *> copy_args{grvConst,
                                       const_uint64(ctx, R_EAX),
                                       llvConst,
-                                      constSlot(I.getArgOperand(2)),
+                                      constWeakSlot(I.getArgOperand(2)),
                                       const_uint64(ctx, 1),
                                       constInstr(&I)};
             auto call_inst = CallInst::Create(copyF, copy_args);


### PR DESCRIPTION
This fixes an assertion error in the Taint 2 plugin. Note, this only occurs if you're using a debug build of LLVM and in certain guests.

I'm not sure about the difference between a {{constSlot}} and a {{constWeakSlot}}, but the fix does work without breaking any of our existing tests.