### PR TITLE
Network Taint Refinements

### DIFF
--- a/panda/plugins/ida_taint2/ida_taint2.cpp
+++ b/panda/plugins/ida_taint2/ida_taint2.cpp
@@ -21,6 +21,8 @@ PANDAENDCOMMENT */
 #include "osi/osi_types.h"
 #include "osi/osi_ext.h"
 
+#include "ida_taint2_api.h"
+
 // These need to be extern "C" so that the ABI is compatible with
 // QEMU/PANDA, which is written in C
 extern "C" {
@@ -112,6 +114,12 @@ void taint_state_changed(Addr a, uint64_t size)
     }
 }
 
+const char *filename;
+
+const char *ida_taint2_get_filename(void) {
+    return filename;
+}
+
 bool init_plugin(void *self)
 {
     // Setup OSI
@@ -130,8 +138,7 @@ bool init_plugin(void *self)
 
     // Setup CSV file.
     panda_arg_list *args = panda_get_args("ida_taint2");
-    const char *filename =
-        panda_parse_string(args, "filename", "ida_taint2.csv");
+    filename = panda_parse_string(args, "filename", "ida_taint2.csv");
 
     // Open up a CSV file and write the header.
     pidpclog = fopen(filename, "w");

--- a/panda/plugins/ida_taint2/ida_taint2_api.h
+++ b/panda/plugins/ida_taint2/ida_taint2_api.h
@@ -1,0 +1,3 @@
+extern "C" {
+const char *ida_taint2_get_filename(void);
+}

--- a/panda/plugins/ida_taint2/ida_taint2_int.h
+++ b/panda/plugins/ida_taint2/ida_taint2_int.h
@@ -1,0 +1,1 @@
+#include "ida_taint2_int_fns.h"

--- a/panda/plugins/ida_taint2/ida_taint2_int_fns.h
+++ b/panda/plugins/ida_taint2/ida_taint2_int_fns.h
@@ -1,0 +1,2 @@
+
+const char *ida_taint2_get_filename(void);

--- a/panda/plugins/tainted_net/USAGE.md
+++ b/panda/plugins/tainted_net/USAGE.md
@@ -13,7 +13,13 @@ Arguments
 
 * `label_incoming_network`: boolean. Whether to apply taint labels to incoming network traffic.
 * `query_outgoing_network`: boolean. Whether to display taint on outgoing network traffic.
-* `positional_taint`: boolean. Whether to apply a different label to each tainted byte in the incoming packet.
+* `semantic`: boolean. Whether to apply a different label to each tainted byte in the incoming packet.  An additional file will be generated for ida taint so semantic labels can be displayed in IDA Pro.
+* `packets`: string. List of packet numbers or ranges to taint.  Values should be separated by colons.  Example: 1-3:5
+* `ip_proto`: string.  List of IPV4 protocol numbers or ranges to taint.
+* `bytes`: string.  List of byte offsets or ranges in each packet to taint.
+* `ip_src`: string.  If specified, only packets received from the specified IPV4 address will be considered for tainting.
+* `ip_dst`: string.  If specified, only packets destined for the specified IPV4 address will be considered for tainting.
+* `eth_type`: string.  Type of packet encapulated in the received ethernet packet.
 * `file`: string, defaults to "tainted_net_query.csv". The name of the file to which outgoing network traffic taint information will be written.
 
 At least one of `label_incoming_network` or `query_outgoing_network` must be true.
@@ -52,4 +58,4 @@ To taint the string `quick` and then see if it is sent out over the network, wri
         -replay foo \
         -panda stringsearch:str="quick" -panda tstringsearch \
         -panda tainted_net:query_outgoing_network=true,file=quick_tnss.csv
-        
+

--- a/panda/plugins/tainted_net/USAGE.md
+++ b/panda/plugins/tainted_net/USAGE.md
@@ -1,4 +1,4 @@
-Plugin: tainted_net
+Plugin: tainted\_net
 ===========
 
 Summary
@@ -20,7 +20,7 @@ Arguments
 * `ip_src`: string.  If specified, only packets received from the specified IPV4 address will be considered for tainting.
 * `ip_dst`: string.  If specified, only packets destined for the specified IPV4 address will be considered for tainting.
 * `eth_type`: string.  Type of packet encapulated in the received ethernet packet.
-* `file`: string, defaults to "tainted_net_query.csv". The name of the file to which outgoing network traffic taint information will be written.
+* `file`: string, defaults to "tainted\_net\_query.csv". The name of the file to which outgoing network traffic taint information will be written.
 
 At least one of `label_incoming_network` or `query_outgoing_network` must be true.
 
@@ -52,7 +52,7 @@ Note that the `taint2` plugin is not explicitly listed here because it is automa
         -panda tainted_net:label_incoming_network=true \
         -panda tainted_instr
 
-To taint the string `quick` and then see if it is sent out over the network, writing the outgoing taint information to quick_tnss.csv, do:
+To taint the string `quick` and then see if it is sent out over the network, writing the outgoing taint information to quick\_tnss.csv, do:
 
     $PANDA_PATH/i386-softmmu/qemu-system-i386 -net nic -net user \
         -replay foo \

--- a/panda/plugins/tainted_net/tainted_net.cpp
+++ b/panda/plugins/tainted_net/tainted_net.cpp
@@ -1,35 +1,54 @@
 /* PANDABEGINCOMMENT
- * 
- * Authors:
- *  Laura L. Mann
- * 
- * This work is licensed under the terms of the GNU GPL, version 2. 
- * See the COPYING file in the top-level directory. 
- * 
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
+ *
 PANDAENDCOMMENT */
 // This needs to be defined before anything is included in order to get
 // the PRIx64 macro
 #define __STDC_FORMAT_MACROS
 
 #include <iostream>
+#include <set>
+#include <cstring>
+#include <stdint.h>
 
 #include "panda/plugin.h"
 #include "panda/network.h"
 #include "taint2/taint2.h"
 
-extern "C" {
+extern "C"
+{
 #include "qemu/cutils.h"
 #include "taint2/taint2_ext.h"
-}
+#include "ida_taint2/ida_taint2_ext.h"
 
 // These need to be extern "C" so that the ABI is compatible with
 // QEMU/PANDA, which is written in C
-extern "C" {
-bool init_plugin(void *);
-void uninit_plugin(void *);
-int on_replay_handle_packet(CPUState *env, uint8_t *buf, int size, uint8_t
-    direction, uint64_t old_buf_addr);
+bool init_plugin(void *self);
+void uninit_plugin(void *self);
+int on_replay_handle_packet(CPUState *env, uint8_t *buf, int packet_size,
+    uint8_t direction, uint64_t old_buf_addr);
 }
+
+const std::string PLUGIN_NM = std::string("tainted_net");
+
+// Delimiter for options that specify sets of integer ranges
+const std::string DELIM = std::string(":");
+
+// Default value for options that specify sets of integer ranges
+const std::string DEFAULT_ALL = std::string("all");
+
+// IPV4/Ethernet constants
+
+constexpr int MAC_HEADER_SIZE = 14;
+constexpr int ETHERTYPE_OCTET = 12;
+constexpr int IPV4_HEADER_MIN_SIZE = 19;
+constexpr int IPV4_VERSION_OCTET = (MAC_HEADER_SIZE+0);
+constexpr int IPV4_VERSION_MASK = (1 << 6);
+constexpr int IPV4_PROTOCOL_OCTET = (MAC_HEADER_SIZE+9);
+constexpr int IPV4_SOURCE_IP_OCTET = (MAC_HEADER_SIZE+12);
+constexpr int IPV4_DEST_IP_OCTET = (MAC_HEADER_SIZE+16);
 
 // buffer for getting labels on transmitted packets
 uint32_t *taint_labels = NULL;
@@ -38,195 +57,481 @@ size_t cur_max_labels = 10;
 // Configuration
 bool label_incoming_network_traffic = false;
 bool query_outgoing_network_traffic = false;
-bool positional_tainting = false;
+bool semantic_labels = false;
 const char *tx_filename = NULL;
 
 bool firstOpen = true;
 
+// File that semantic label data is written to.
+FILE *semantic_labels_file = NULL;
 
-// a packet has come in over the network, or is about to go out over the network
-int on_replay_handle_packet(CPUState *env, uint8_t *buf, int size, uint8_t
-    direction, uint64_t old_buf_addr) {
+// Counter for each incoming network packet.  Allows for tainting only specific
+// packet numbers.
+uint32_t packet_count = 0;
 
-    if (PANDA_NET_RX == direction)
+// Label counter.  Used when semantic labelling is enabled.
+uint32_t label_count = 0;
+
+// Set of packet numbers that will be tainted.
+std::set<uint32_t> packets_to_taint;
+
+// Set of IPV4 protocol numbers to taint.  Only packets with protocol numbers
+// in this set will be tainted.
+std::set<uint32_t> protocols_to_taint;
+
+// Set of byte offsets in packets to taint.
+std::set<uint32_t> bytes_to_taint;
+
+// If non-zero, only taint packets that arrive from this source ip.
+uint32_t source_ip=0;
+
+// If non-zero, only taint packets with this destination ip.
+uint32_t dest_ip=0;
+
+// If non-zero, only taint packets with this ethertype protocol number.
+uint16_t ethertype=0;
+
+static void output_message(const std::string &message)
+{
+    std::cerr << PANDA_MSG << message << std::endl;
+}
+
+// Called when a packet received passes all filtering criteria.
+// Data within the packet should be tainted.
+// User-specified options may limit the data that is tainted (e.g. only taint
+// bytes 56-60.)
+
+void taint_network_data(int packet_size, uint64_t old_buf_addr)
+{
+    // Counts number of labels applied to this packet.
+    int num_labels_applied = 0;
+
+    // Default label value is 100.  This will be overwritten if semantic labeling is enabled.
+    int label_value = 100;
+
+    if (0 == taint2_enabled())
     {
-        if (label_incoming_network_traffic)
+        output_message("Label operation detected (network)");
+        output_message("Enabling taint processing");
+        taint2_enable_taint();
+    }
+
+    // Loop through each byte in the packet
+    for (int byte_offset = 0; byte_offset < packet_size; byte_offset++)
+    {
+        // If only specific bytes are to be tainted, check to see if this byte should be tainted
+        if(bytes_to_taint.empty() || (bytes_to_taint.find(byte_offset)!=bytes_to_taint.end()))
         {
-            if (!taint2_enabled())
+            // Label is to be applied, increment the counter.
+            num_labels_applied++;
+
+            if (semantic_labels)
             {
-                std::cerr << PANDA_MSG "Label operation detected (network)" <<
-                  std::endl;
-                std::cerr << PANDA_MSG "Enabling taint processing" << std::endl;
-                taint2_enable_taint();
+                // With semantic labels, increment the counter and write out the packet count and byte offset.
+                // The IDA taint plugin will read this data so semantic labels can be displayed in IDA.
+                label_value=++label_count;
+                assert(fprintf(semantic_labels_file, "%u,%u-%u\n", label_value, packet_count, byte_offset) > 0);
             }
-            fprintf(stderr, PANDA_MSG "Applying labels to %d IO items starting at 0x%lx\n",
-                size, old_buf_addr);
-            for (int i = 0; i < size; i++)
-            {
-                if (positional_tainting)
-                {
-                    taint2_label_io((old_buf_addr + i), i);
-                }
-                else
-                {
-                    taint2_label_io((old_buf_addr + i), 100);
-                }
-            }
+
+            // Apply taint label
+            taint2_label_io(old_buf_addr + byte_offset, label_value);
         }
     }
-    else if (PANDA_NET_TX == direction)
-    {
-        if (query_outgoing_network_traffic && taint2_enabled())
-        {
-            // the output can be rather voluminous, so send it to a file
-            // just keep appending data to same file - the column headers will
-            // separate the packets
-            FILE *taintlogF = NULL;
-            if (firstOpen)
-            {
-                taintlogF = fopen(tx_filename, "w+");
-                firstOpen = false;
-            }
-            else
-            {
-               taintlogF = fopen(tx_filename, "a+");
-            }
-            fprintf(taintlogF, "\"Address\",\"Datum\",\"Labels\"\n");
 
-            uint32_t numLabels = 0;
-            uint64_t curAddr = 0;
-            for (int i = 0; i < size; i++)
+    // Notify user that data is being tainted.
+    fprintf(stderr, PANDA_MSG "Applying labels to %d of %d IO items starting at 0x%lx, packet #%u\n",
+        num_labels_applied, packet_size, old_buf_addr, packet_count);
+}
+
+// if filtering on specific ipv4 protocols, determine if this packet matches one of the target protocols
+static bool validate_protocol(uint8_t *buf, bool is_ipv4)
+{
+    return protocols_to_taint.empty() || 
+        (is_ipv4 && protocols_to_taint.find(buf[IPV4_PROTOCOL_OCTET])!=protocols_to_taint.end());
+}
+
+// if filtering on specific packet numbers, determine if this packet matches one of the target packet numbers
+static bool validate_packet_number(void)
+{
+    return packets_to_taint.empty() || (packets_to_taint.find(packet_count)!=packets_to_taint.end());
+}
+
+// if filtering on specific source ip, determine if this packet matches
+static bool validate_source_ip(uint8_t *buf, bool is_ipv4)
+{
+    return (0 == source_ip) || (is_ipv4 && (0 == memcmp(buf+IPV4_SOURCE_IP_OCTET, &source_ip, sizeof(source_ip))));
+}
+
+// if filtering on specific destination ip, determine if this packet matches
+static bool validate_dest_ip(uint8_t *buf, bool is_ipv4)
+{
+    return (0 == dest_ip) || (is_ipv4 && (0 == memcmp(buf+IPV4_DEST_IP_OCTET, &dest_ip, sizeof(dest_ip))));
+}
+
+// if filtering on specific protocol encapsulated within an ethernet packet, determine if this packet matches
+static bool validate_ethertype(uint8_t *buf, int packet_size)
+{
+    return (0 == ethertype) || 
+        ((packet_size > MAC_HEADER_SIZE) && (0 == memcmp(buf+ETHERTYPE_OCTET, &ethertype, sizeof(ethertype))));
+}
+
+
+static void on_replay_handle_incoming_packet(CPUState *env, uint8_t *buf, int packet_size, uint64_t old_buf_addr)
+{
+    // determine if this is an IPV4 packet
+    bool is_ipv4 = (packet_size > (MAC_HEADER_SIZE + IPV4_HEADER_MIN_SIZE)) &&
+        ((buf[IPV4_VERSION_OCTET] & IPV4_VERSION_MASK) == IPV4_VERSION_MASK);
+
+    if(validate_protocol(buf, is_ipv4) &&
+        validate_packet_number() &&
+        validate_source_ip(buf, is_ipv4) &&
+        validate_dest_ip(buf, is_ipv4) &&
+        validate_ethertype(buf, packet_size))
+    {
+        // if we get here, packet has matched all filter criteria.  start tainting.
+        taint_network_data(packet_size, old_buf_addr);
+    }
+}
+
+static void on_replay_handle_outgoing_packet(CPUState *env, uint8_t *buf, int packet_size, uint64_t old_buf_addr)
+{
+    if (0 != taint2_enabled())
+    {
+        // the output can be rather voluminous, so send it to a file
+        // just keep appending data to same file - the column headers will
+        // separate the packets
+        FILE *taintlogF = NULL;
+        if (firstOpen)
+        {
+            taintlogF = fopen(tx_filename, "w+");
+            firstOpen = false;
+        }
+        else
+        {
+           taintlogF = fopen(tx_filename, "a+");
+        }
+        fprintf(taintlogF, "\"Address\",\"Datum\",\"Labels\"\n");
+
+        uint32_t numLabels = 0;
+        uint64_t curAddr = 0;
+        for (int i = 0; i < packet_size; i++)
+        {
+            curAddr = old_buf_addr + i;
+            numLabels = taint2_query_io(curAddr);
+            if (numLabels > 0)
             {
-                curAddr = old_buf_addr + i;
-                numLabels = taint2_query_io(curAddr);
-                if (numLabels > 0)
+                // is my label buffer big enough?
+                if (numLabels > cur_max_labels)
                 {
-                    // is my label buffer big enough?
-                    if (numLabels > cur_max_labels)
-                    {
-                        taint_labels = (uint32_t *)realloc(taint_labels,
-                            numLabels * sizeof(uint32_t));
-                        cur_max_labels = numLabels;
-                    }
-                   
-                    // fetch the labels on curAddr into taint_labels
-                    taint2_query_set_io(curAddr, taint_labels);
-                   
-                    // print out info for this datum, using . for unprintable
-                    // characters
-                    if (isprint(buf[i]))
-                    {
-                        fprintf(taintlogF, "%ld,%c,", curAddr, buf[i]);
-                    }
-                    else
-                    {
-                        fprintf(taintlogF, "%ld,.,", curAddr);
-                    }
-                    for (int j = 0; j < numLabels; j++)
-                    {
-                        fprintf(taintlogF, " %d", taint_labels[j]);
-                    }
-                    fprintf(taintlogF, "\n");
-                } // end of item-in-TX-buffer-has-label(s)
+                    taint_labels = static_cast<uint32_t *>(realloc(taint_labels,
+                        numLabels * sizeof(uint32_t)));
+                    cur_max_labels = numLabels;
+                }
+
+                // fetch the labels on curAddr into taint_labels
+                taint2_query_set_io(curAddr, taint_labels);
+
+                // print out info for this datum, using . for unprintable
+                // characters
+                if (isprint(buf[i]))
+                {
+                    fprintf(taintlogF, "%ld,%c,", curAddr, buf[i]);
+                }
                 else
                 {
-                    if (isprint(buf[i]))
-                    {
-                        fprintf(taintlogF, "%ld,%c, NULL\n", curAddr, buf[i]);
-                    }
-                    else
-                    {
-                        fprintf(taintlogF, "%ld,., NULL\n", curAddr);
-                    }
+                    fprintf(taintlogF, "%ld,.,", curAddr);
                 }
-            } // end of loop through items in TX buffer
-            
-            qemu_fdatasync(fileno(taintlogF));  // ensure ALL data gets flushed
-            int status = fclose(taintlogF);
-            if (status != 0)
+                for (int j = 0; j < numLabels; j++)
+                {
+                    fprintf(taintlogF, " %d", taint_labels[j]);
+                }
+                fprintf(taintlogF, "\n");
+            } // end of item-in-TX-buffer-has-label(s)
+            else
             {
-                fprintf(stderr, "ERROR closing %s\n", tx_filename);
+                if (isprint(buf[i]))
+                {
+                    fprintf(taintlogF, "%ld,%c, NULL\n", curAddr, buf[i]);
+                }
+                else
+                {
+                    fprintf(taintlogF, "%ld,., NULL\n", curAddr);
+                }
             }
-        } // end of care-about-outgoing-taint
+        } // end of loop through items in TX buffer
+
+        qemu_fdatasync(fileno(taintlogF));  // ensure ALL data gets flushed
+        int status = fclose(taintlogF);
+        if (status != 0)
+        {
+            output_message(std::string("ERROR closing ") + tx_filename);
+        }
+    } // end of care-about-outgoing-taint
+}
+
+// a packet has come in over the network, or is about to go out over the network
+int on_replay_handle_packet(CPUState *env, uint8_t *buf, int packet_size, 
+        uint8_t direction, uint64_t old_buf_addr)
+{
+    // Increment packet counter.  This count should agree with the count in the
+    // wireshark file that is produced by the network plugin.
+    ++packet_count;
+
+    if ((PANDA_NET_RX == direction) && label_incoming_network_traffic)
+    {
+        on_replay_handle_incoming_packet(env, buf, packet_size, old_buf_addr);
+    }
+    else if ((PANDA_NET_TX == direction) && query_outgoing_network_traffic)
+    {
+        on_replay_handle_outgoing_packet(env, buf, packet_size, old_buf_addr);
     }
     else
     {
         fprintf(stderr, "Unrecognized network packet direction (%d)\n",
             direction);
     }
-    
+
     return 1;
 }
 
+// Parse a string containing a set of integers and/or ranges and return a set containing all
+// specified values.
+// Example valid inputs:
+// 1
+// 1:2
+// 1:2:3
+// 1-3 (identical to 1:2:3)
+// 1-3:5
+// 1-3:5:6:7
+// 1-3:5-7
+std::set<uint32_t> parse_int_ranges(panda_arg_list *args, const char *arg_name,
+        const char *help_text)
+{
+    std::set<uint32_t> int_set;
 
-bool init_plugin(void *self) {
+    const char *arg_value = panda_parse_string_opt(args, arg_name, DEFAULT_ALL.c_str(),
+        help_text);
+
+    if(0 != std::strcmp(arg_value, DEFAULT_ALL.c_str()))
+    {
+        char *tmp = new char[std::strlen(arg_value)+1];
+        std::strncpy(tmp, arg_value, std::strlen(arg_value)+1);
+
+        char *savptr;
+
+        for(char *s=strtok_r(tmp,DELIM.c_str(),&savptr); s; s=strtok_r(NULL,DELIM.c_str(),&savptr))
+        {
+            char *t=std::strchr(s, '-');
+            unsigned long first;
+            unsigned long last;
+            if(t != NULL)
+            {
+                *(t++)='\0';
+                first=std::strtoul(s,NULL,0);
+                last=std::strtoul(t,NULL,0);
+            }
+            else
+            {
+                first=(last=std::strtoul(s,NULL,0));
+            }
+            assert(first!=0);
+            assert(last!=0);
+            assert(first!=ULONG_MAX);
+            assert(last!=ULONG_MAX);
+            assert(last<=UINT32_MAX);
+            assert(first<=last);
+            for(uint32_t i=first; i<=last; i++)
+            {
+                int_set.insert(i);
+            }
+        }
+        delete[] tmp;
+    }
+
+    return int_set;
+}
+
+// convert a command line argument value to a uint16_t
+uint16_t parse_uint16_t(panda_arg_list *args, const char *arg_name,
+        const char *help_text)
+{
+
+    uint16_t num = 0;
+
+    const char *arg_value = panda_parse_string_opt(args, arg_name, "", help_text);
+
+    assert(arg_value);
+
+    if(*arg_value != '\0')
+    {
+        unsigned long n=std::strtoul(arg_value,NULL,0);
+        assert(n!=ULONG_MAX);
+        assert(n<=UINT16_MAX);
+        num = static_cast<uint16_t>(n);
+    }
+
+    return num;
+}
+
+// convert a command line argument value to a binary ipv4 address
+uint32_t parse_ip(panda_arg_list *args, const char *arg_name,
+        const char *help_text)
+{
+
+    uint32_t ip = 0;
+
+    const char *arg_value = panda_parse_string_opt(args, arg_name, "", help_text);
+
+    assert(arg_value);
+
+    if(*arg_value != '\0')
+    {
+        assert(1 == inet_pton(AF_INET, arg_value, &ip));
+    }
+
+    return ip;
+}
+
+// Get values in set as a std::string
+std::string get_set_as_string(std::set<uint32_t> const &set)
+{
+    std::string s=std::string();
+    for(auto it = set.begin(); it!=set.end(); ++it)
+    {
+        s+=std::to_string(*it) + " ";
+    }
+    return s;
+}
+
+bool init_plugin(void *self)
+{
     panda_cb pcb;
 #ifdef CONFIG_SOFTMMU
-    
+
     // fetch the plugin arguments
-    panda_arg_list *args = panda_get_args("tainted_net");
-    
+    panda_arg_list *args = panda_get_args(PLUGIN_NM.c_str());
+
     label_incoming_network_traffic = panda_parse_bool_opt(args,
         "label_incoming_network",
         "apply taint labels to incoming network traffic");
-    std::cerr << PANDA_MSG "label incoming network traffic " <<
-      PANDA_FLAG_STATUS(label_incoming_network_traffic) << std::endl;
-    
+    output_message(std::string("label incoming network traffic ") +
+      PANDA_FLAG_STATUS(label_incoming_network_traffic));
+
     query_outgoing_network_traffic = panda_parse_bool_opt(args,
         "query_outgoing_network", "display taint on outgoing network traffic");
-    std::cerr << PANDA_MSG "query outgoing network traffic " <<
-      PANDA_FLAG_STATUS(query_outgoing_network_traffic) << std::endl;
-    
+    output_message(std::string("query outgoing network traffic ") +
+      PANDA_FLAG_STATUS(query_outgoing_network_traffic));
+
     if (!(label_incoming_network_traffic || query_outgoing_network_traffic))
     {
-        std::cerr <<
-          PANDA_MSG "tainted_net needs at least one of label_incoming_network or query_outgoing_network enabled" <<
-          std::endl;
+        output_message(PLUGIN_NM + " needs at least one of label_incoming_network or query_outgoing_network enabled");
         return false;
     }
-    
-    // for incoming packets, does each byte get same label, or different
-    // (positional) labels?
+
     if (label_incoming_network_traffic)
     {
-        positional_tainting = panda_parse_bool_opt(args, "pos",
-            "positional taint");
-        std::cerr << PANDA_MSG "apply positional taint labels " <<
-          PANDA_FLAG_STATUS(positional_tainting) << std::endl;
+        semantic_labels = panda_parse_bool_opt(args, "semantic",
+            "semantic labels");
+        output_message(std::string("apply semantic taint labels ") +
+          PANDA_FLAG_STATUS(semantic_labels));
+
+        packets_to_taint = parse_int_ranges(args, "packets",
+            ("list of packet numbers or ranges to taint: example: 22" + DELIM + "33-40").c_str());
+        if(!packets_to_taint.empty())
+        {
+            output_message("packets to taint " + get_set_as_string(packets_to_taint));
+        }
+
+        protocols_to_taint = parse_int_ranges(args, "ip_proto",
+            "list of protocol numbers or ranges to taint");
+        if(!protocols_to_taint.empty())
+        {
+            output_message("only tainting IPV4 protocols " + get_set_as_string(protocols_to_taint));
+        }
+
+        bytes_to_taint = parse_int_ranges(args, "bytes",
+            "list of byte offsets or ranges to taint");
+        if(!bytes_to_taint.empty())
+        {
+            output_message("only tainting packet bytes offsets " + get_set_as_string(bytes_to_taint));
+        }
+
+        source_ip = parse_ip(args, "ip_src",
+            "only taint packets originating from specific ip address");
+        if(source_ip != 0)
+        {
+            output_message("only tainting packets with IPV4 source addr " + std::to_string(source_ip));
+        }
+
+        dest_ip = parse_ip(args, "ip_dst",
+            "only taint packets sent to a specific ip address");
+        if(dest_ip != 0)
+        {
+            output_message("only tainting packets with IPV4 dest addr " + std::to_string(dest_ip));
+        }
+
+        ethertype = parse_uint16_t(args, "eth_type",
+            "protocol number of packet encapsulated in ethernet");
+        if(ethertype != 0)
+        {
+            output_message("only tainting packets with ethertype " + std::to_string(ethertype));
+            ethertype=htons(ethertype);
+        }
+
+        if(semantic_labels)
+        {
+            panda_require("ida_taint2");
+            assert(init_ida_taint2_api());
+            const char *taint2_filename = ida_taint2_get_filename();
+            assert(taint2_filename);
+            assert(*taint2_filename);
+            const char *filename_suffix = ".semantic_labels";
+
+            std::string semantic_labels_filename=std::string(taint2_filename);
+            semantic_labels_filename.append(filename_suffix);
+
+            semantic_labels_file=fopen(semantic_labels_filename.c_str(), "w");
+            assert(semantic_labels_file);
+        }
     }
-    
+
     // need a file name if watching for outgoing taint
     if (query_outgoing_network_traffic)
     {
         tx_filename = panda_parse_string_opt(args, "file",
-            "tainted_net_query.csv",
+            (PLUGIN_NM + "_query.csv").c_str(),
             "name of file for taint information on outgoing network packets");
-        std::cerr << PANDA_MSG "outgoing network traffic taint file " <<
-            tx_filename << std::endl;
-            
+        output_message(std::string("outgoing network traffic taint file ") + tx_filename);
+
         // need some initialize room in the buffer for taint labels too
-        taint_labels = (uint32_t *)malloc(cur_max_labels * sizeof(uint32_t));
+        taint_labels = static_cast<uint32_t *>(malloc(cur_max_labels * sizeof(uint32_t)));
     }
-    
+
     panda_require("taint2");
-    
+
     pcb.replay_handle_packet = on_replay_handle_packet;
     panda_register_callback(self, PANDA_CB_REPLAY_HANDLE_PACKET, pcb);
-    
+
     assert(init_taint2_api());
-    
+
     return true;
 #else
-    std::cerr << PANDA_MSG "tainted_net does not support user mode" <<
-      std::endl;
+    output_message(PLUGIN_NM + " does not support user mode");
     return false;
 #endif
 }
 
 void uninit_plugin(void *self)
 {
-    if (query_outgoing_network_traffic)
+    if (taint_labels != NULL)
     {
         free(taint_labels);
+        taint_labels = NULL;
+    }
+
+    if(semantic_labels_file != NULL)
+    {
+        fclose(semantic_labels_file);
+        semantic_labels_file = NULL;
     }
 }


### PR DESCRIPTION
Added support for semantic labels to IDA taint.
Plugins that wish to use this feature should create an additional file that maps integer taint labels to a semantic label.
Replaced positional taint labels in tainted_net with semantic labels.  When semantic labels are used, tainted instructions in IDA Pro will be annotated with "Packet Number-Byte Offset" instead of integers.
Added options to tainted_net to refine which network packets and/or which byte offsets in packets are tainted.