### PR TITLE
Add ability to collect coverage data through monitor commands

### DIFF
--- a/hmp-commands.hx
+++ b/hmp-commands.hx
@@ -1838,6 +1838,14 @@ ETEXI
         .cmd = hmp_end_replay,
     },
 
+    {
+        .name       = "plugin_cmd",
+        .args_type  = "cmd:s",
+        .params     = "cmd",
+        .help       = "Execute a plugin monitor command",
+        .cmd        = hmp_panda_plugin_cmd,
+    },
+
 STEXI
 @end table
 ETEXI

--- a/hmp.h
+++ b/hmp.h
@@ -150,5 +150,6 @@ void hmp_end_replay(Monitor *mon, const QDict *qdict);
 void hmp_panda_load_plugin(Monitor *mon, const QDict *qdict);
 void hmp_panda_unload_plugin(Monitor *mon, const QDict *qdict);
 void hmp_panda_list_plugins(Monitor *mon, const QDict *qdict);
+void hmp_panda_plugin_cmd(Monitor *mon, const QDict *qdict);
 
 #endif

--- a/panda/plugins/coverage/USAGE.md
+++ b/panda/plugins/coverage/USAGE.md
@@ -9,6 +9,8 @@ The `coverage` plugin may be run in either of two modes, each of which stores ad
 
 The default behavior is to store a record for each block only the first time it is executed for a given process and thread (for `process` mode) or ASID (for `asid` mode).  However, the `full` option can be used to store a record every time a particular block is executed.  (Due to a known issue, a block which starts execution, but then exits while still in the prologue added by the translator is still recorded as a executed block.  This results in duplicate entries when the block is finally executed to completion after handling whatever interrupted it the first time around.)
 
+When using the `coverage` plugin with a live guest system, it is also possible to enable and disable the instrumentation using monitor commands.  If desired, the plugin can be loaded as normal using PANDA command line arguments, and (optionally) the  `start_disabled=true` argument added to tell the system not to start collecting any data yet.  (The `filename` argument is ignored in this case.)  It is also possible to wait until the guest is up to load the `coverage` plugin, using the standard `load_plugin` command.  Regardless of how the plugin was loaded, the standard  `plugin_cmd` monitor command can then be used to send the `coverage_enable` command to the plugin to start the data collection, or `coverage_disable` can be used to stop data collection.  If no file name is provided with the `coverage_enable` monitor command, then the default, `coverage.csv` is used.
+
 This plugin can be used with the included `coverage.py` script in IDAPython. `coverage.py` colorizes the dissasembly in IDA Pro using the CSV file produced by this plugin.  It also provides options to add comments to the blocks noting the sequence of execution, and/or the thread ID (for `process` mode files).  The `coverage.py` script works best when there are no duplicate records, but it will also work  (more slowly) if the file was produced using the `full` option.
 
 To use the `coverage.py` script, open your target binary in IDA Pro, import the script in the File -> Script Command window, ensure the Scripting Language is set to Python, click Run, and when prompted supply the path to the CSV file and the process or ASID you are analyzing.  You can also turn off the sequence number or  (if applicable) thread ID comments by unchecking the appropriate check box.
@@ -17,10 +19,17 @@ Note, this script assumes IDA has loaded your binary with the correct base addre
 
 Arguments
 ---------
-`filename` - The name of the file to output (default:  `coverage.csv`).
-`mode` - Type of segregation used for blocks (`process` (the default if `-os` is specifed), or `asid`)
-`full` - When `true`, logs each block every time it is executed (default:  `false`)
-`buffer_size` - size of buffer, in bytes, for `filename` (default is `BUFSIZ`, 0=no buffer)
+* `filename` - The name of the file to output (default:  `coverage.csv`).
+* `mode` - Type of segregation used for blocks (`process` (the default if `-os` is specifed), or `asid`)
+* `full` - When `true`, logs each block every time it is executed (default:  `false`)
+* `buffer_size` - size of buffer, in bytes, for `filename` (default is `BUFSIZ`, 0=no buffer)
+* `start_disabled` - When `true`, does not start data collection when the plugin is initialized (default:  `false`)
+
+Monitor Commands
+------------
+* `help` - LIsts the following monitor commands.
+* `coverage_enable` - Start collecting data to the provided file name.  Uses `coverage.csv` if no file name is provided.
+* `coverage_disable` - Stop collecting data, closing the currently open file.
 
 Dependencies
 ------------
@@ -32,8 +41,31 @@ None
 
 Example
 -------
+Use the coverage plugin with a recording:
 ```
 qemu-system-i386 -m 2G -replay test \
     -os windows-32-xpsp3 \
     -panda coverage:filename=test_coverage.csv,mode=process
+```
+Use the coverage plugin on a live system:
+```
+quemu-system-i386 -monitor stdio -m 2G -net nic -net user -os linux-32-.+ -panda osi -panda osi_linux:kconf_file=myconf.conf,kconf_group=mygroup -hda myimage.img
+(qemu) load_plugin coverage,filename=test01.csv,mode=process
+PANDA[core]:initializing coverage
+PANDA[coverage]:output file name test01.csv
+PANDA[coverage]:file buffer_size 8192
+PANDA[coverage]:log all records DISABLED
+PANDA[coverage]:mode process
+PANDA[core]:loading required plugin osi
+PANDA[core]:/omitted/for/sake/of/security/panda_osi.so already loaded
+PANDA[coverage]:start disabled DISABLED
+(qemu) plugin_cmd help
+PANDA[coverage]:coverage_enable=filename:  start logging coverage information to the named file
+PANDA[coverage]:coverage_disable:  stop logging coverage information and close the current file
+...(do something interesting in the guest)...
+(qemu) plugin_cmd coverage_disable
+...(do something do not want recorded)...
+(qemu) plugin_cmd coverage_enable=test02.csv
+...(do something interesting in the guest)...
+(qemu) plugin_cmd coverage_disable
 ```

--- a/panda/plugins/coverage/coverage.cpp
+++ b/panda/plugins/coverage/coverage.cpp
@@ -330,12 +330,12 @@ int monitor_callback(Monitor *mon, const char *cmd)
                         enable_logging(pequal+1);
                     } else {
                         log_message("Instrumentation enabled without filename, "
-                            "using default of ", DEFAULT_FILE);
+                            "using default of", DEFAULT_FILE);
                         enable_logging(DEFAULT_FILE);
                     }
                 } else {
                     log_message("Instrumentation enabled without filename, "
-                        "using default of ", DEFAULT_FILE);
+                        "using default of", DEFAULT_FILE);
                     enable_logging(DEFAULT_FILE);
                 }
                 // if enable_logging failed, it will already have spit out a

--- a/panda/plugins/coverage/coverage.cpp
+++ b/panda/plugins/coverage/coverage.cpp
@@ -17,7 +17,18 @@ PANDAENDCOMMENT */
 #include "osi/osi_types.h"
 #include "osi/osi_ext.h"
 
-static FILE *coveragelog;
+const char *DEFAULT_FILE = "coverage.csv";
+
+// commands that can be accessed through the QEMU monitor
+const char *MONITOR_HELP = "help";
+constexpr size_t MONITOR_HELP_LEN = 4;
+const char *MONITOR_ENABLE = "coverage_enable";
+constexpr size_t MONITOR_ENABLE_LEN = 15;
+const char *MONITOR_DISABLE = "coverage_disable";
+constexpr size_t MONITOR_DISABLE_LEN = 16;
+
+
+static FILE *coveragelog = NULL;
 
 enum coverage_mode {
     MODE_PROCESS = 0,
@@ -60,10 +71,33 @@ bool operator==(const RecordID &lhs, const RecordID &rhs)
     return result;
 }
 
+// the pointer passed in to init_plugin
+void *coverage_plugin = nullptr;
+
 coverage_mode mode = MODE_ASID;
+panda_cb pcb_before_block_exec;
+uint32_t buffer_size = BUFSIZ;
+bool enabled = false;
+bool before_block_exec_registered = false;
+
+static void log_message(const char *message)
+{
+    printf("%s%s\n", PANDA_MSG, message);
+}
+
+static void log_message(const char *message1, const char *message2)
+{
+    printf("%s%s %s\n", PANDA_MSG, message1, message2);
+}
+
+static void log_message(const char *message, uint32_t number)
+{
+    printf("%s%s %d\n", PANDA_MSG, message, number);
+}
 
 void write_process_record(RecordID id, uint64_t size)
 {
+
     // Get the process name
     char *process_name = NULL;
     bool in_kernel = panda_in_kernel(first_cpu);
@@ -93,6 +127,11 @@ void write_process_record(RecordID id, uint64_t size)
 
 int before_block_exec_process_full(CPUState *cpu, TranslationBlock *tb)
 {
+    // part of workaround to broken enable/disable plugin callback framework
+    if (!enabled) {
+        return 0;
+    }
+
     RecordID id;
     id.pc = tb->pc;
     OsiThread *thread = get_current_thread(cpu);
@@ -112,6 +151,11 @@ int before_block_exec_process_full(CPUState *cpu, TranslationBlock *tb)
 
 int before_block_exec_process_unique(CPUState *cpu, TranslationBlock *tb)
 {
+    // part of workaround to broken enable/disable plugin callback framework
+    if (!enabled) {
+        return 0;
+    }
+
     // We keep track of PID/TID/PC tuples that we've already seen
     // since we only need to write out distinct tuples once.
     static std::unordered_set<RecordID> seen;
@@ -155,6 +199,11 @@ void write_asid_record(RecordID id, uint64_t size)
 
 int before_block_exec_asid_full(CPUState *cpu, TranslationBlock *tb)
 {
+    // part of workaround to broken enable/disable plugin callback framework
+    if (!enabled) {
+        return 0;
+    }
+
     RecordID id;
     id.pc = tb->pc;
     id.pidOrAsid = panda_current_asid(first_cpu);
@@ -165,6 +214,11 @@ int before_block_exec_asid_full(CPUState *cpu, TranslationBlock *tb)
 
 int before_block_exec_asid_unique(CPUState *cpu, TranslationBlock *tb)
 {
+    // part of workaround to broken enable/disable plugin callback framework
+    if (!enabled) {
+        return 0;
+    }
+
     // We keep track of pairs of ASIDs and PCs that we've already seen
     // since we only need to write out distinct pairs once.
     static std::unordered_set<RecordID> seen;
@@ -182,6 +236,123 @@ int before_block_exec_asid_unique(CPUState *cpu, TranslationBlock *tb)
     return 0;
 }
 
+bool enable_logging(const char *filename)
+{
+    // Open the coverage CSV file, and set up the file buffering
+    coveragelog = fopen(filename, "w");
+    if (BUFSIZ != buffer_size) {
+        int buf_mode = _IOFBF;
+        // If buffer_size is 0, then turn off buffering
+        if (0 == buffer_size) {
+            buf_mode = _IONBF;
+        }
+        // Let setvbuf take care of allocating and freeing buffer
+        int ret_code = setvbuf(coveragelog, NULL, buf_mode, buffer_size);
+        if (0 != ret_code) {
+            LOG_ERROR("could not change buffer size");
+            return false;
+        }
+    }
+
+    // Output headers
+    if (MODE_PROCESS == mode) {
+        fprintf(coveragelog, "process\n");
+        fprintf(coveragelog, "process name,process id,thread id,in kernel,"
+                "block address,block size\n");
+    } else {
+        fprintf(coveragelog, "asid\n");
+        fprintf(coveragelog, "asid,in kernel,block address,block size\n");
+    }
+
+    // Register callback
+    // it would be nice if we could use panda_enable_callback and
+    // panda_disable_callback to enable and disable instrumentation, but that
+    // framework is broken - see public PANDA issue 451
+    if (!before_block_exec_registered) {
+        panda_register_callback(coverage_plugin, PANDA_CB_BEFORE_BLOCK_EXEC,
+            pcb_before_block_exec);
+        before_block_exec_registered = true;
+    }
+
+    enabled = true;
+    return true;
+}
+
+
+void disable_logging()
+{
+    if (coveragelog != NULL) {
+        // this is where we would like to call panda_disable_callback (assuming
+        // the callback has been registered), if the framework were using the
+        // callback's enabled flag properly - see public PANDA issue 451
+        fclose(coveragelog);
+        coveragelog = NULL;
+        enabled = false;
+    }
+}
+
+int monitor_callback(Monitor *mon, const char *cmd)
+{
+    char *cmd_copy = g_strdup(cmd);
+    char *word;
+    char *pequal;
+    size_t wordlen;
+
+    word = strtok(cmd_copy, " ");
+    do {
+        if (0 == strncmp(MONITOR_HELP, word, MONITOR_HELP_LEN)) {
+            // yes there is a nice monitor_printf function in monitor.h, but
+            // attempting to include that file in a plugin causes great grief
+            log_message("coverage_enable=filename:  start logging "
+                    "coverage information to the named file");
+            log_message("coverage_disable:  stop logging coverage "
+                    "information and close the current file");
+        } else if (0 == strncmp(MONITOR_DISABLE, word, MONITOR_DISABLE_LEN)) {
+            if (enabled) {
+                disable_logging();
+            } else {
+                log_message(
+                  "Instrumentation not enabled, ignoring request to disable");
+            }
+        } else if (0 == strncmp(MONITOR_ENABLE, word, MONITOR_ENABLE_LEN)) {
+            // we know word at least STARTS with coverage_enable
+            if (!enabled) {
+                pequal=strchr(word, '=');
+                if (pequal != NULL) {
+                    // extract after = as new filename
+                    wordlen = strlen(word);
+                    if (wordlen > (MONITOR_ENABLE_LEN+1)) {
+                        // I really, really don't want to allocate new memory
+                        // for the file name every time enable, and as I can't
+                        // predict the maximum filename length that doesn't
+                        // leave me with much choice on how to send the filename
+                        // to enable_logging
+                        enable_logging(pequal+1);
+                    } else {
+                        log_message("Instrumentation enabled without filename, "
+                            "using default of ", DEFAULT_FILE);
+                        enable_logging(DEFAULT_FILE);
+                    }
+                } else {
+                    log_message("Instrumentation enabled without filename, "
+                        "using default of ", DEFAULT_FILE);
+                    enable_logging(DEFAULT_FILE);
+                }
+                // if enable_logging failed, it will already have spit out a
+                // warning, which is most can do here
+            } else {
+                log_message("Instrumentation already enabled, ignoring "
+                        "request to enable");
+            }
+        }
+        word = strtok(NULL, " ");
+    } while (word != NULL);
+    g_free(cmd_copy);
+
+    // return value is ignored, so doesn't matter what return
+    return 1;
+}
+
 // These need to be extern "C" so that the ABI is compatible with QEMU/PANDA
 extern "C" {
 bool init_plugin(void *self);
@@ -190,11 +361,13 @@ void uninit_plugin(void *self);
 
 bool init_plugin(void *self)
 {
+    coverage_plugin = self;
+
     // Get Plugin Arguments
     panda_arg_list *args = panda_get_args("coverage");
     const char *filename =
-        panda_parse_string(args, "filename", "coverage.csv");
-    printf("%soutput file name %s\n", PANDA_MSG, filename);
+        panda_parse_string(args, "filename", DEFAULT_FILE);
+    log_message("output file name", filename);
 
     const char *mode_arg;
     if (OS_UNKNOWN == panda_os_familyno) {
@@ -213,77 +386,71 @@ bool init_plugin(void *self)
         return false;
     }
 
-    uint32_t buffer_size = panda_parse_uint32_opt(args, "buffer_size", BUFSIZ,
+    buffer_size = panda_parse_uint32_opt(args, "buffer_size", BUFSIZ,
         "size of output buffer (default=BUFSIZ)");
     // Don't use LOG_INFO because I always want to see the informational
     // messages (which aren't on by default)
-    printf("%sfile buffer_size %d\n", PANDA_MSG, buffer_size);
+    log_message("file buffer_size", buffer_size);
 
     bool log_all_records = panda_parse_bool_opt(args, "full",
             "log all records instead of just uniquely identified ones");
-    printf("%slog all records %s\n", PANDA_MSG,
-            PANDA_FLAG_STATUS(log_all_records));
+    log_message("log all records", PANDA_FLAG_STATUS(log_all_records));
 
     if (MODE_PROCESS == mode) {
         if (OS_UNKNOWN == panda_os_familyno) {
             LOG_WARNING("no OS specified, switching to asid mode");
             mode = MODE_ASID;
         } else {
-            printf("%smode process\n", PANDA_MSG);
+            log_message("mode process");
             panda_require("osi");
             assert(init_osi_api());
         }
     } else {
-        printf("%smode asid\n", PANDA_MSG);
+        log_message("mode asid");
     }
 
-    // Open the coverage CSV file, and set up the file buffering
-    panda_cb pcb;
-    coveragelog = fopen(filename, "w");
-    if (BUFSIZ != buffer_size) {
-        int buf_mode = _IOFBF;
-        // If buffer_size is 0, then turn off buffering
-        if (0 == buffer_size) {
-            buf_mode = _IONBF;
-        }
-        // Let setvbuf take care of allocating and freeing buffer
-        int ret_code = setvbuf(coveragelog, NULL, buf_mode, buffer_size);
-        if (0 != ret_code) {
-            LOG_ERROR("could not change buffer size");
-            return false;
-        }
-    }
+    bool start_disabled = panda_parse_bool_opt(args, "start_disabled",
+            "start the plugin with instrumentation disabled");
+    log_message("start disabled", PANDA_FLAG_STATUS(start_disabled));
 
-    // Output headers, and select appropriate callback
+    // remember what callback should be used when logging is enabled
     // we're trying to avoid making decisions during data collection, especially
     // when logging all records, to make things go faster
     if (MODE_PROCESS == mode) {
-        fprintf(coveragelog, "process\n");
-        fprintf(coveragelog, "process name,process id,thread id,in kernel,"
-                "block address,block size\n");
         if (log_all_records) {
-            pcb.before_block_exec = before_block_exec_process_full;
+            pcb_before_block_exec.before_block_exec =
+                    before_block_exec_process_full;
         } else {
-            pcb.before_block_exec = before_block_exec_process_unique;
+            pcb_before_block_exec.before_block_exec =
+                    before_block_exec_process_unique;
         }
     } else {
-        fprintf(coveragelog, "asid\n");
-        fprintf(coveragelog, "asid,in kernel,block address,block size\n");
         if (log_all_records) {
-            pcb.before_block_exec = before_block_exec_asid_full;
+            pcb_before_block_exec.before_block_exec =
+                    before_block_exec_asid_full;
         } else {
-            pcb.before_block_exec = before_block_exec_asid_unique;
+            pcb_before_block_exec.before_block_exec =
+                    before_block_exec_asid_unique;
         }
     }
 
-    // Register callback
-    panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+    bool all_ok = true;
+    if (!start_disabled)
+    {
+        all_ok = enable_logging(filename);
+    }
 
-    return true;
+    if (all_ok)
+    {
+        panda_cb pcb;
+        pcb.monitor = monitor_callback;
+        panda_register_callback(self, PANDA_CB_MONITOR, pcb);
+    }
+
+    return all_ok;
 }
 
 void uninit_plugin(void *self) 
 {
-    fclose(coveragelog);
-    coveragelog = NULL;
+    disable_logging();
 }

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -925,9 +925,6 @@ void qmp_plugin_cmd(const char * cmd, Error **errp) {
     
 }
 
-void hmp_panda_plugin_cmd(Monitor *mon, const QDict *qdict);
-
-
 // HMP
 void hmp_panda_load_plugin(Monitor *mon, const QDict *qdict) {
     Error *err;


### PR DESCRIPTION
Enhanced coverage plugin so that monitor commands can be used to enable and disable the collection of coverage data.
This required fixing the monitor callback framework (thank you @nathanjackson ) so it was hooked up properly.