### PR TITLE
protobuf parser fix

### DIFF
--- a/panda/scripts/pp.py
+++ b/panda/scripts/pp.py
@@ -1,23 +1,51 @@
-#!/usr/bin/python
-
-import sys
-import re
+#!/usr/bin/env python3
+import logging
 import os.path
-debug = False
+import re
+import sys
+import textwrap
 
-pproto_filename = sys.argv[1]
+LOGLEVEL = logging.INFO
+logging.basicConfig(format='%(levelname)s: %(message)s', level=LOGLEVEL)
 
-def find_message(buf):
-    i = buf.find("message")
-    if i == -1:
-        return None
-    j = buf.find("{", i)
-    k = buf.find("}", j)
-    before = buf[:i]
-    message = buf[i:k+1]
-    after = buf[k+1:]
+def indent_snippet(label, s):
+    if s is None or s == '':
+        return '  %s:\n' % (label)
+    else:
+        return '  %s:\n%s\n' % (label, textwrap.indent(s, '  | '))
+
+def parse_message_block(buf):
+    start = buf.find('message')
+    if start == -1:
+        return (buf.strip(), None, None)
+
+    brace_open = 0
+    brace_close = 0
+    for i, c in enumerate(buf[start:]):
+        if c == '{':
+            brace_open += 1
+        elif c == '}':
+            brace_close += 1
+        if brace_open == brace_close and brace_open > 0:
+            break
+
+    if brace_open == brace_close and brace_open > 0:
+        # ok
+        before = buf[:start].strip()
+        message = buf[start:start+i+1].strip()
+        after = buf[start+i+1:].strip()
+    else:
+        # unbalanced block
+        before = buf[:start].strip()
+        message = None
+        after = buf[start:].strip()
+
+    logging.debug('message parser\n%s%s%s',
+            indent_snippet('before', before),
+            indent_snippet('message', message),
+            indent_snippet('after', after))
+
     return (before, message, after)
-
 
 def get_proto_text(filename):
     buf = ""
@@ -28,107 +56,63 @@ def get_proto_text(filename):
         bar = re.search("^(\s*)$", line)
         if bar:
             continue
-#        print "line=[%s]" % line   
         buf += line
+    logging.debug('%s\n%s', filename, indent_snippet('content', buf))
     return buf
     
-
-def check_blank(buf):
-    foo = re.search("^(\s*)$", buf)
-    if foo:
-        return True
-    return buf.strip() 
-
 def parse_proto_part(buf):
-    # find the messages
     messages = []
     rests = []
     while True:
-        x = find_message(buf)
-        if x is None:       
-            y = check_blank(buf)
-            if not (y is True):
-                rests.append(y)
+        before, message, after = parse_message_block(buf)
+        if before:
+            rests.append(before)
+        if message is None and after is None:
+            # no message found
             break
-        (before, message, after) = x
-        messages.append(message)
-#        print "message = [%s]" % message
-        y = check_blank(before)
-        if not (y is True):
-            rests.append(y)
-        buf = after
-#        print len(after)
+        elif message is None:
+            # unbalanced brace
+            logging.error('unbalanced brace\n%s', indent_snippet('block', after))
+            break
+        else:
+            messages.append(message)
+            buf = after
     return (messages, rests)
 
+if __name__ == '__main__':
+    messages = []
+    rests = []
+    for plugins_filename in sys.argv[2:]:
+        logging.info('processing proto files for plugins in %s', plugins_filename)
+        plugins_dir = os.path.dirname(plugins_filename)
+        with open(plugins_filename) as plugins_file:
+            for plugin_name in plugins_file:
+                plugin_name = plugin_name.strip()
+                if plugin_name[0] == '#': continue
+                proto_file = os.path.join(plugins_dir, plugin_name, '%s.proto' % plugin_name)
+                if not os.path.isfile(proto_file):
+                    logging.debug('no proto file for plugin %s.', plugin_name)
+                    continue
+                logging.debug('processing %s proto', plugin_name)
+                proto_part = get_proto_text(proto_file)
+                (m, r) = parse_proto_part(proto_part)
+                messages.extend(m)
+                rests.extend(r)
 
+    with open(sys.argv[1], "w") as f:
+        f.write(textwrap.dedent("""
+            syntax = "proto2";
+            package panda;
+        """).lstrip())
+        for message in messages:
+            f.write(message + "\n")
+        f.write(textwrap.dedent("""
+            message LogEntry {
+            required uint64 pc = 1;
+            required uint64 instr = 2;
+        """).lstrip())
+        for line in rests:
+            f.write(line + "\n")
+        f.write ("\n}\n" )
 
-
-
-pproto = """
-syntax = "proto2";
-package panda;
-message LogEntry {
-required uint64 pc = 1;
-required uint64 instr = 2;
-"""
-
-
-messages = []
-rests = []
-
-if debug:
-    print("PP: {} {}".format(sys.argv[2], sys.argv[3]))
-
-lines = open(sys.argv[2]).readlines() + open(sys.argv[3]).readlines()
-plugin_dir = os.path.dirname(sys.argv[2])
-for plugin in lines:
-    p = plugin.strip()
-    if (p[0] == '#'): continue
-    proto_part_file = os.path.join(plugin_dir, '%s/%s.proto') % (p, p)
-    if os.path.isfile(proto_part_file):
-        proto_part = get_proto_text(proto_part_file)
-        (m, r) = parse_proto_part(proto_part)
-        messages.extend(m)
-        rests.extend(r)
-
-if len(sys.argv) > 4:
-    if debug:
-        print("PP: processing extra plugins at {}".format(sys.argv[4]))
-    extra_plugin_config = sys.argv[4]
-    extra_plugin_dir = os.path.dirname(extra_plugin_config)
-    for plugin in open(extra_plugin_config):
-        p = plugin.strip()
-        if (p[0] == '#'): continue
-        proto_part_file = os.path.join(extra_plugin_dir, '%s/%s.proto') % (p, p)
-        if os.path.isfile(proto_part_file):
-            proto_part = get_proto_text(proto_part_file)
-            (m, r) = parse_proto_part(proto_part)
-            messages.extend(m)
-            rests.extend(r)
-
-f = open(pproto_filename, "w")
-
-f.write ("""
-syntax = "proto2";
-package panda;
-
-""")
-
-for message in messages:
-    f.write( message + "\n" )
-
-f.write("""
-
-message LogEntry {
-
-required uint64 pc = 1;
-required uint64 instr = 2;
-
-""")
-
-for line in rests:
-    f.write( line + "\n" )
-
-f.write ("\n}\n" )
-
-f.close()
+# vim: set tabstop=4 softtabstop=4 expandtab :


### PR DESCRIPTION
Protobuf parser script was assuming that message blocks could not be nested. This is a false assumption because there are constructs like enumerations which use `{...}` blocks and can be nested inside messages. See: https://developers.google.com/protocol-buffers/docs/proto#enum

This PR improves the protobuf parser script to properly handle nested braces. The script readability is also improved a bit.