### PR TITLE
Enhanced Callstack Segregation Options

### DIFF
--- a/panda/plugins/callstack_instr/Makefile
+++ b/panda/plugins/callstack_instr/Makefile
@@ -1,8 +1,6 @@
 # Don't forget to add your plugin to config.panda!
 
 # If you need custom CFLAGS or LIBS, set them up here
-# -DUSE_STACK_HEURISTIC tries to detect thread switches by sudden
-# jumps in the stack pointer
 LIBS+=-lcapstone
 
 # The main rule for your plugin. List all object-file dependencies.

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -14,7 +14,7 @@ Arguments
 ---------
 
 * `verbose`: boolean, defaults to false. Whether to output debugging messages.
-* `stack_type`: string, defaults to `asid`. Sets how diffferent stacks are to be distinguished from each other (by `asid`, `heuristic` or `threaded`).
+* `stack_type`: string, defaults to `threaded` if `-os` is specified, and `asid` otherwise. Sets how different stacks are to be distinguished from each other (by `asid`, `heuristic` or `threaded`).
 
 Dependencies
 ------------

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -63,10 +63,6 @@ uint32_t get_functions(target_ulong *functions, uint32_t n, CPUState *env);
 // This isn't quite the right place for it, but since it's awkward
 // right now to have a "utilities" library, this will have to do
 void get_prog_point(CPUState *env, prog_point *p);
-
-// Get the stack ID, as a string, from the given program point. The returned
-// object must be freed with g_free when it is no longer needed.
-char *get_stackid_string(prog_poing p);
 ```
 
 There are also functions available for getting callstack information in [pandalog format](docs/pandalog.md):
@@ -77,6 +73,14 @@ Panda__CallStack *pandalog_callstack_create(void);
 
 // Free a Panda__CallStack struct
 void pandalog_callstack_free(Panda__CallStack *cs);
+```
+
+In addition to the plugin-plugin API noted above, there is one additional function provided in `prog_point.h` for formating a `prog_point` as a string.  It can be called even after the `callstack_instr` plugin has been unloaded:
+
+```C
+// Get the stack ID, as a string, from the given program point. The returned
+// object must be freed with g_free when it is no longer needed.
+char *get_stackid_string(prog_point p);
 ```
 
 Example

--- a/panda/plugins/callstack_instr/USAGE.md
+++ b/panda/plugins/callstack_instr/USAGE.md
@@ -6,17 +6,20 @@ Summary
 
 The `callstack_instr` plugin keeps track of function calls and returns as they occur in the guest. These are tracked using a shadow call stack, so it should be more reliable than trying to do a stack walk. The plugin makes this information available through an exposed plugin-plugin interaction API, and offers callbacks to let other plugins be notified.
 
+By default, the callstack entries are segregated based on what address space ID (`asid`) they occur in.  Although this algorithm is the most general, it has been known to categorize entries incorrectly when the recording has multiple threads.  The `stack_type` argument can be used to change to another segregation method.  The `heuristic` method tries to detect thread switches by sudden jumps in the stack pointer.  Like the `asid` technique, it can be used with any guest operating system (OS) and architecture, and it is more accurate, but it also runs more slowly than the other two techniques.  The `threaded` technique uses OS introspection (OSI) support to get the process ID and thread ID and uses them to distinguish between stacks.  It is more accurate than the `asid` and `heuristic` techniques, but requires OSI support for the guest OS, which is not always available.
+
 `callstack_instr` currently requires `Capstone` to be installed so it can disassemble instructions and identify `call`s and `ret`s.
 
 Arguments
 ---------
 
 * `verbose`: boolean, defaults to false. Whether to output debugging messages.
+* `stack_type`: string, defaults to `asid`. Sets how diffferent stacks are to be distinguished from each other (by `asid`, `heuristic` or `threaded`).
 
 Dependencies
 ------------
 
-None.
+If the `stack_type` is `threaded`, then `callstack_instr` depends upon an introspection provider for the `osi` plugin.
 
 APIs and Callbacks
 ------------------
@@ -46,20 +49,24 @@ Description: Called every time a function call returns in guest (e.g., at the `r
 `callstack_instr` also provides the following API functions that can be called from other plugins:
 
 ```C
-// Get up to n callers from the given address space at this moment
+// Get up to n callers from the given stack in use at this moment
 // Callers are returned in callers[], most recent first
 // Return value is the number of callers actually retrieved
 uint32_t get_callers(target_ulong *callers, uint32_t n, CPUState *env);
 
-// Get up to n functions from the given address space at this moment
+// Get up to n functions from the given stack in use at this moment
 // Functions are returned in functions[], most recent first
 // Return value is the number of callers actually retrieved
 uint32_t get_functions(target_ulong *functions, uint32_t n, CPUState *env);
 
-// Get the current program point: (Caller, PC, ASID)
+// Get the current program point: (Caller, PC, stack ID)
 // This isn't quite the right place for it, but since it's awkward
 // right now to have a "utilities" library, this will have to do
 void get_prog_point(CPUState *env, prog_point *p);
+
+// Get the stack ID, as a string, from the given program point. The returned
+// object must be freed with g_free when it is no longer needed.
+char *get_stackid_string(prog_poing p);
 ```
 
 There are also functions available for getting callstack information in [pandalog format](docs/pandalog.md):

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -239,25 +239,6 @@ static stackid get_stackid(CPUArchState* env) {
     // end of function get_stackid
 }
 
-// Get stack ID from the program point as a string
-// Caller must use g_free to free the returned object when done with it
-char *get_stackid_string(prog_point p) {
-    char *sid_string;
-    if (STACK_HEURISTIC == p.stackKind) {
-        sid_string = g_strdup_printf("(asid=0x" TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx ")",
-                p.sidFirst, p.sidSecond);
-    } else if (STACK_THREADED == p.stackKind) {
-        sid_string = g_strdup_printf("(processID=0x" TARGET_FMT_lx ", threadID=0x" TARGET_FMT_lx ")",
-                p.sidFirst, p.sidSecond);
-    } else {
-        // STACK_ASID
-        sid_string = g_strdup_printf("(asid=0x" TARGET_FMT_lx ")", p.sidFirst);
-    }
-
-    assert(sid_string);
-    return sid_string;
-}
-
 instr_type disas_block(CPUArchState* env, target_ulong pc, int size) {
     unsigned char *buf = (unsigned char *) malloc(size);
     int err = panda_virtual_memory_rw(ENV_GET_CPU(env), pc, buf, size, 0);

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -16,6 +16,7 @@ PANDAENDCOMMENT */
 // 2018-APR-13   watch for x86 processor mode changing in i386 build
 // 2019-JAN-29   do not put an entry in the callstack if the block was stopped
 //               before the call at the end was made
+// 2019-MAY-21   add (more accurate) stack segregation option (threaded)
 #define __STDC_FORMAT_MACROS
 
 #include <cstdio>
@@ -38,6 +39,13 @@ PANDAENDCOMMENT */
 #include "panda/plugin.h"
 #include "panda/plugin_plugin.h"
 
+// needed for the threaded stack_type
+#include "osi/osi_types.h"
+#include "osi/osi_ext.h"
+#include "wintrospection/wintrospection.h"
+#include "wintrospection/wintrospection_ext.h"
+#include "osi_linux/osi_linux_ext.h"
+
 #include "callstack_instr.h"
 
 extern "C" {
@@ -59,6 +67,8 @@ PPP_PROT_REG_CB(on_ret);
 
 PPP_CB_BOILERPLATE(on_call);
 PPP_CB_BOILERPLATE(on_ret);
+
+stack_type stack_segregation = STACK_ASID;
 
 // callstack_instr arguments
 static bool verbose = false;
@@ -86,18 +96,17 @@ csh cs_handle_32;
 csh cs_handle_64;
 
 // Track the different stacks we have seen to handle multiple threads
-// within a single process.
+// within a single process.  Used by STACK_HEURISTIC
 std::map<target_ulong,std::set<target_ulong>> stacks_seen;
 
-// Use a typedef here so we can switch between the stack heuristic and
-// the original code easily
-#ifdef USE_STACK_HEURISTIC
+// For STACK_ASID, the first entry of the pair is the ASID, and the second is 0
+// For STACK_HEURISTIC, the first entry is the ASID and the second is the SP
+// For STACK_THREADED, the first entry is the process ID and the second is the thread ID
 typedef std::pair<target_ulong,target_ulong> stackid;
+
+// STACK_HEURISTIC also needs to cache the SP and ASID
 target_ulong cached_sp = 0;
 target_ulong cached_asid = 0;
-#else
-typedef target_ulong stackid;
-#endif
 
 // stackid -> shadow stack
 std::map<stackid, std::vector<stack_entry>> callstacks;
@@ -113,13 +122,17 @@ int last_ret_size = 0;
 void verbose_log(const char *msg, TranslationBlock *tb, stackid curStackid,
         bool logReturn) {
     if (verbose) {
-        printf("%s:  asid=0x", msg);
-#ifdef USE_STACK_HEURISTIC
-        printf(TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx, curStackid.first,
-                curStackid.second);
-#else
-        printf(TARGET_FMT_lx, curStackid);
-#endif
+        printf("%s:  ", msg);
+        if (STACK_HEURISTIC== stack_segregation) {
+            printf("asid=0x" TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx,
+                curStackid.first, curStackid.second);
+        } else if (STACK_THREADED == stack_segregation) {
+            printf("processID=0x" TARGET_FMT_lx ", threadID=0x" TARGET_FMT_lx,
+                    curStackid.first, curStackid.second);
+        } else {
+            // STACK_ASID
+            printf("asid=0x" TARGET_FMT_lx, curStackid.first);
+        }
         printf(", block pc=0x" TARGET_FMT_lx, tb->pc);
         if (logReturn) {
             printf(", returns to 0x" TARGET_FMT_lx, (tb->pc+tb->size));
@@ -150,54 +163,87 @@ static inline target_ulong get_stack_pointer(CPUArchState* env) {
 }
 
 static stackid get_stackid(CPUArchState* env) {
-#ifdef USE_STACK_HEURISTIC
-    target_ulong asid;
+    if (STACK_HEURISTIC == stack_segregation) {
+        target_ulong asid;
 
-    // Track all kernel-mode stacks together
-    if (in_kernelspace(env))
-        asid = 0;
-    else
-        asid = panda_current_asid(ENV_GET_CPU(env));
+        // Track all kernel-mode stacks together
+        if (in_kernelspace(env))
+            asid = 0;
+        else
+            asid = panda_current_asid(ENV_GET_CPU(env));
 
-    // Invalidate cached stack pointer on ASID change
-    if (cached_asid == 0 || cached_asid != asid) {
-        cached_sp = 0;
-        cached_asid = asid;
-    }
-
-    target_ulong sp = get_stack_pointer(env);
-
-    // We can short-circuit the search in most cases
-    if (std::abs(sp - cached_sp) < MAX_STACK_DIFF) {
-        return std::make_pair(asid, cached_sp);
-    }
-
-    auto &stackset = stacks_seen[asid];
-    if (stackset.empty()) {
-        stackset.insert(sp);
-        cached_sp = sp;
-        return std::make_pair(asid,sp);
-    }
-    else {
-        // Find the closest stack pointer we've seen
-        auto lb = std::lower_bound(stackset.begin(), stackset.end(), sp);
-        target_ulong stack1 = *lb;
-        lb--;
-        target_ulong stack2 = *lb;
-        target_ulong stack = (std::abs(stack1 - sp) < std::abs(stack2 - sp)) ? stack1 : stack2;
-        int diff = std::abs(stack-sp);
-        if (diff < MAX_STACK_DIFF) {
-            return std::make_pair(asid,stack);
+        // Invalidate cached stack pointer on ASID change
+        if (cached_asid == 0 || cached_asid != asid) {
+            cached_sp = 0;
+            cached_asid = asid;
         }
-        else {
+
+        target_ulong sp = get_stack_pointer(env);
+
+        // We can short-circuit the search in most cases
+        if (std::abs(sp - cached_sp) < MAX_STACK_DIFF) {
+            return std::make_pair(asid, cached_sp);
+        }
+
+        auto &stackset = stacks_seen[asid];
+        if (stackset.empty()) {
             stackset.insert(sp);
             cached_sp = sp;
             return std::make_pair(asid,sp);
         }
+        else {
+            // Find the closest stack pointer we've seen
+            auto lb = std::lower_bound(stackset.begin(), stackset.end(), sp);
+            target_ulong stack1 = *lb;
+            lb--;
+            target_ulong stack2 = *lb;
+            target_ulong stack = (std::abs(stack1 - sp) < std::abs(stack2 - sp)) ? stack1 : stack2;
+            int diff = std::abs(stack-sp);
+            if (diff < MAX_STACK_DIFF) {
+                return std::make_pair(asid,stack);
+            }
+            else {
+                stackset.insert(sp);
+                cached_sp = sp;
+                return std::make_pair(asid,sp);
+            }
+        }
+    } else if (STACK_THREADED == stack_segregation) {
+        OsiThread *thr = get_current_thread(first_cpu);
+        stackid cursi;
+        if (NULL != thr) {
+            cursi = std::make_pair(thr->pid, thr->tid);
+        } else {
+            // assuming 0 is never a valid process ID and thread ID
+            cursi = std::make_pair(0, 0);
+        }
+        free_osithread(thr);
+        return cursi;
+    } else {
+        // STACK_ASID
+        target_ulong asid = panda_current_asid(ENV_GET_CPU(env));
+        return std::make_pair(asid, 0);
     }
-#else
-    return panda_current_asid(ENV_GET_CPU(env));
-#endif
+    // end of function get_stackid
+}
+
+// Get stack ID from the program point as a string
+// Caller must use g_free to free the returned object when done with it
+char *get_stackid_string(prog_point p) {
+    char *sid_string;
+    if (STACK_HEURISTIC == p.stackKind) {
+        sid_string = g_strdup_printf("(asid=0x" TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx ")",
+                p.sidFirst, p.sidSecond);
+    } else if (STACK_THREADED == p.stackKind) {
+        sid_string = g_strdup_printf("(processID=0x" TARGET_FMT_lx ", threadID=0x" TARGET_FMT_lx ")",
+                p.sidFirst, p.sidSecond);
+    } else {
+        // STACK_ASID
+        sid_string = g_strdup_printf("(asid=0x" TARGET_FMT_lx ")", p.sidFirst);
+    }
+
+    assert(sid_string);
+    return sid_string;
 }
 
 instr_type disas_block(CPUArchState* env, target_ulong pc, int size) {
@@ -424,12 +470,15 @@ void get_prog_point(CPUState* cpu, prog_point *p) {
     CPUArchState* env = (CPUArchState*)cpu->env_ptr;
     if (!p) return;
 
-    // Get address space identifier
-    target_ulong asid = panda_current_asid(ENV_GET_CPU(env));
-    // Lump all kernel-mode CR3s together
+    // Get stack ID
+    stackid curStackid = get_stackid(env);
 
-    if(!in_kernelspace(env))
-        p->cr3 = asid;
+    // Lump all kernel-mode CR3s together
+    if(!in_kernelspace(env)) {
+        p->sidFirst = curStackid.first;
+        p->sidSecond = curStackid.second;}
+
+    p->stackKind = stack_segregation;
 
     // Try to get the caller
     int n_callers = 0;
@@ -458,6 +507,20 @@ bool init_plugin(void *self) {
     panda_arg_list *args = panda_get_args("callstack_instr");
     verbose = panda_parse_bool_opt(args, "verbose", "enable verbose output");
 
+    const char *stackType = panda_parse_string_opt(args, "stack_type", "asid",
+            "type of segregation used for stack entries (threaded, heuristic, or the default, asid");
+    if (0 == strcmp(stackType, "asid")) {
+        stack_segregation = STACK_ASID;
+    } else if (0 == strcmp(stackType, "heuristic")) {
+        stack_segregation = STACK_HEURISTIC;
+    } else if (0 == strcmp(stackType, "threaded")) {
+        stack_segregation = STACK_THREADED;
+    } else {
+        printf("ERROR:  callstack_instr:  invalid stack_type (%s) provided\n",
+                stackType);
+        return false;
+    }
+
 #if defined(TARGET_I386)
     if (cs_open(CS_ARCH_X86, CS_MODE_32, &cs_handle_32) != CS_ERR_OK)
         return false;
@@ -471,13 +534,6 @@ bool init_plugin(void *self) {
 #elif defined(TARGET_PPC)
     if (cs_open(CS_ARCH_PPC, CS_MODE_32, &cs_handle_32) != CS_ERR_OK)
         return false;
-#endif
-
-    // note which build was used, as it is useful in analyzing the results
-#ifdef USE_STACK_HEURISTIC
-    printf("callstack_instr:  using USE_STACK_HEURISTIC build\n");
-#else
-    printf("callstack_instr:  using standard build\n");
 #endif
 
     // Need details in capstone to have instruction groupings
@@ -497,6 +553,48 @@ bool init_plugin(void *self) {
     panda_register_callback(self, PANDA_CB_AFTER_BLOCK_EXEC, pcb);
     pcb.before_block_exec = before_block_exec;
     panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+
+    // the STACK_THREADED stack type needs some OS specific setup
+    if (STACK_THREADED == stack_segregation) {
+        switch (panda_os_familyno) {
+        case OS_WINDOWS: {
+#if defined(TARGET_I386) && !defined(TARGET_X86_64)
+            printf("callstack_instr: setting up Windows threaded stack_type\n");
+            panda_require("osi");
+            assert(init_osi_api());
+            panda_require("wintrospection");
+            assert(init_wintrospection_api());
+#else
+            fprintf(stderr, "ERROR: Windows is only supported on x86 (32-bit)\n");
+            return false;
+#endif
+        } break;
+        case OS_LINUX: {
+#if defined(TARGET_I386) && !defined(TARGET_X86_64)
+            printf("callstack_instr: setting up Linux threaded stack_type\n");
+            panda_require("osi");
+            assert(init_osi_api());
+            panda_require("osi_linux");
+            assert(init_osi_linux_api());
+#else
+            fprintf(stderr, "ERROR: Linux is only supported on x86 (32-bit)\n");
+            return false;
+#endif
+        } break;
+        case OS_UNKNOWN: {
+            printf("WARNING:  callstack_instr:  no OS specified, switching to asid stack_type\n");
+            stack_segregation = STACK_ASID;
+        } break;
+        default: {
+            printf("WARNING:  callstack_instr: OS not supported, switching to asid stack_type\n");
+            stack_segregation = STACK_ASID;
+        } break;
+        }
+    } else if (STACK_ASID == stack_segregation) {
+        printf("callstack_instr:  using asid stack_type\n");
+    } else {
+        printf("callstack_instr:  using heuristic stack_type\n");
+    }
 
     return true;
 }

--- a/panda/plugins/callstack_instr/callstack_instr_int_fns.h
+++ b/panda/plugins/callstack_instr/callstack_instr_int_fns.h
@@ -16,10 +16,6 @@ uint32_t get_functions(target_ulong *functions, uint32_t n, CPUState *cpu);
 // right now to have a "utilities" library, this will have to do
 void get_prog_point(CPUState *cpu, prog_point *p);
 
-// Get the stack ID, as a string, from the given program point.  The returned
-// object must be freed with g_free when it is no longer needed.
-char *get_stackid_string(prog_point p);
-
 // create pandalog message for callstack info
 Panda__CallStack *pandalog_callstack_create(void);
 

--- a/panda/plugins/callstack_instr/callstack_instr_int_fns.h
+++ b/panda/plugins/callstack_instr/callstack_instr_int_fns.h
@@ -3,18 +3,22 @@
 
 // Public interface
 
-// Get up to n callers from the given address space at this moment
+// Get up to n callers from the given stack in use at this moment
 // Callers are returned in callers[], most recent first
 uint32_t get_callers(target_ulong *callers, uint32_t n, CPUState *cpu);
 
-// Get up to n functions from the given address space at this moment
+// Get up to n functions from the given stack in use at this moment
 // Functions are returned in functions[], most recent first
 uint32_t get_functions(target_ulong *functions, uint32_t n, CPUState *cpu);
 
-// Get the current program point: (Caller, PC, ASID)
+// Get the current program point: (Caller, PC, stack type, stack ID components)
 // This isn't quite the right place for it, but since it's awkward
 // right now to have a "utilities" library, this will have to do
 void get_prog_point(CPUState *cpu, prog_point *p);
+
+// Get the stack ID, as a string, from the given program point.  The returned
+// object must be freed with g_free when it is no longer needed.
+char *get_stackid_string(prog_point p);
 
 // create pandalog message for callstack info
 Panda__CallStack *pandalog_callstack_create(void);

--- a/panda/plugins/callstack_instr/prog_point.h
+++ b/panda/plugins/callstack_instr/prog_point.h
@@ -42,10 +42,13 @@ struct prog_point {
                        (this->stackKind < p.stackKind));
     }
     bool operator ==(const prog_point &p) const {
-        return ((this->pc == p.pc) && (this->caller == p.caller) && \
-                (this->sidFirst == p.sidFirst) && \
-                (this->sidSecond == p.sidSecond) && \
-                (this->stackKind == p.stackKind));
+        bool sids_match = true;
+        if ((this->sidFirst != p.sidFirst) ||
+                (this->sidSecond != p.sidSecond) ||
+                (this->stackKind != p.stackKind)) {
+            sids_match = false;
+        }
+        return ((this->pc == p.pc) && (this->caller == p.caller) && sids_match);
     }
 #endif
 };

--- a/panda/plugins/callstack_instr/prog_point.h
+++ b/panda/plugins/callstack_instr/prog_point.h
@@ -13,18 +13,39 @@
 PANDAENDCOMMENT */
 #ifndef __PROG_POINT_H
 #define __PROG_POINT_H
+
+// different ways to segregate the stacks
+enum stack_type {
+    STACK_ASID = 0,
+    STACK_HEURISTIC,
+    STACK_THREADED
+};
+
 struct prog_point {
     target_ulong caller;
     target_ulong pc;
-    target_ulong cr3;
+    target_ulong sidFirst;
+    target_ulong sidSecond;
+    stack_type stackKind;
 #ifdef __cplusplus
     bool operator <(const prog_point &p) const {
         return (this->pc < p.pc) || \
-               (this->pc == p.pc && this->caller < p.caller) || \
-               (this->pc == p.pc && this->caller == p.caller && this->cr3 < p.cr3);
+               ((this->pc == p.pc) && (this->caller < p.caller)) || \
+               ((this->pc == p.pc) && (this->caller == p.caller) && \
+                       (this->sidFirst < p.sidFirst)) || \
+               ((this->pc == p.pc) && (this->caller == p.caller) && \
+                       (this->sidFirst == p.sidFirst) && \
+                       (this->sidSecond < p.sidSecond)) || \
+               ((this->pc == p.pc) && (this->caller == p.caller) && \
+                       (this->sidFirst == p.sidFirst) && \
+                       (this->sidSecond == p.sidSecond) && \
+                       (this->stackKind < p.stackKind));
     }
     bool operator ==(const prog_point &p) const {
-        return (this->pc == p.pc && this->caller == p.caller && this->cr3 == p.cr3);
+        return ((this->pc == p.pc) && (this->caller == p.caller) && \
+                (this->sidFirst == p.sidFirst) && \
+                (this->sidSecond == p.sidSecond) && \
+                (this->stackKind == p.stackKind));
     }
 #endif
 };
@@ -36,8 +57,10 @@ struct hash_prog_point{
     {
         size_t h1 = std::hash<target_ulong>()(p.caller);
         size_t h2 = std::hash<target_ulong>()(p.pc);
-        size_t h3 = std::hash<target_ulong>()(p.cr3);
-        return h1 ^ h2 ^ h3;
+        size_t h3 = std::hash<target_ulong>()(p.sidFirst);
+        size_t h4 = std::hash<target_ulong>()(p.sidSecond);
+        size_t h5 = std::hash<target_ulong>()(p.stackKind);
+        return h1 ^ h2 ^ h3 ^ h4 ^ h5;
     }
 };
 

--- a/panda/plugins/callstack_instr/prog_point.h
+++ b/panda/plugins/callstack_instr/prog_point.h
@@ -70,4 +70,25 @@ struct hash_prog_point{
 
 #endif
 
+// Get stack ID from the program point as a string
+// Caller must use g_free to free the returned object when done with it
+static inline char *get_stackid_string(prog_point p) {
+    // this function is intentionally not callstack_instr plugin API so that it
+    // can be called after callstack_instr has been unloaded
+    char *sid_string;
+    if (STACK_HEURISTIC == p.stackKind) {
+        sid_string = g_strdup_printf("(asid=0x" TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx ")",
+                p.sidFirst, p.sidSecond);
+    } else if (STACK_THREADED == p.stackKind) {
+        sid_string = g_strdup_printf("(processID=0x" TARGET_FMT_lx ", threadID=0x" TARGET_FMT_lx ")",
+                p.sidFirst, p.sidSecond);
+    } else {
+        // STACK_ASID
+        sid_string = g_strdup_printf("(asid=0x" TARGET_FMT_lx ")", p.sidFirst);
+    }
+
+    assert(sid_string);
+    return sid_string;
+}
+
 #endif

--- a/panda/plugins/stringsearch/USAGE.md
+++ b/panda/plugins/stringsearch/USAGE.md
@@ -13,13 +13,13 @@ By default, `stringsearch` reads strings to search for from a text file named `$
 
 Will search for the string `has stopped working` and the byte sequence `0x01 0x02 0x03 0x04` being written to or read from memory.
 
-When a match is found, it is saved into `${NAME}_string_matches.txt` in a file listing the callstack, program counter, address space, and number of hits. The number of entries in the callstack is a configurable parameter. For example, with just two levels of callstack information, example output might look like:
+When a match is found, it is saved into `${NAME}_string_matches.txt` in a file listing the callstack, program counter, address space, and number of hits. The address space is determined by the `stack_type` setting in the `callstack_instr` plugin. The number of entries in the callstack is a configurable parameter. For example, with just two levels of callstack information and a `stack_type` of `asid`, example output might look like:
 
-    826954f7 8269669d 23d1a0e2 3eb5b3c0  1
-    3140cd87 330f54a0 23d1a11f 3eb5b3c0  1
-    826954f7 8269669d 23d1a11f 3eb5b3c0  1
-    188b2992 1c9196fc 23d7f60a 3eb5b3c0  3
-    1fd615c5 1fd621d8 23d80d9e 3eb5b3c0  8
+    826954f7 8269669d 23d1a0e2 (asid=0x3eb5b3c0)  1
+    3140cd87 330f54a0 23d1a11f (asid=0x3eb5b3c0)  1
+    826954f7 8269669d 23d1a11f (asid=0x3eb5b3c0)  1
+    188b2992 1c9196fc 23d7f60a (asid=0x3eb5b3c0)  3
+    1fd615c5 1fd621d8 23d80d9e (asid=0x3eb5b3c0)  8
 
 Arguments
 ---------

--- a/panda/plugins/textprinter/USAGE.md
+++ b/panda/plugins/textprinter/USAGE.md
@@ -8,13 +8,18 @@ The somewhat misnamed `textprinter` plugin writes the contents of any data flowi
 
 The plugin is usually used after identifying some tap points of interest, using something like the `stringsearch` plugin.
 
-`textprinter` reads a list of tap points to monitor from a file named `tap_points.txt`, one per line. Each tap point consists of a caller, program counter, and address space.
+`textprinter` reads a list of tap points to monitor from a file named `tap_points.txt`. The first line of the file is the number of the Stack Type used to specify the address space portion of each tap point.
+- 0 (asid) each address space is a single number, the ASID
+- 1 (heuristic) each address space is specified by an ASID and an SP
+- 2 (threaded) each address space is specified by a process ID and a thread ID
+(Please see the `callstack_instr` plugin for more information.)
+After the stack type, the tap points are listed, one per line. Each tap point consists of a caller, program counter, and address space.
 
 `textprinter` saves output to two files named `read_tap_buffers.txt.gz` and `write_tap_buffers.txt.gz`. These logs are gzipped text files that have entries of the form:
 
-    [Callstack] [PC] [ASID] [Virtual Address] [Access Count] [Byte Value]
+    [Callstack] [PC] [Stack Type] [Address Space] [Virtual Address] [Access Count] [Byte Value]
 
-The virtual address is the location in memory where the data was read from or written to. The access count is a number indicating how many memory operations have occurred; the idea is that for a multi-byte write (e.g., `mov DWORD PTR [0x1234], eax`) all four bytes will have the same access count.
+The address space in the output file is always specified by two numbers. (If the stack type is 0 (asid), then the second number is always 0.) The virtual address is the location in memory where the data was read from or written to. The access count is a number indicating how many memory operations have occurred; the idea is that for a multi-byte write (e.g., `mov DWORD PTR [0x1234], eax`) all four bytes will have the same access count.
 
 Once you have a tap point log, you can split it up into its constitutent tap points with `scripts/split_taps.py`:
 
@@ -42,7 +47,7 @@ None.
 Dependencies
 ------------
 
-`textprinter` uses the `callstack_instr` plugin to get callstack information for each memory access.
+`textprinter` uses the `callstack_instr` plugin to get callstack information for each memory access. Be sure to specify the same `stack_type` as is specified in the `tap_points.txt` file.
 
 APIs and Callbacks
 ------------------
@@ -52,20 +57,23 @@ None.
 Example
 -------
 
-First create a file called `tap_points.txt` with your tap points:
+First create a file called `tap_points.txt` with your tap points. The following example uses the threaded stack type:
 
-    683158d0 686a375c 3eb5b180
-    680c54e2 686dd7e3 3eb5b180
+    2
+    7800f6a8 7800fc97 0000019c 00000210
+    7800f6a8 7800fc97 0000019c 00000244
+    7800f6a8 7800fc9a 0000019c 00000210
+    7800f6a8 7800fc9a 0000019c 00000244
 
 Then run PANDA with `textprinter`:
 
     $PANDA_PATH/x86_64-softmmu/qemu-system-x86_64 -replay foo \
-        -panda callstack_instr -panda textprinter
+        -panda callstack_instr,stack_type=threaded -panda textprinter
 
-You will get output in `read_tap_buffers.txt.gz` and `write_tap_buffers.txt.gz`. This snippet of such a log file shows four bytes (`0x8d 0x64 0x24 0x04`) being written to address `0x001aebe8`:
+You will get output in `read_tap_buffers.txt.gz` and `write_tap_buffers.txt.gz`. This snippet of such a log file shows four bytes (`0x62 0x72 0x61 0x6e`) being written to address `0x003f3830`:
 
-    692483d1 [...] 683158d0 686a375c 3eb5b180 001aebe8 3331087336 8d
-    692483d1 [...] 683158d0 686a375c 3eb5b180 001aebe9 3331087336 64
-    692483d1 [...] 683158d0 686a375c 3eb5b180 001aebea 3331087336 24
-    692483d1 [...] 683158d0 686a375c 3eb5b180 001aebeb 3331087336 04
+    77fa15db [...] 7800f6a8 7800fc9a 2 0000019c 00000210 003f3830 6520348 62
+    77fa15db [...] 7800f6a8 7800fc9a 2 0000019c 00000210 003f3831 6520348 72
+    77fa15db [...] 7800f6a8 7800fc9a 2 0000019c 00000210 003f3832 6520348 61
+    77fa15db [...] 7800f6a8 7800fc9a 2 0000019c 00000210 003f3833 6520348 6e
 

--- a/panda/plugins/textprinter/textprinter.cpp
+++ b/panda/plugins/textprinter/textprinter.cpp
@@ -66,13 +66,14 @@ int mem_callback(CPUState *env, target_ulong pc, target_ulong addr,
     if (tap_points.find(p) != tap_points.end()) {
         target_ulong callers[16] = {0};
         int nret = get_callers(callers, 16, env);
+        unsigned char *buf_uc = static_cast<unsigned char *>(buf);
         for (unsigned int i = 0; i < size; i++) {
             for (int j = nret-1; j > 0; j--) {
                 gzprintf(f, TARGET_FMT_lx " ", callers[j]);
             }
             gzprintf(f, TARGET_FMT_lx " " TARGET_FMT_lx " %d " TARGET_FMT_lx " " TARGET_FMT_lx " " TARGET_FMT_lx " %ld %02x\n",
                     p.caller, p.pc, p.stackKind, p.sidFirst, p.sidSecond,
-                    addr+i, mem_counter, ((unsigned char *)buf)[i]);
+                    addr+i, mem_counter, buf_uc[i]);
         }
     }
     mem_counter++;

--- a/panda/plugins/unigrams/unigrams.cpp
+++ b/panda/plugins/unigrams/unigrams.cpp
@@ -94,10 +94,18 @@ void write_report(FILE *report, std::map<prog_point,text_counter> &tracker) {
     // Cross platform support: need to know how big a target_ulong is
     uint32_t target_ulong_size = sizeof(target_ulong);
     fwrite(&target_ulong_size, sizeof(uint32_t), 1, report);
+    uint32_t stack_type_size = sizeof(stack_type);
+    fwrite(&stack_type_size, sizeof(uint32_t), 1, report);
 
     std::map<prog_point,text_counter>::iterator it;
     for(it = tracker.begin(); it != tracker.end(); it++) {
-        fwrite(&it->first, sizeof(prog_point), 1, report);
+        // prog_point parts
+        fwrite(&it->first.stackKind, stack_type_size, 1, report);
+        fwrite(&it->first.caller, target_ulong_size, 1, report);
+        fwrite(&it->first.pc, target_ulong_size, 1, report);
+        fwrite(&it->first.sidFirst, target_ulong_size, 1, report);
+        fwrite(&it->first.sidSecond, target_ulong_size, 1, report);
+
         unsigned int hist[256] = {};
         for(int i = 0; i < 256; i++) {
             if (it->second.hist.find(i) != it->second.hist.end())

--- a/panda/scripts/find_drm.py
+++ b/panda/scripts/find_drm.py
@@ -32,18 +32,18 @@ if (writes['stackKind'].all() != 0):
     writes = writes[writes['sidSecond'] != 0]
 
 ## Chi squared test
-print "Computing randomness of read buffers using Chi-Squared test..."
+print("Computing randomness of read buffers using Chi-Squared test...")
 #read_chi,read_p = scipy.stats.chisquare(reads['hist'].T)
 read_chi = chisq(reads['hist'])
-print "Computing randomness of write buffers using Chi-Squared test..."
+print("Computing randomness of write buffers using Chi-Squared test...")
 #write_chi,write_p = scipy.stats.chisquare(writes['hist'].T)
 write_chi = chisq(writes['hist'])
 
 # Entropy for each
-print "Computing read buffer entropy..."
+print("Computing read buffer entropy...")
 read_ent = ent(reads['hist'])
 
-print "Computing write buffer entropy..."
+print("Computing write buffer entropy...")
 write_ent = ent(writes['hist'])
 
 # Now we reduce, looking for callers that have high entropy read and write
@@ -57,7 +57,7 @@ mask = write_ent > 7
 high_ent_writes = writes[mask]
 write_chi = write_chi[mask]
 
-print "High entropy reads: %d writes: %d" % (len(high_ent_reads),len(high_ent_writes))
+print("High entropy reads: %d writes: %d" % (len(high_ent_reads),len(high_ent_writes)))
 
 # Further reduce so that they have low randomness on the write and
 # high randomness on the read
@@ -77,29 +77,29 @@ mask = np.in1d(write_candidates[['caller','sidFirst','sidSecond']],intersection)
 write_final = write_candidates[mask]
 write_chi = write_chi[mask]
 
-print "Results: reads: %d, writes: %d" % (len(read_final), len(write_final))
-print "================ Writes ================"
+print("Results: reads: %d, writes: %d" % (len(read_final), len(write_final)))
+print("================ Writes ================")
 for row in write_final:
-    print "(%08x %08x %08x %08x): %d bytes" % (row['caller'], row['pc'], row['sidFirst'], row['sidSecond'], row['hist'].sum())
-print "================ Reads  ================"
+    print("(%08x %08x %08x %08x): %d bytes" % (row['caller'], row['pc'], row['sidFirst'], row['sidSecond'], row['hist'].sum()))
+print("================ Reads  ================")
 for row in read_final:
-    print "(%08x %08x %08x %08x): %d bytes" % (row['caller'], row['pc'], row['sidFirst'], row['sidSecond'], row['hist'].sum())
+    print("(%08x %08x %08x %08x): %d bytes" % (row['caller'], row['pc'], row['sidFirst'], row['sidSecond'], row['hist'].sum()))
 
 wcount = Counter(tuple(row) for row in write_final[['caller','sidFirst','sidSecond']])
 rcount = Counter(tuple(row) for row in read_final[['caller','sidFirst','sidSecond']])
 
-print "Read x Write combinations by caller:"
+print("Read x Write combinations by caller:")
 for caller, sidFirst, sidSecond in rcount:
-    print "(%08x %08x %08x): %d x %d combinations" % (caller, sidFirst, sidSecond, rcount[(caller,sidFirst,sidSecond)], wcount[(caller,sidFirst,sidSecond)])
+    print("(%08x %08x %08x): %d x %d combinations" % (caller, sidFirst, sidSecond, rcount[(caller,sidFirst,sidSecond)], wcount[(caller,sidFirst,sidSecond)]))
     read_sizes = read_final['hist'][(read_final['caller'] == caller) & (read_final['sidFirst'] == sidFirst) & (read_final['sidSecond'] == sidSecond)].sum(axis=1)
-    print "  Read sizes: ",
-    print ", ".join(("%d" % x) for x in read_sizes)
+    print("  Read sizes: ")
+    print(", ".join(("%d" % x) for x in read_sizes))
     write_sizes = write_final['hist'][(write_final['caller'] == caller) & (write_final['sidFirst'] == sidFirst) & (write_final['sidSecond'] == sidSecond)].sum(axis=1)
-    print "  Write sizes:",
-    print ", ".join(("%d" % x) for x in write_sizes)
-    print "  Read rand: ",
-    print ", ".join(("%f" % x) for x in read_chi[(read_final['caller'] == caller) & (read_final['sidFirst'] == sidFirst) & (read_final['sidSecond'] == sidSecond)])
-    print "  Write rand:",
-    print ", ".join(("%f" % x) for x in write_chi[(write_final['caller'] == caller) & (write_final['sidFirst'] == sidFirst) & (write_final['sidSecond'] == sidSecond)])
-    print "  Best input/output ratio (0 is best possible):",
+    print("  Write sizes:")
+    print(", ".join(("%d" % x) for x in write_sizes))
+    print("  Read rand: ")
+    print(", ".join(("%f" % x) for x in read_chi[(read_final['caller'] == caller) & (read_final['sidFirst'] == sidFirst) & (read_final['sidSecond'] == sidSecond)]))
+    print("  Write rand:")
+    print(", ".join(("%f" % x) for x in write_chi[(write_final['caller'] == caller) & (write_final['sidFirst'] == sidFirst) & (write_final['sidSecond'] == sidSecond)]))
+    print("  Best input/output ratio (0 is best possible):")
     print min(np.abs(1-(xx/float(yy))) for xx in read_sizes for yy in write_sizes)

--- a/panda/scripts/find_drm.py
+++ b/panda/scripts/find_drm.py
@@ -22,10 +22,14 @@ def chisq(arr):
 
 reads = unigram_hist.load_hist(open(sys.argv[1]))
 reads = reads[reads['hist'].sum(axis=1) > 500]
-reads = reads[reads['cr3'] != 0]
+reads = reads[reads['sidFirst'] != 0]
+if (reads['stackKind'].all() != 0):
+    reads = reads[reads['sidSecond'] != 0]
 writes = unigram_hist.load_hist(open(sys.argv[2]))
 writes = writes[writes['hist'].sum(axis=1) > 500]
-writes = writes[writes['cr3'] != 0]
+writes = writes[writes['sidFirst'] != 0]
+if (writes['stackKind'].all() != 0):
+    writes = writes[writes['sidSecond'] != 0]
 
 ## Chi squared test
 print "Computing randomness of read buffers using Chi-Squared test..."
@@ -65,37 +69,37 @@ write_candidates = high_ent_writes[mask]
 write_chi = write_chi[mask]
 
 # Intersect
-intersection = np.intersect1d(read_candidates[['caller','cr3']], write_candidates[['caller','cr3']])
-mask = np.in1d(read_candidates[['caller','cr3']],intersection)
+intersection = np.intersect1d(read_candidates[['caller','sidFirst','sidSecond']], write_candidates[['caller','sidFirst','sidSecond']])
+mask = np.in1d(read_candidates[['caller','sidFirst','sidSecond']],intersection)
 read_final = read_candidates[mask]
 read_chi = read_chi[mask]
-mask = np.in1d(write_candidates[['caller','cr3']],intersection)
+mask = np.in1d(write_candidates[['caller','sidFirst','sidSecond']],intersection)
 write_final = write_candidates[mask]
 write_chi = write_chi[mask]
 
 print "Results: reads: %d, writes: %d" % (len(read_final), len(write_final))
 print "================ Writes ================"
 for row in write_final:
-    print "(%08x %08x %08x): %d bytes" % (row['caller'], row['pc'], row['cr3'], row['hist'].sum())
+    print "(%08x %08x %08x %08x): %d bytes" % (row['caller'], row['pc'], row['sidFirst'], row['sidSecond'], row['hist'].sum())
 print "================ Reads  ================"
 for row in read_final:
-    print "(%08x %08x %08x): %d bytes" % (row['caller'], row['pc'], row['cr3'], row['hist'].sum())
+    print "(%08x %08x %08x %08x): %d bytes" % (row['caller'], row['pc'], row['sidFirst'], row['sidSecond'], row['hist'].sum())
 
-wcount = Counter(tuple(row) for row in write_final[['caller','cr3']])
-rcount = Counter(tuple(row) for row in read_final[['caller','cr3']])
+wcount = Counter(tuple(row) for row in write_final[['caller','sidFirst','sidSecond']])
+rcount = Counter(tuple(row) for row in read_final[['caller','sidFirst','sidSecond']])
 
 print "Read x Write combinations by caller:"
-for caller, cr3 in rcount:
-    print "(%08x %08x): %d x %d combinations" % (caller, cr3, rcount[(caller,cr3)], wcount[(caller,cr3)])
-    read_sizes = read_final['hist'][(read_final['caller'] == caller) & (read_final['cr3'] == cr3)].sum(axis=1)
+for caller, sidFirst, sidSecond in rcount:
+    print "(%08x %08x %08x): %d x %d combinations" % (caller, sidFirst, sidSecond, rcount[(caller,sidFirst,sidSecond)], wcount[(caller,sidFirst,sidSecond)])
+    read_sizes = read_final['hist'][(read_final['caller'] == caller) & (read_final['sidFirst'] == sidFirst) & (read_final['sidSecond'] == sidSecond)].sum(axis=1)
     print "  Read sizes: ",
     print ", ".join(("%d" % x) for x in read_sizes)
-    write_sizes = write_final['hist'][(write_final['caller'] == caller) & (write_final['cr3'] == cr3)].sum(axis=1)
+    write_sizes = write_final['hist'][(write_final['caller'] == caller) & (write_final['sidFirst'] == sidFirst) & (write_final['sidSecond'] == sidSecond)].sum(axis=1)
     print "  Write sizes:",
     print ", ".join(("%d" % x) for x in write_sizes)
     print "  Read rand: ",
-    print ", ".join(("%f" % x) for x in read_chi[(read_final['caller'] == caller) & (read_final['cr3'] == cr3)])
+    print ", ".join(("%f" % x) for x in read_chi[(read_final['caller'] == caller) & (read_final['sidFirst'] == sidFirst) & (read_final['sidSecond'] == sidSecond)])
     print "  Write rand:",
-    print ", ".join(("%f" % x) for x in write_chi[(write_final['caller'] == caller) & (write_final['cr3'] == cr3)])
+    print ", ".join(("%f" % x) for x in write_chi[(write_final['caller'] == caller) & (write_final['sidFirst'] == sidFirst) & (write_final['sidSecond'] == sidSecond)])
     print "  Best input/output ratio (0 is best possible):",
     print min(np.abs(1-(xx/float(yy))) for xx in read_sizes for yy in write_sizes)

--- a/panda/scripts/split_taps.py
+++ b/panda/scripts/split_taps.py
@@ -17,9 +17,9 @@ def main(logfile, prefix, num_callers=1):
             for o in filemap.values(): o.close()
             filemap = {}
 
-        callers, pc, cr3, addr, n, val = line.strip().rsplit(" ", 5)
+        callers, pc, stackKind, sidFirst, sidSecond, addr, n, val = line.strip().rsplit(" ", 7)
         callers = callers.split()
-        fname = prefix + "." + ".".join( callers[-num_callers:] + [pc, cr3] ) + ".dat"
+        fname = prefix + "." + ".".join( callers[-num_callers:] + [pc, stackKind, sidFirst, sidSecond] ) + ".dat"
         if fname not in filemap:
             filemap[fname] = open(fname,'a')
 

--- a/panda/scripts/split_taps.py
+++ b/panda/scripts/split_taps.py
@@ -17,9 +17,9 @@ def main(logfile, prefix, num_callers=1):
             for o in filemap.values(): o.close()
             filemap = {}
 
-        callers, pc, stackKind, sidFirst, sidSecond, addr, n, val = line.strip().rsplit(" ", 7)
+        callers, pc, stack_kind, sid_first, sid_second, addr, n, val = line.strip().rsplit(" ", 7)
         callers = callers.split()
-        fname = prefix + "." + ".".join( callers[-num_callers:] + [pc, stackKind, sidFirst, sidSecond] ) + ".dat"
+        fname = prefix + "." + ".".join( callers[-num_callers:] + [pc, stack_kind, sid_first, sid_second] ) + ".dat"
         if fname not in filemap:
             filemap[fname] = open(fname,'a')
 

--- a/panda/scripts/unigram_hist.py
+++ b/panda/scripts/unigram_hist.py
@@ -9,6 +9,8 @@ from struct import unpack
 def load_hist(f):
     ulong_size = unpack("<i", f.read(4))[0]
     ulong_fmt = '<u%d' % ulong_size
-    rectype = np.dtype( [ ('caller', ulong_fmt), ('pc', ulong_fmt), ('cr3', ulong_fmt), ('hist', '<i4', 256) ] )
+    stack_type_size = unpack("<i", f.read(4))[0]
+    stack_type_fmt = '<u%d' % stack_type_size
+    rectype = np.dtype( [ ('stackKind', stack_type_fmt), ('caller', ulong_fmt), ('pc', ulong_fmt), ('sidFirst', ulong_fmt), ('sidSecond', ulong_fmt), ('hist', '<i4', 256) ] )
     data = np.fromfile(f, dtype=rectype)
     return data


### PR DESCRIPTION
The main thing was to add an option to use the process ID and thread ID to segregate callstacks.  This does a better job of distinguishing between stacks than the ASID.  This technique does require OSI support, so the ASID and USE_STACK_HEURISTIC techniques are still available in case OSI is not available for one's guest OS.  Note that if an OS is specified (via the -os switch), that this new technique (called "threaded") is used instead of ASID.  The "asid" technique remains the default if no OS is specified.
Also changed the old USE_STACK_HEURISTIC option, which was formerly made available only at build time, to now be a run-time option.
Also adjusted the get_prog_point API in callstack_instr, and the plugins which rely upon it (stringsearch, textprinter, unigrams) to not assume the callstacks were segregated via ASID.
I think this takes care of issue #411.