### PR TITLE
panda_get_retval() inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@
 /docs/qemu-qmp-ref.info*
 /docs/qemu-qmp-ref.txt
 /docs/version.texi
+/panda/plugins/*/docs/
 *.tps
 .stgit-*
 cscope.*

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -312,26 +312,40 @@ are hoping to support dynamic configuration of code generation soon.
 
 
 #### Miscellany
-```C
-void panda_memsavep(FILE *out);
-```
-Saves a physical memory snapshot into the open file pointer `out`. This function
-is guaranteed not to perturb guest state.
-```C
-target_ulong panda_current_asid(CPUState *env);
-```
-Returns the current asid for a variety of architectures (`cr3` for x86, e.g.).
-```C
-bool panda_in_kernel(CPUState *env);
-```
-Returns true if the processor is in the privilege level corresponding to
-executing kernel code for various architectures.
-
-```C
-void panda_disas(FILE *out, void *code, unsigned long size);
-```
-Writes a textual representation of disassembly of the guest code at virtual
-address `code` of `size` bytes.
+  * ```C
+    void panda_memsavep(FILE *out);
+    ```
+    Saves a physical memory snapshot into the open file pointer `out`.
+    This function is guaranteed not to perturb guest state.
+  * ```C
+    target_ulong panda_current_asid(CPUState *cpu);
+    ```
+    Returns the current asid for any of the PANDA supported
+    architectures (e.g. `cr3` for x86).
+  * ```C
+    bool panda_in_kernel(CPUState *cpu);
+    ```
+    Returns `true` if the processor is in the privilege level
+    corresponding to executing kernel code for any of the PANDA
+    supported architectures.
+  * ```C
+    target_ulong panda_current_sp(CPUState *cpu);
+    ```
+    Returns the guest stack pointer for any of the PANDA supported
+    architectures.
+  * ```C
+    target_ulong panda_get_retval(CPUState *cpu);
+    ```
+    Retrieves the return value of a returned call for any of the
+    PANDA supported architectures. The function has to be called in
+    the proper context in order to return a meaningful value. If the
+    context is not right (i.e. the return value has already been
+    overwritten), it will return garbage.
+  * ```C
+    void panda_disas(FILE *out, void *code, unsigned long size);
+    ```
+    Writes a textual representation of disassembly of the guest code
+    at virtual address `code` of `size` bytes.
 
 ## Record/Replay Details
 

--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -180,11 +180,33 @@ static inline target_ulong panda_current_sp(CPUState *cpu) {
     // R1 on PPC.
     return env->gpr[1];
 #else
-#error "panda_current_asid() not implemented for target architecture."
+#error "panda_current_sp() not implemented for target architecture."
     return 0;
 #endif
 }
 
+/**
+ * @brief Returns the return value of the guest.
+ * The function is only meant to provide a platform-independent
+ * abstraction for retrieving a call return value. It still has to
+ * be used in the proper context to retrieve a meaningful value.
+ */
+static inline target_ulong panda_get_retval(CPUState *cpu) {
+    CPUArchState *env = (CPUArchState *)cpu->env_ptr;
+#if defined(TARGET_I386)
+    // EAX for x86.
+    return env->regs[R_EAX];
+#elif defined(TARGET_ARM)
+    // R0 on ARM.
+    return env->regs[0];
+#elif defined(TARGET_PPC)
+    // R3 on PPC.
+    return env->gpr[3];
+#else
+#error "panda_get_retval() not implemented for target architecture."
+    return 0;
+#endif
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Somehow this was still missing. Yet another wrapper function that abstracts platform details.