### PR TITLE
Better Windows Thread ID Query and In Kernel Flag for Threaded Stack IDs

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -101,7 +101,8 @@ std::map<target_ulong,std::set<target_ulong>> stacks_seen;
 
 // For STACK_ASID, the first entry of the pair is the ASID, and the second is 0
 // For STACK_HEURISTIC, the first entry is the ASID and the second is the SP
-// For STACK_THREADED, the first entry is the process ID and the second is the thread ID
+// For STACK_THREADED, the first entry is the process ID, the second is the
+// thread ID, and the third is a flag to indicate kernel mode.
 typedef std::tuple<target_ulong, target_ulong, bool> stackid;
 
 // STACK_HEURISTIC also needs to cache the SP and ASID
@@ -124,13 +125,17 @@ void verbose_log(const char *msg, TranslationBlock *tb, stackid curStackid,
     if (verbose) {
         printf("%s:  ", msg);
         if (STACK_HEURISTIC== stack_segregation) {
+            // Kernel flag omitted, not required when using stack heuristic.
             printf("asid=0x" TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx,
                    std::get<0>(curStackid), std::get<1>(curStackid));
         } else if (STACK_THREADED == stack_segregation) {
-            printf("processID=0x" TARGET_FMT_lx ", threadID=0x" TARGET_FMT_lx,
-                   std::get<0>(curStackid), std::get<1>(curStackid));
+            printf("processID=0x" TARGET_FMT_lx ", threadID=0x" TARGET_FMT_lx
+                   ", inKernel=%s",
+                   std::get<0>(curStackid), std::get<1>(curStackid),
+                   std::get<2>(curStackid) ? "true" : "false");
         } else {
             // STACK_ASID
+            // Kernel flag omitted, not required when using asid stack type.
             printf("asid=0x" TARGET_FMT_lx, std::get<0>(curStackid));
         }
         printf(", block pc=0x" TARGET_FMT_lx, tb->pc);

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -102,7 +102,7 @@ std::map<target_ulong,std::set<target_ulong>> stacks_seen;
 // For STACK_ASID, the first entry of the pair is the ASID, and the second is 0
 // For STACK_HEURISTIC, the first entry is the ASID and the second is the SP
 // For STACK_THREADED, the first entry is the process ID and the second is the thread ID
-typedef std::pair<target_ulong,target_ulong> stackid;
+typedef std::tuple<target_ulong, target_ulong, bool> stackid;
 
 // STACK_HEURISTIC also needs to cache the SP and ASID
 target_ulong cached_sp = 0;
@@ -125,13 +125,13 @@ void verbose_log(const char *msg, TranslationBlock *tb, stackid curStackid,
         printf("%s:  ", msg);
         if (STACK_HEURISTIC== stack_segregation) {
             printf("asid=0x" TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx,
-                curStackid.first, curStackid.second);
+                   std::get<0>(curStackid), std::get<1>(curStackid));
         } else if (STACK_THREADED == stack_segregation) {
             printf("processID=0x" TARGET_FMT_lx ", threadID=0x" TARGET_FMT_lx,
-                    curStackid.first, curStackid.second);
+                   std::get<0>(curStackid), std::get<1>(curStackid));
         } else {
             // STACK_ASID
-            printf("asid=0x" TARGET_FMT_lx, curStackid.first);
+            printf("asid=0x" TARGET_FMT_lx, std::get<0>(curStackid));
         }
         printf(", block pc=0x" TARGET_FMT_lx, tb->pc);
         if (logReturn) {
@@ -169,9 +169,10 @@ static stackid get_heuristic_stackid(CPUArchState* env) {
     // complaining about get_stackid having too many return statements without
     // causing it to complain about if statements being nested too deep
     target_ulong asid;
+    int in_kernel = in_kernelspace(env);
 
     // Track all kernel-mode stacks together
-    if (in_kernelspace(env)) {
+    if (in_kernel) {
         asid = 0;
     } else {
         asid = panda_current_asid(ENV_GET_CPU(env));
@@ -188,13 +189,13 @@ static stackid get_heuristic_stackid(CPUArchState* env) {
 
     // We can short-circuit the search in most cases
     if (std::abs(sp - cached_sp) < MAX_STACK_DIFF) {
-        cursi = std::make_pair(asid, cached_sp);
+        cursi = std::make_tuple(asid, cached_sp, in_kernel);
     } else {
         auto &stackset = stacks_seen[asid];
         if (stackset.empty()) {
             stackset.insert(sp);
             cached_sp = sp;
-            cursi = std::make_pair(asid,sp);
+            cursi = std::make_tuple(asid, sp, in_kernel);
         }
         else {
             // Find the closest stack pointer we've seen
@@ -205,12 +206,12 @@ static stackid get_heuristic_stackid(CPUArchState* env) {
             target_ulong stack = (std::abs(stack1 - sp) < std::abs(stack2 - sp)) ? stack1 : stack2;
             int diff = std::abs(stack-sp);
             if (diff < MAX_STACK_DIFF) {
-                cursi = std::make_pair(asid,stack);
+                cursi = std::make_tuple(asid, stack, in_kernel);
             }
             else {
                 stackset.insert(sp);
                 cached_sp = sp;
-                cursi = std::make_pair(asid,sp);
+                cursi = std::make_tuple(asid, sp, in_kernel);
             }
         }
     }
@@ -218,23 +219,24 @@ static stackid get_heuristic_stackid(CPUArchState* env) {
 }
 
 static stackid get_stackid(CPUArchState* env) {
+    int in_kernel = in_kernelspace(env);
     if (STACK_HEURISTIC == stack_segregation) {
         return get_heuristic_stackid(env);
     } else if (STACK_THREADED == stack_segregation) {
         OsiThread *thr = get_current_thread(first_cpu);
         stackid cursi;
         if (NULL != thr) {
-            cursi = std::make_pair(thr->pid, thr->tid);
+            cursi = std::make_tuple(thr->pid, thr->tid, in_kernel);
         } else {
             // assuming 0 is never a valid process ID and thread ID
-            cursi = std::make_pair(0, 0);
+            cursi = std::make_tuple(0, 0, in_kernel);
         }
         free_osithread(thr);
         return cursi;
     } else {
         // STACK_ASID
         target_ulong asid = panda_current_asid(ENV_GET_CPU(env));
-        return std::make_pair(asid, 0);
+        return std::make_tuple(asid, 0, in_kernel);
     }
     // end of function get_stackid
 }
@@ -468,9 +470,11 @@ void get_prog_point(CPUState* cpu, prog_point *p) {
 
     // Lump all kernel-mode CR3s together
     if(!in_kernelspace(env)) {
-        p->sidFirst = curStackid.first;
-        p->sidSecond = curStackid.second;}
+        p->sidFirst = std::get<0>(curStackid);
+        p->sidSecond = std::get<1>(curStackid);
+    }
 
+    p->isKernelMode = std::get<2>(curStackid);
     p->stackKind = stack_segregation;
 
     // Try to get the caller

--- a/panda/plugins/callstack_instr/prog_point.h
+++ b/panda/plugins/callstack_instr/prog_point.h
@@ -26,7 +26,7 @@ struct prog_point {
     target_ulong pc;
     target_ulong sidFirst;
     target_ulong sidSecond;
-    target_ulong isKernelMode;
+    bool isKernelMode;
     stack_type stackKind;
 #ifdef __cplusplus
     bool operator <(const prog_point &p) const {
@@ -85,6 +85,7 @@ static inline char *get_stackid_string(prog_point p) {
     // can be called after callstack_instr has been unloaded
     char *sid_string;
     if (STACK_HEURISTIC == p.stackKind) {
+        // Kernel flag omitted, not required when using stack heuristic.
         sid_string = g_strdup_printf("(asid=0x" TARGET_FMT_lx ", sp=0x" TARGET_FMT_lx ")",
                 p.sidFirst, p.sidSecond);
     } else if (STACK_THREADED == p.stackKind) {
@@ -94,6 +95,7 @@ static inline char *get_stackid_string(prog_point p) {
             p.sidFirst, p.sidSecond, p.isKernelMode > 0 ? "true" : "false");
     } else {
         // STACK_ASID
+        // Kernel flag omitted, not required when using asid stack type.
         sid_string = g_strdup_printf("(asid=0x" TARGET_FMT_lx ")", p.sidFirst);
     }
 

--- a/panda/plugins/textprinter/textprinter.cpp
+++ b/panda/plugins/textprinter/textprinter.cpp
@@ -125,6 +125,9 @@ bool init_plugin(void *self) {
         } else {
             taps >> std::hex >> p.sidSecond;
         }
+        if (STACK_THREADED == stack_kind) {
+            taps >> std::hex >> p.isKernelMode;
+        }
 
         p.stackKind = static_cast<stack_type>(stack_kind);
 

--- a/panda/plugins/textprinter/textprinter.cpp
+++ b/panda/plugins/textprinter/textprinter.cpp
@@ -71,9 +71,13 @@ int mem_callback(CPUState *env, target_ulong pc, target_ulong addr,
             for (int j = nret-1; j > 0; j--) {
                 gzprintf(f, TARGET_FMT_lx " ", callers[j]);
             }
-            gzprintf(f, TARGET_FMT_lx " " TARGET_FMT_lx " %d " TARGET_FMT_lx " " TARGET_FMT_lx " " TARGET_FMT_lx " %ld %02x\n",
-                    p.caller, p.pc, p.stackKind, p.sidFirst, p.sidSecond,
-                    addr+i, mem_counter, buf_uc[i]);
+            gzprintf(f,
+                     TARGET_FMT_lx " " TARGET_FMT_lx " %d " TARGET_FMT_lx
+                                   " " TARGET_FMT_lx " %s " TARGET_FMT_lx
+                                   " %ld %02x\n",
+                     p.caller, p.pc, p.stackKind, p.sidFirst, p.sidSecond,
+                     p.isKernelMode ? "kernel" : "user", addr + i, mem_counter,
+                     buf_uc[i]);
         }
     }
     mem_counter++;

--- a/panda/plugins/unigrams/unigrams.cpp
+++ b/panda/plugins/unigrams/unigrams.cpp
@@ -105,6 +105,7 @@ void write_report(FILE *report, std::map<prog_point,text_counter> &tracker) {
         fwrite(&it->first.pc, target_ulong_size, 1, report);
         fwrite(&it->first.sidFirst, target_ulong_size, 1, report);
         fwrite(&it->first.sidSecond, target_ulong_size, 1, report);
+        fwrite(&it->first.isKernelMode, sizeof(bool), 1, report);
 
         unsigned int hist[256] = {};
         for(int i = 0; i < 256; i++) {

--- a/panda/scripts/unigram_hist.py
+++ b/panda/scripts/unigram_hist.py
@@ -11,6 +11,6 @@ def load_hist(f):
     ulong_fmt = '<u%d' % ulong_size
     stack_type_size = unpack("<i", f.read(4))[0]
     stack_type_fmt = '<u%d' % stack_type_size
-    rectype = np.dtype( [ ('stackKind', stack_type_fmt), ('caller', ulong_fmt), ('pc', ulong_fmt), ('sidFirst', ulong_fmt), ('sidSecond', ulong_fmt), ('hist', '<i4', 256) ] )
+    rectype = np.dtype( [ ('stackKind', stack_type_fmt), ('caller', ulong_fmt), ('pc', ulong_fmt), ('sidFirst', ulong_fmt), ('sidSecond', ulong_fmt), ('isKernelMode', '<u1'), ('hist', '<i4', 256) ] )
     data = np.fromfile(f, dtype=rectype)
     return data


### PR DESCRIPTION
This PR addresses an issue with the Windows thread id lookup we discovered. Basically, looking up the thread ID by starting with the FS segment is only valid in user-mode. In kernel mode, this is sometimes valid but other times not. This pull will fix wintrospection so that the thread id may be looked up for any threads, not just those that have a thread information block.

After updating the thread id lookup, we found some inconsistencies with the new threaded stack type. It turns out that we weren't accounting for kernel and user mode stacks. In Linux and Windows, each thread has a separate stack for kernel and user space as a security measure. By adding a flag, the callstack plugin can differentiate between the kernel and user space stack. Unigrams, textprinter, and stringsearch have been updated accordingly.