### PR TITLE
install_ubuntu.sh compatibility with Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,28 +21,41 @@ Laboratory, NYU, and Northeastern University.
 
 ## Building
 
-###  Debian 7/8, Ubuntu 14.04 / 16.04
+###  Debian, Ubuntu
 Because PANDA has a few dependencies, we've encoded the build instructions into
 a script,, [panda/scripts/install\_ubuntu.sh](panda/scripts/install\_ubuntu.sh).
-The script should actually work on Debian 7/8 and Ubuntu 14.04, and it
-shouldn't be hard to translate the `apt-get` commands into whatever package
-manager your distribution uses. We currently only vouch for buildability  on
-Debian 7/8 and Ubuntu 14.04, but we welcome pull requests to fix issues with
-other distros.
+The script should actually work on the latest Debian stable/Ubuntu LTS versions.
+It should be straightforward to translate the `apt-get` commands into whatever
+package manager your distribution uses. We currently only vouch for buildability
+on the latest Debian stable/Ubuntu LTS, but we welcome pull requests to fix issues
+with other distros.
 
 Note that if you want to use our LLVM features (mainly the dynamic taint
 system), you will need to install LLVM 3.3 from OS packages or compiled from
-source. On Ubuntu 14.04 this will happen automatically via `install_ubuntu.sh`.
-Alternatively, we have created an Ubuntu PPA at `ppa:phulin/panda`. You can use
-the following commands to install all dependencies on 14.04 or 16.04:
+source. On Ubuntu this should happen automatically via `install_ubuntu.sh`.
 
-```
+Alternatively, you can manually add the Ubuntu PPA we have created at
+`ppa:phulin/panda` and use the following commands to install PANDA
+dependencies:
+
+```sh
+# install qemu pre-requisites
 sudo add-apt-repository ppa:phulin/panda
 sudo apt-get update
 sudo apt-get build-dep qemu
-sudo apt-get install python-pip git protobuf-compiler protobuf-c-compiler \
-  libprotobuf-c0-dev libprotoc-dev python-protobuf libelf-dev \
-  libcapstone-dev libdwarf-dev python-pycparser llvm-3.3 clang-3.3 libc++-dev
+
+# install generic dependencies
+sudo apt-get install git python-pip libc++-dev libelf-dev libdwarf-dev \
+  libelf-dev libdwarf-dev libwiretap-dev wireshark-dev python-pycparser
+
+# install llvm dependencies from ppa:phulin/panda
+sudo apt-get install llvm-3.3 clang-3.3
+
+# install protobuf dependencies
+sudo apt-get install protobuf-compiler protobuf-c-compiler python-protobuf \
+  libprotoc-dev libprotobuf-dev libprotobuf-c-dev
+
+# clone and build PANDA
 git clone https://github.com/panda-re/panda
 mkdir -p build-panda && cd build-panda
 ../panda/build.sh

--- a/build.sh
+++ b/build.sh
@@ -35,14 +35,14 @@ elif [ $GCC_VERSION_MAJOR -lt $GCC_TOOLCHAIN_VERSION_REQ -a $GCXX_VERSION_MAJOR 
     echo "Older gcc/g++ found. Enforcing gnu11 mode."
     COMPILER_CONFIG="--extra-cflags=-std=gnu11"
 else
-    echo "Modern gcc/g++ found. Trying with default."
+    echo "Modern gcc/g++ found. Trying with default. This is likely to fail!"
     COMPILER_CONFIG=""
 fi
 
 ### Check for protobuf v2.
 if ! pkg-config --exists protobuf; then
     echo "No pkg-config for protobuf. Continuing anyway..."
-elif pkg-config --exists protobuf "protobuf > 1 protobuf < 3"; then
+elif pkg-config --exists protobuf "protobuf >= 2"; then
     echo "Using protobuf $(pkg-config --modversion protobuf)."
 else
     echo "Found incompatible protobuf $(pkg-config --modversion protobuf) -- ABORTING"

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -21,6 +21,7 @@ PANDAENDCOMMENT */
 
 #include <cstdio>
 #include <cstdlib>
+#include <cmath>
 
 #include <map>
 #include <set>

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -1,26 +1,36 @@
 #!/bin/bash
+# This script installs all of PANDA after first taking care of current
+# dependencies. Known to work on Debian 7 install.
 
-# This is just everything in compile.md
-# turned into a script
-# you should be able to run it, type in
-# sudo passwd and have it install all of panda.
-# Verified that this script works
-# from a clean install of deb7.
-#
-#
-# This script installs all of PANDA after first taking care of current dependencies. 
-# Known to work on debian 7 install.
+# some globals
+PANDA_GIT="https://github.com/panda-re/panda.git"
+PANDA_PPA="ppa:phulin/panda"
+LIBDWARF_GIT="git://git.code.sf.net/p/libdwarf/code"
+UBUNTU_FALLBACK="xenial"
+
+# system information
+vendor=$(lsb_release --id | awk -F':[\t ]+' '{print $2}')
+codename=$(lsb_release --codename | awk -F':[\t ]+' '{print $2}')
 
 progress() {
   echo
   echo -e "\e[32m[panda_install]\e[0m \e[1m$1\e[0m"
 }
 
+ppa_list_file() {
+  local SOURCES_LIST_D="/etc/apt/sources.list.d"
+  local PPA_OWNER=$(echo "$1" | awk -F'[:/]' '{print $2}')
+  local PPA_NAME=$(echo "$1" | awk -F'[:/]' '{print $3}')
+  printf "%s/%s-%s-%s-%s.list" \
+    "$SOURCES_LIST_D" "$PPA_OWNER" "$(echo "$2" | tr A-Z a-z)" \
+    "$PPA_NAME" "$3"
+}
+
 # Exit on error.
 set -e
 
 progress "Installing qemu dependencies..."
-sudo apt-get update
+sudo apt-get update || true
 sudo apt-get -y build-dep qemu
 
 progress "Installing PANDA dependencies..."
@@ -30,19 +40,36 @@ sudo apt-get -y install python-pip git protobuf-compiler protobuf-c-compiler \
 
 pushd /tmp
 
-if lsb_release -d | grep -E 'Ubuntu (14\.04|16\.04|18\.04)'
-then
+if [ "$vendor" = "Ubuntu" ]; then
   sudo apt-get -y install software-properties-common
-  sudo add-apt-repository -y ppa:phulin/panda
-  sudo apt-get update
+  panda_ppa_file=$(ppa_list_file "$PANDA_PPA" "$vendor" "$codename")
+  panda_ppa_file_fallback=$(ppa_list_file "$PANDA_PPA" "$vendor" "$UBUNTU_FALLBACK")
+
+  # add custom ppa
+  case $codename in
+    trusty)  ;&
+    xenial)  ;&
+    yakkety)
+      # directly supported release
+      sudo add-apt-repository -y "$PANDA_PPA"
+      ;;
+    *)
+      # use fallback release
+      sudo rm -f "$panda_ppa_file" "$panda_ppa_file_fallback"
+      sudo add-apt-repository -y "$PANDA_PPA" || true
+      sudo sed -i "s/$codename/$UBUNTU_FALLBACK/g" "$panda_ppa_file"
+      sudo mv -f "$panda_ppa_file" "$panda_ppa_file_fallback"
+      ;;
+  esac
 
   # For Ubuntu 18.04 the vendor packages are more recent than those in the PPA
   # and will be preferred.
+  sudo apt-get update
   sudo apt-get -y install libcapstone-dev libdwarf-dev python-pycparser
 else
   if [ ! \( -e "/usr/local/lib/libdwarf.so" -o -e "/usr/lib/libdwarf.so" \) ]
   then
-    git clone git://git.code.sf.net/p/libdwarf/code libdwarf-code
+    git clone "$LIBDWARF_GIT" libdwarf-code
     pushd libdwarf-code
     progress "Installing libdwarf..."
     ./configure --prefix=/usr/local --includedir=/usr/local/include/libdwarf --enable-shared
@@ -79,7 +106,7 @@ EOF
 fi
 
 # Install libclang for apigen.py
-sudo apt-get -y install libclang-3.8 python-clang-3.8
+# sudo apt-get -y install libclang-3.8 python-clang-3.8
 
 # Upgrading protocol buffers python support
 sudo pip install --upgrade protobuf
@@ -92,16 +119,28 @@ fi
 
 popd
 
-if [ ! -e "build.sh" ]
-then
-  progress "Cloning PANDA into $(pwd) ..."
-  git clone https://github.com/panda-re/panda.git
+if [ -e "build.sh" ]; then
+  progress "Already in PANDA directory."
+elif [ -e "panda/build.sh" ]; then
+  progress "Switching to PANDA directory."
+  cd panda
+elif ! [ -d "panda" ]; then
+  progress "Cloning PANDA into $(pwd)/panda..."
+  git clone "$PANDA_GIT" panda
   cd panda
 else
-  progress "Already in PANDA directory."
+  progress "Aborting. Can't find build.sh in $(pwd)/panda."
+  exit 1
 fi
+
 progress "Trying to update DTC submodule (if necessary)..."
 git submodule update --init dtc || true
+
+if [ -d "build" ]; then
+  progress "Removing build directory."
+  rm -rf "build"
+fi
+
 progress "Building PANDA..."
 mkdir build
 cd build

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -45,12 +45,9 @@ else
     git clone git://git.code.sf.net/p/libdwarf/code libdwarf-code
     pushd libdwarf-code
     progress "Installing libdwarf..."
-    ./configure --enable-shared
+    ./configure --prefix=/usr/local --includedir=/usr/local/include/libdwarf --enable-shared
     make -j$(nproc)
-    sudo mkdir -p /usr/local/include/libdwarf
-    sudo cp libdwarf/libdwarf.h /usr/local/include/libdwarf/
-    sudo cp libdwarf/dwarf.h /usr/local/include/libdwarf/
-    sudo cp libdwarf/libdwarf.so /usr/local/lib/
+    sudo make install
     popd
   else
     progress "Skipping libdwarf..."

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -30,11 +30,14 @@ sudo apt-get -y install python-pip git protobuf-compiler protobuf-c-compiler \
 
 pushd /tmp
 
-if lsb_release -d | grep -E 'Ubuntu (14\.04|16\.04)'
+if lsb_release -d | grep -E 'Ubuntu (14\.04|16\.04|18\.04)'
 then
   sudo apt-get -y install software-properties-common
   sudo add-apt-repository -y ppa:phulin/panda
   sudo apt-get update
+
+  # For Ubuntu 18.04 the vendor packages are more recent than those in the PPA
+  # and will be preferred.
   sudo apt-get -y install libcapstone-dev libdwarf-dev python-pycparser
 else
   if [ ! \( -e "/usr/local/lib/libdwarf.so" -o -e "/usr/lib/libdwarf.so" \) ]

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -105,9 +105,6 @@ EOF
   fi
 fi
 
-# Install libclang for apigen.py
-# sudo apt-get -y install libclang-3.8 python-clang-3.8
-
 # Upgrading protocol buffers python support
 sudo pip install --upgrade protobuf
 


### PR DESCRIPTION
install_ubuntu.sh should now be compatible with Ubuntu 18.04. The main issue was that the PANDA repository doesn't support the 18.04/bionic release. A fallback to 16.04/xenial packages was implemented for that case.
Also reworded README.md a bit to restate that target platform as "the latest Debian stable/Ubuntu LTS". There may be issues when a new release is made, but these issues should be considered as bugs and reported so they can eventually be ironed out.