### PR TITLE
get_syscall_retval API call

### DIFF
--- a/panda/plugins/syscalls2/USAGE.md
+++ b/panda/plugins/syscalls2/USAGE.md
@@ -95,6 +95,16 @@ Description: Called whenever any system call returns in the guest. The `call` pa
 ### API calls
 Finally the plugin provides two API calls:
 
+Name: **get_syscall_retval**
+
+Signature:
+
+```C
+target_long get_syscall_retval(CPUState *cpu)
+```
+
+Description: Retrieves the return value of a system call, abstracting away architecture-specific details. The call must be made in the appropriate context, so that the return value is still available (e.g. in a `on_all_sys_return` callback).
+
 Name: **get_syscall_info**
 
 Signature:

--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -44,6 +44,9 @@ bool init_plugin(void *);
 void uninit_plugin(void *);
 void registerExecPreCallback(void (*callback)(CPUState*, target_ulong));
 
+// API calls
+#include "syscalls2_int_fns.h"
+
 // PPP code
 #include "syscalls_ext_typedefs.h"
 #include "generated/syscall_ppp_boilerplate_enter.cpp"
@@ -634,6 +637,33 @@ bool translate_callback(CPUState* cpu, target_ulong pc){
 }
 
 
+/* ### API calls ######################################################## */
+/*!
+ * @brief Returns a pointer to the meta-information for the specified syscall.
+ */
+target_long get_syscall_retval(CPUState *cpu) {
+    return syscalls_profile->get_return_val(cpu);
+}
+
+/*!
+ * @brief Returns a pointer to the meta-information for the specified syscall.
+ */
+const syscall_info_t *get_syscall_info(uint32_t callno) {
+    if (syscall_info != NULL) {
+        return &syscall_info[callno];
+    } else {
+        return NULL;
+    }
+}
+
+/*!
+ * @brief Returns a pointer to the array containing the meta-information
+ * for all syscalls.
+ */
+const syscall_meta_t *get_syscall_meta(void) { return syscall_meta; }
+
+
+/* ### Plugin bootstrapping ############################################# */
 bool init_plugin(void *self) {
 // Don't bother if we're not on a supported target
 #if defined(TARGET_I386) || defined(TARGET_ARM)
@@ -715,9 +745,8 @@ bool init_plugin(void *self) {
     return true;
 }
 
-
 void uninit_plugin(void *self) {
-    (void) self;
+    //(void) self;
 #ifdef DEBUG
     std::cout << PANDA_MSG "DEBUG syscall count per asid:";
     for(const auto &asid_count : syscallCounter){
@@ -730,3 +759,4 @@ void uninit_plugin(void *self) {
 #endif
 }
 
+/* vim:set tabstop=4 softtabstop=4 expandtab: */

--- a/panda/plugins/syscalls2/syscalls2_info.c
+++ b/panda/plugins/syscalls2/syscalls2_info.c
@@ -66,17 +66,4 @@ int load_syscall_info(void) {
     return 0;
 }
 
-
-const syscall_info_t *get_syscall_info(uint32_t callno) {
-    if (syscall_info != NULL) {
-        return &syscall_info[callno];
-    }
-    else {
-        return NULL;
-    }
-}
-
-
-const syscall_meta_t *get_syscall_meta(void) {
-    return syscall_meta;
-}
+/* vim:set tabstop=4 softtabstop=4 expandtab: */

--- a/panda/plugins/syscalls2/syscalls2_int.h
+++ b/panda/plugins/syscalls2/syscalls2_int.h
@@ -4,6 +4,8 @@
 typedef void syscall_info_t;
 typedef void syscall_meta_t;
 typedef void uint32_t;
+typedef void target_long;
+typedef void CPUState;
 
 #include "syscalls2_int_fns.h"
 

--- a/panda/plugins/syscalls2/syscalls2_int_fns.h
+++ b/panda/plugins/syscalls2/syscalls2_int_fns.h
@@ -1,5 +1,4 @@
-#ifndef SYSCALLS2_INT_FNS_H
-#define SYSCALLS2_INT_FNS_H
+#pragma once
 
 // returns information about the syscall with the specified number
 const syscall_info_t *get_syscall_info(uint32_t callno);
@@ -7,4 +6,6 @@ const syscall_info_t *get_syscall_info(uint32_t callno);
 // returns meta-information about the syscalls of the guest os
 const syscall_meta_t *get_syscall_meta(void);
 
-#endif
+// returns the system call return value, hiding arch-specific details
+target_long get_syscall_retval(CPUState *cpu);
+


### PR DESCRIPTION
`syscalls2` has implemented a profiles-based solution for retrieving system call return values. However, this was not exposed to other plugins, which means that each plugin had to reimplement something similar.