### PR TITLE
Bugfix: stop vm in rr_do_end_replay()

### DIFF
--- a/panda/src/rr/rr_log.c
+++ b/panda/src/rr/rr_log.c
@@ -1648,6 +1648,7 @@ void rr_do_end_replay(int is_error)
         panda_cleanup();
         abort();
     } else {
+        vm_stop(RUN_STATE_PAUSED);
         qemu_system_shutdown_request();
     }
 #endif // CONFIG_SOFTMMU


### PR DESCRIPTION
This PR is a minor bugfix for the rr_do_end_replay() function: it forces to stop the vm before issuing the qemu_system_shutdown_request.

Without this additional stop, the VM would continue to run for a couple of cycles, which under normal circumstances doesn't lead to any problems; however, for the panda-fork of avatar², this bug is the root-cause for other problems.

I assume that it is desired behavior that the guest inside Qemu doesn't continue execution after the replay is finished. Hence, this PR to mainline the change.