### PR TITLE
Pypanda: support for changing between record/replay/live modes plus general cleanup

### DIFF
--- a/include/qemu/rcu.h
+++ b/include/qemu/rcu.h
@@ -105,6 +105,7 @@ extern void synchronize_rcu(void);
  */
 extern void rcu_register_thread(void);
 extern void rcu_unregister_thread(void);
+extern void kill_rcu_thread(void);
 extern void rcu_after_fork(void);
 
 struct rcu_head;

--- a/include/sysemu/cpus.h
+++ b/include/sysemu/cpus.h
@@ -26,6 +26,7 @@ void cpu_synchronize_all_post_reset(void);
 void cpu_synchronize_all_post_init(void);
 
 void qtest_clock_warp(int64_t dest);
+void kill_tcg_thread(void);
 
 #ifndef CONFIG_USER_ONLY
 /* vl.c */

--- a/panda/include/panda/panda_api.h
+++ b/panda/include/panda/panda_api.h
@@ -29,16 +29,15 @@ void panda_disable_llvm_helpers(void);
 void panda_memsavep(FILE *f);
 
 // from panda_api.c
-int panda_pre(int argc, char **argv, char **envp);
 int panda_init(int argc, char **argv, char **envp);
 int panda_run(void);
-void panda_stop(void);
+void panda_stop(int code);
 void panda_cont(void);
+void panda_start_pandalog(const char *name);
 int panda_revert(char *snapshot_name);
 int panda_snap(char *snapshot_name);
 int panda_replay(char *replay_name);
 int panda_finish(void);
-
 
 void panda_set_qemu_path(char* filepath);
 
@@ -59,11 +58,9 @@ bool panda_in_kernel_external(CPUState *cpu);
 
 //void panda_monitor_run(char* buf, uint32_t len);
 int panda_delvm(char *snapshot_name);
-void panda_exit_emul_loop(void);
-
-
 
 #ifdef PYPANDA
+
 // Create a monitor for panda
 void panda_init_monitor(void);
 

--- a/panda/include/panda/panda_common.h
+++ b/panda/include/panda/panda_common.h
@@ -6,6 +6,10 @@ void panda_cleanup(void);
 void panda_set_os_name(char *os_name);
 void panda_before_find_fast(void);
 void panda_disas(FILE *out, void *code, unsigned long size);
+void panda_break_main_loop(void);
+
+extern bool panda_break_cpu_loop_req;
+extern bool panda_break_vl_loop_req;
 
 /*
  * @brief Returns the guest address space identifier.

--- a/panda/plugins/scissors/scissors.c
+++ b/panda/plugins/scissors/scissors.c
@@ -24,8 +24,6 @@ int before_block_exec(CPUState *env, TranslationBlock *tb);
 void check_start_snip(CPUState *env);
 void check_end_snip(CPUState *env);
 
-extern bool panda_exit_loop;
-
 static uint64_t start_count;
 static uint64_t actual_start_count;
 static uint64_t end_count;
@@ -344,11 +342,11 @@ void check_end_snip(CPUState *env) {
 int before_block_exec(CPUState *env, TranslationBlock *tb) {
     uint64_t count = rr_get_guest_instr_count();
     if (!snipping && count+tb->icount > start_count) {
-        panda_exit_loop = true;
+        panda_break_cpu_loop_req = true;
         request_start_snip = true;
     }
     if (snipping && !done && count > end_count) {
-        panda_exit_loop = true;
+        panda_break_cpu_loop_req = true;
         request_end_snip = true;
         rr_end_replay_requested = 1;
     }

--- a/panda/pypanda/.gitignore
+++ b/panda/pypanda/.gitignore
@@ -1,0 +1,3 @@
+*-rr-snp
+*.plog
+*.recording

--- a/panda/pypanda/asyncthread.py
+++ b/panda/pypanda/asyncthread.py
@@ -1,6 +1,6 @@
 import threading
 import functools
-from queue import Queue
+from queue import Queue, Empty
 from time import sleep
 from colorama import Fore, Style
 
@@ -27,28 +27,38 @@ class AsyncThread:
         self.athread.start()
 
     def stop(self):
-        # XXX: This doesn't work until a command finishes
         self.running = False
 
     def queue(self, func): # Queue a function to be run soon. Must be @blocking
+        if not func:
+            raise RuntimeError("Queued up an undefined function")
         if not (hasattr(func, "__blocking__")) or not func.__blocking__:
             raise RuntimeError("Refusing to queue function '{}' without @blocking decorator".format(func.__name__))
         self.task_queue.put_nowait(func)
 
     def run(self): # Run functions from queue
         #name = threading.get_ident()
-
-
         while self.running: # Note setting this to false will take some time
-            func = self.task_queue.get() # Implicit (blocking) wait
-            # Don't interact with guest if it isn't running 
-            self.panda_started.wait()
+            try: # Try to get an item repeatedly, but also check if we want to stop running
+                func = self.task_queue.get(True, 1) # Implicit (blocking) wait for 1s
+            except Empty:
+                continue
 
+            # Don't interact with guest if it isn't running
+            # Wait for self.panda_started, but also abort if running becomes false
+            while not self.panda_started and self.running:
+                try:
+                    self.panda_started.wait(True, 1)
+                except Empty:
+                    continue
+
+            if not self.running:
+                break
             try:
-                #print(f"{name} calling {func}")
+                print(f"Calling {func.__name__}")
+                # XXX: If running become false while func is running we need a way to kill it
                 func()
             except Exception as e:
-                #print(f"{name} exception {e!r}")
                 print("exception {}".format(e))
                 raise
             finally:
@@ -60,20 +70,25 @@ if __name__ == '__main__':
     # Should output t0 three times, then maybe t1 three times, then shutdown
     from time import sleep
 
-    a = AsyncThread()
+    started = threading.Event()
+    a = AsyncThread(started)
 
     def afunc():
         for x in range(3):
-            print("afunc: t{}")
-            sleep(10)
+            print("afunc: t{}".format(x))
+            sleep(1)
+
+    afunc.__blocking__ = "placeholder" # Hack to pretend it's decorated
 
     print("\nQueuing up functions...")
     a.queue(afunc)
     a.queue(afunc)
     a.queue(afunc)
 
-    print("\nAll queued. Wait 1s")
+    print("\nAll queued. Wait 5s")
     sleep(5)
 
     print("\nBegin shutdown")
     a.stop()
+
+    # Expected output: t0, t1, t2, t0, t1

--- a/panda/pypanda/create_panda_datatypes.py
+++ b/panda/pypanda/create_panda_datatypes.py
@@ -280,4 +280,3 @@ with open("include/panda_datatypes.h", "w") as pdth:
     # probably a better way... 
     pdth.write("typedef target_ulong target_ptr_t;\n")
     include_this("../include/panda/panda_common.h")
-

--- a/panda/pypanda/example_args.py
+++ b/panda/pypanda/example_args.py
@@ -41,11 +41,9 @@ def before_block_execute(cpustate, transblock):
         panda.unload_plugin("coverage")
         progress("Unloaded coverage plugin")
 
-    """
-    if blocks > 20000:
-        progress("Saw 100 BBs. Stopping")
-        panda.stop()
-    """
+    if blocks > 200:
+        progress("Saw 200 BBs. Stopping")
+        panda.stop_run()
 
     blocks += 1
     return 0

--- a/panda/pypanda/example_network.py
+++ b/panda/pypanda/example_network.py
@@ -9,7 +9,6 @@ writes the buffer out to a pcap.
 Run with: python3 example_network.py i386 out.pcap /path/to/recording
 '''
 from pypanda import *
-from time import sleep
 from sys import argv
 from scapy.all import Ether, wrpcap
 

--- a/panda/pypanda/example_plugin.py
+++ b/panda/pypanda/example_plugin.py
@@ -9,15 +9,24 @@ Run this with python3 example_plugin.py
 
 '''
 from pypanda import *
+from time import sleep
 from sys import argv
 
 # Single arg of arch, defaults to i386
 arch = "i386" if len(argv) <= 1 else argv[1]
 panda = Panda(generic=arch)
 
-@panda.cb_before_block_exec()
+@panda.callback.init
+def init(handle):
+	progress("init in python. handle="+str(handle))
+	panda.register_callback(handle, panda.callback.before_block_exec, \
+	 						before_block_execute)
+	return True
+
+@panda.callback.before_block_exec
 def before_block_execute(cpustate,transblock):
 	progress("Before Block Run")
 	return 0
 
+panda.load_python_plugin(init,"example_plugin")
 panda.run()

--- a/panda/pypanda/example_record_replay_broken.py
+++ b/panda/pypanda/example_record_replay_broken.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+'''
+example_record_replay.py
+
+Registers asid_changed and runs a replay from a file specified.
+
+Run with: python3 example_record_replay.py i386 /path/to/recording
+'''
+from pypanda import *
+from time import sleep
+from sys import argv
+
+# Single arg of arch, defaults to i386
+arch = "i386" if len(argv) <= 1 else argv[1]
+panda = Panda(generic=arch)
+
+#@panda.callback.init
+#def init(handle):
+#	panda.register_callback(handle, panda.callback.asid_changed, asid_changed)
+#	return True
+
+@panda.cb_asid_changed()
+def asid_changed(cpustate,old_asid, new_asid):
+	if old_asid != new_asid:
+		progress("asid changed from %d to %d" %(old_asid, new_asid))
+	return 0
+
+#replay_file = argv[2]
+#panda.begin_replay(replay_file)
+panda.run()

--- a/panda/pypanda/example_run_multiarch.py
+++ b/panda/pypanda/example_run_multiarch.py
@@ -3,9 +3,8 @@
 from pypanda import *
 from sys import argv
 
+# XXX This doesn't work
 # Re-initialize panda object as various pandas of different archicectures
-
-# XXX: Doesn't currently work
 
 @blocking
 def run_cmd():
@@ -17,6 +16,7 @@ def run_cmd():
 def quit():
     panda.run_monitor_cmd("quit")
 
+# XXX: Generally you can't recreate the panda object, but it can be done here because the arch is changing
 for arch in ["x86_64", "i386", "arm", "ppc"]:
     progress(f"Starting {arch}")
     panda = Panda(generic=arch)

--- a/panda/pypanda/example_stop.py
+++ b/panda/pypanda/example_stop.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Example script to stop an analysis as cleanly as we can
+
+from pypanda import Panda
+from sys import argv
+
+# Single arg of arch, defaults to i386
+arch = "i386" if len(argv) <= 1 else argv[1]
+panda = Panda(generic=arch)
+
+block_count = 0
+@panda.cb_before_block_exec(name="before")
+def before_block_execute(cpustate, transblock):
+    global block_count
+
+    if block_count == 10:
+        print("Finished with 10 BBs. Loading coverage plugin to start analysis")
+        panda.load_plugin("coverage")
+
+    if block_count == 100:
+        print("\n\n")
+        print("Saw 100 BBs. End analysis")
+        panda.end_analysis()
+        print("\n\n")
+
+    assert(block_count <= 100), "Callback run after call to end analysis"
+
+    block_count += 1
+    return 0
+panda.run()
+print("Finished")  # Note this won't run until after end_analysis

--- a/panda/pypanda/experimental/example_plugin_arm.py
+++ b/panda/pypanda/experimental/example_plugin_arm.py
@@ -17,18 +17,11 @@ from sys import argv
 arch = "arm" if len(argv) <= 1 else argv[1]
 panda = Panda(generic=arch,arch=arch)
 
-@panda.callback.init
-def init(handle):
-	progress("init in python. handle="+str(handle))
-	panda.register_callback(handle, panda.callback.before_block_exec, \
-	 						before_block_execute)
-	return True
 
-@panda.callback.before_block_exec
+@panda.cb_before_block_exec()
 def before_block_execute(cpustate,transblock):
 	arm_cpustate = panda.get_cpu(cpustate)
 	progress("PC: "+str(arm_cpustate.pc))
 	return 0
 
-panda.load_python_plugin(init,"example_plugin")
 panda.run()

--- a/panda/pypanda/include/panda_datatypes.h
+++ b/panda/pypanda/include/panda_datatypes.h
@@ -864,16 +864,15 @@ void panda_disable_llvm_helpers(void);
 void panda_memsavep(FILE *f);
 
 // from panda_api.c
-int panda_pre(int argc, char **argv, char **envp);
 int panda_init(int argc, char **argv, char **envp);
 int panda_run(void);
-void panda_stop(void);
+void panda_stop(int code);
 void panda_cont(void);
+void panda_start_pandalog(const char *name);
 int panda_revert(char *snapshot_name);
 int panda_snap(char *snapshot_name);
 int panda_replay(char *replay_name);
 int panda_finish(void);
-
 
 void panda_set_qemu_path(char* filepath);
 
@@ -894,8 +893,6 @@ bool panda_in_kernel_external(CPUState *cpu);
 
 //void panda_monitor_run(char* buf, uint32_t len);
 int panda_delvm(char *snapshot_name);
-void panda_exit_emul_loop(void);
-
 
 
 // Create a monitor for panda
@@ -951,6 +948,10 @@ void panda_cleanup(void);
 void panda_set_os_name(char *os_name);
 void panda_before_find_fast(void);
 void panda_disas(FILE *out, void *code, unsigned long size);
+void panda_break_main_loop(void);
+
+extern bool panda_break_cpu_loop_req;
+extern bool panda_break_vl_loop_req;
 
 /*
  * @brief Returns the guest address space identifier.

--- a/panda/pypanda/panda_expect.py
+++ b/panda/pypanda/panda_expect.py
@@ -32,7 +32,7 @@ class Expect(object):
         self.running = True
         self.expectation = expectation
 
-        # If cosuned_first is false, we'll consume a message before anything else. Requires self.expectation to be set
+        # If consumed_first is false, we'll consume a message before anything else. Requires self.expectation to be set
         self.consumed_first = True
         if consume_first:
             self.consumed_first = False
@@ -79,7 +79,7 @@ class Expect(object):
 
                     if b"\r\n" in sofar: # Serial will echo our command back, try to strip it out
                         resp = sofar.split(b"\r\n")
-                        if self.last_msg and resp[0].decode('utf8').replace(" \r", "").strip() == self.last_msg.decode('utf8').strip():
+                        if self.last_msg and resp[0].decode('utf8', 'ignore').replace(" \r", "").strip() == self.last_msg.decode('utf8', 'ignore').strip():
                             resp[:] = resp[1:] # drop last cmd
 
                         if resp[-1].decode('utf8') == expectation:

--- a/panda/pypanda/plog.py
+++ b/panda/pypanda/plog.py
@@ -93,3 +93,11 @@ class PLogReader:
             self.chunk_data_idx = 0
 
         return msg
+
+if __name__ == "__main__":
+    print('[')
+    with PLogReader(sys.argv[1]) as plr:
+        for i, m in enumerate(plr):
+            if i > 0: print(',')
+            print(MessageToJson(m), end='')
+    print('\n]')

--- a/panda/pypanda/qcows.py
+++ b/panda/pypanda/qcows.py
@@ -20,7 +20,7 @@ Arch = namedtuple('Arch', ['dir',        'arch',    'binary',             'os', 
 Arch.__new__.__defaults__ = (None,None)
 SUPPORTED_ARCHES = {
         'i386':   Arch('i386-softmmu',   'i386',   'qemu-system-i386',   "linux-32-debian:3.2.0-4-686-pae", "root@debian-i386:~# ",    "wheezy_panda2.qcow2", "ide1-cd0", "root"),
-        'x86_64': Arch('x86_64-softmmu', 'x86_64', 'qemu-system-x86_64', "linux-64-debian:x.y.z-arm64-pae", "root@debian-amd64:~# ",   "wheezy_x64.qcow2",    "ide1-cd0", "root"),
+        'x86_64': Arch('x86_64-softmmu', 'x86_64', 'qemu-system-x86_64', "linux-64-debian:x.y.z-amd64-pae", "root@debian-amd64:~# ",   "wheezy_x64.qcow2",    "ide1-cd0", "root"),
         'ppc':    Arch('ppc-softmmu',    'ppc',    'qemu-system-ppc',    "linux-32-debian:x.y.z-ppc-pae",
             
             "root@debian-powerpc:~# ", "ppc_wheezy.qcow",     "ide1-cd0", "root"),

--- a/panda/pypanda/rodeo-record.py
+++ b/panda/pypanda/rodeo-record.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+from pypanda import *
+from sys import argv
+import subprocess
+import os
+import shlex
+# Take a recording of a program running, then 
+# replay and do a tainted_branch analysis on the recording
+
+# Single arg of arch, defaults to i386
+arch = "i386" if len(argv) <= 1 else argv[1]
+panda = Panda(generic=arch, extra_args = "")
+
+name = None
+
+"""
+import glob
+files = glob.glob("/nas/andrew/rode0day/clean/bins/14_jpegS-122_D1V-5D3V-lava-corpus-2018-09-20-17-15-17/inputs/*")
+"""
+
+# Record, then replay with plugins
+@blocking
+def record():
+    global name
+    input_name = "testorig-fuzzed-1028.jpg"
+
+    guest_command = "/mnt/lava-install-public/bin/memdjpeg /mnt/inputs/" + input_name
+    copy_directory = "/nas/andrew/rode0day/clean/bins/14_jpegS-122_D1V-5D3V-lava-corpus-2018-09-20-17-15-17"
+    #panda.run_monitor_cmd("c")
+    panda.record_cmd(guest_command, copy_directory, recording_name=name+".recording")
+    progress("All done with recording")
+    #panda.run_monitor_cmd("stop")
+    panda.stop_run()
+
+@blocking
+def cont():
+    print("CONT")
+    print(panda.run_monitor_cmd("c"))
+    print("CONT end")
+
+def prepare_replay(name_):
+    global name
+    name = name_
+    input_name = "testorig-fuzzed-1028.jpg"
+    """
+    panda.load_plugin("taint2", {"no_tp": True})
+    panda.load_plugin("tainted_branch")
+    panda.load_plugin("file_taint", args={"cache_process_details_on_basic_block": True, "pos": True,
+                                          "filename": "/mnt/inputs/"+ input_name, "enable_taint_on_open": True})
+    """
+    panda.set_pandalog(name+".plog")
+
+    progress("\nRun replay {} => {}".format(name+".plog", name+".recording"))
+    panda.begin_replay(name+".recording") # XXX: when replay ends main thread will progress past panda.run()
+
+def analyze():
+    global name
+    print("Done running panda. Now let's parse the plog")
+
+    count = 0
+    tainted_branch_pcs = set()
+    with PLogReader(name+".plog") as plr:
+        for i, m in enumerate(plr):
+            if m.HasField('tainted_branch'):
+                #print(m.pc, m.instr)
+                tainted_branch_pcs.add(m.pc)
+                count+=1
+    print('\n]')
+
+    print("Total taint branch count = {}".format(count))
+    print("Unique PCs of tainted branches = {}".format(len(tainted_branch_pcs)))
+
+
+names = ["jpeg1", "jpeg2"]
+
+# XXX Can't do record,replay,record. But maybe can do record,record,replay,replay
+
+# First take two recordings
+for name in names:
+    print("\nRECORD {}".format(name))
+    panda.queue_async(record)
+    panda.run()
+
+# Then analyze the replays and build plogs
+for name in names:
+    #prepare_replay(name)
+    panda.begin_replay(name+".recording") # XXX: when replay ends main thread will progress past panda.run()
+    panda.run()
+
+# Finally analyze the plogs
+for name in names:
+    print("ANALYZE {}".format(name))
+    analyze()

--- a/panda/pypanda/taint.py
+++ b/panda/pypanda/taint.py
@@ -1,103 +1,116 @@
 #!/usr/bin/env python3
 
 from pypanda import *
-from panda_x86_helper import *
-from sys import argv, stdout
 import os
-#from capstone import *
 
-#md = Cs(CS_ARCH_X86, CS_MODE_64)
-
+qcowpath = os.getenv("HOME") + "/.panda/debian:3.2.0-4-686-pae-i386-128M.qcow"
 
 
-arch = "i386" if len(argv) <= 1 else argv[1]
-panda = Panda(generic=arch)
-
-#qcowpath = os.getenv("HOME") + "/.panda/debian:3.2.0-4-686-pae-i386-128M.qcow"
-
-
-#panda = Panda(qcow=qcowpath, extra_args="-D ./qemu.log -d in_asm") 
+panda = Panda(qcow=qcowpath, extra_args="-D ./qemu.log -d in_asm") 
 
 
 
 state = 0 # before snapshot load
 
-@panda.cb_after_machine_init(name="init")
+@panda.callback.after_machine_init
 def machinit(env):
-        global state
+	global state
 
-        progress("Machine initialized -- disabling chaining & reverting to booted snapshot\n")
-        panda.disable_tb_chaining()
-        panda.delvm("newroot", now=True)
-        pc = panda.current_pc(env)
-        panda.revert("root", now=True)
-        pc = panda.current_pc(env)
-        progress("After revert: pc=%lx" % pc)
-        state = 1
+	progress("Machine initialized -- disabling chaining & reverting to booted snapshot\n")
+	panda.disable_tb_chaining()
+	panda.delvm("newroot", now=True)
+	pc = panda.current_pc(env)
+	panda.revert("root", now=True)
+	pc = panda.current_pc(env)
+	progress("After revert: pc=%lx" % pc)
+	state = 1
 
 
 
-#init_done = False
+init_done = False
 
 nt = 0
 
-@panda.cb_before_block_exec_invalidate_opt(name="bb")
+
+
+@panda.callback.before_block_exec
 def before_block_exec(env,tb):
-        global nt
-        global state
+	global nt
+	global state
+	if not init_done:
+		return 0
 
-        if state == 0:
-                return 0
+	if state == 0:
+		return 0
 
-        pc = panda.current_pc(env)
-        progress("NEW BASIC BLOCK\n")
-        progress("---------------\n")
-        progress("pc=%x" % pc)
+	pc = panda.current_pc(env)
 
-        
-
+        # we just happen to know we will encounter this bb ...
         # we just happen to know we will encounter this pc
-        label_pc = 0xc12c4648
-        if state == 1 and pc == label_pc:
+        label_pc == 0xc12c4648
+        if pc == label_pc:
                 progress("I'm at label_pc=%x" % label_pc)
                 # we just about to executed this bb and we are returning
                 # so we want to taint eax
-                panda.taint_label_reg(R_EAX, 13)
-                panda.taint_label_reg(R_EBX, 14)
-                panda.taint_label_reg(R_ECX, 15)
-                panda.taint_label_reg(R_EDX, 16)
-                # so we don't keep trying to label over and over
-                state = 2
+                panda.taint_reg(R_EAX, label=R_EAX)
+                panda.taint_reg(R_EBX, label=R_EBX)
+                panda.taint_reg(R_ECX, label=R_ECX)
+                panda.taint_reg(R_EDX, label=R_EDX)
+                state = 1
+                return
 
-                # this should trigger re-translation of this bb s.t. its code will 
-                # get taint instrumentation
-                return 1
+        if state == 1:
+                tqr = panda.query_taint_regs()
+                for tq in tqr:
+                        print (tq)
+#IN:
+#0xc1020c9c:  mov    ecx,DWORD PTR ds:0xc13e62c4
+#0xc1020ca2:  lea    eax,[eax+ecx-0x4000]
+#0xc1020ca9:  mov    DWORD PTR [eax],edx
+#0xc1020cab:  ret
 
 
-        def spit_taint(reg_num):
-                taint = panda.taint_get_reg(reg_num)                
-                for offset in range(panda.register_size):
-                        tq = taint[offset]
-                        if tq is None:
-                                progress("offset=%d  NOTAINT")
-                        else:
-                                progress("offset=%d taint=%s" % (offset, tq))
+	if (state <= 33):
+		progress("Before block exec: state=%d pc=%lx" % (state,pc))
 
-                
-        if panda.taint_enabled:
-                if panda.taint_check_reg(R_EAX):
-                        progress("pc=%x EAX tainted" % pc)
-                        spit_taint(R_EAX)
-                if panda.taint_check_reg(R_EBX):
-                        progress("pc=%x EBX tainted" % pc)
-                        spit_taint(R_EBX)
-                if panda.taint_check_reg(R_ECX):
-                        progress("pc=%x ECX tainted" % pc)
-                        spit_taint(R_ECX)
-                if panda.taint_check_reg(R_EDX):
-                        progress("pc=%x EDX tainted" % pc)
-                        spit_taint(R_EDX)
-                        
-        return 0
+	if (state == 1):
+		assert (pc == 0xc12c4648)
+		state = 2
+
+	if (state == 2 and pc == 0xc101dfec):
+		progress ("\nCreating 'newroot' snapshot at 0xc101dfec")
+		panda.snap("newroot")
+		state = 3
+		return 1
+
+	if state == 3:
+		nt = nt + 1
+		if nt == 10:
+			progress("\nRestoring 'newroot' snapshot")
+			panda.revert("newroot", now=False)
+			nt = 0
+			state = 3
+		return 1
+			
+	return 0
+
+	
+
+# this is the initialiation for this plugin
+@panda.callback.init
+def init(handle):
+	progress("Init of Fwi plugin -- in python. handle="+str(handle))
+	panda.register_callback(handle, panda.callback.after_machine_init, machinit)
+	panda.register_callback(handle, panda.callback.before_block_exec, before_block_exec)
+	return True
+
+
+panda.load_python_plugin(init,"Fwi")
+progress ("--- pypanda done with fwi init")
+
+panda.init()
+progress ("--- pypanda done with INIT")
+init_done = True
+
 
 panda.run()

--- a/panda/src/callback_support.c
+++ b/panda/src/callback_support.c
@@ -374,7 +374,6 @@ typedef enum RunState {
 } RunState;
 */
 
-extern bool panda_exit_loop;
 extern bool panda_stopped;
 int runstate_is_running(void);
 
@@ -387,11 +386,11 @@ void panda_callbacks_main_loop_wait(void) {
         plist->entry.main_loop_wait();
         n ++;
     }
-//    printf ("... %d callbacks.  panda_exit_loop=%d runstate_is_running=%d panda_stopped=%d\n", n, panda_exit_loop, runstate_is_running(), panda_stopped);
+//    printf ("... %d callbacks.  panda_break_cpu_loop_req=%d runstate_is_running=%d panda_stopped=%d\n", n, panda_break_cpu_loop_req, runstate_is_running(), panda_stopped);
 
-    if (panda_exit_loop) {
-        //       printf ("Clearing panda_exit_loop\n");
-        panda_exit_loop = false;
+    if (panda_break_cpu_loop_req) {
+        //       printf ("Clearing panda_break_cpu_loop_req\n");
+        panda_break_cpu_loop_req = false;
     }
 }
 
@@ -401,7 +400,7 @@ void panda_callbacks_pre_shutdown(void) {
     int n = 0;
     for (plist = panda_cbs[PANDA_CB_PRE_SHUTDOWN]; plist != NULL;
          plist = panda_cb_list_next(plist)) {
-        plist->entry.main_loop_wait();
+        plist->entry.pre_shutdown();
         n ++;
     }
 }

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -67,8 +67,6 @@ bool panda_help_wanted = false;
 bool panda_plugin_load_failed = false;
 bool panda_abort_requested = false;
 
-bool panda_exit_loop = false;
-
 bool panda_add_arg(const char *plugin_name, const char *plugin_arg) {
     if (plugin_name == NULL)    // PANDA argument
         panda_argv[panda_argc++] = g_strdup(plugin_arg);
@@ -143,6 +141,8 @@ bool panda_load_plugin(const char *filename, const char *plugin_name) {
     nb_panda_plugins_loaded ++;
 
     // Ensure pypanda is loaded so its symbols can be used in the plugin we're loading (TODO: should we move this to happen earlier (and just once?))
+#ifdef PYPANDA
+    // When running as a library, load libpanda
     void *libpanda = dlopen("../../build/"
 #if defined(TARGET_I386)
         "i386-softmmu/libpanda-i386.so"
@@ -157,6 +157,7 @@ bool panda_load_plugin(const char *filename, const char *plugin_name) {
       fprintf(stderr, "Failed to load libpanda: %s\n", dlerror());
       return false;
     }
+#endif
 
     void *plugin = dlopen(filename, RTLD_NOW);
     if(!plugin) {

--- a/util/main-loop.c
+++ b/util/main-loop.c
@@ -37,9 +37,6 @@
 
 #include "qemu/compatfd.h"
 
-
-extern bool panda_exit_loop;
-
 void panda_callbacks_main_loop_wait(void);
 
 /* If we have signalfd, we mask out the signals we want to handle and then

--- a/vl.h
+++ b/vl.h
@@ -6,7 +6,6 @@
 
 typedef enum panda_main_mode {
     PANDA_NORMAL,             // just run panda/qemu as normal
-    PANDA_PRE,                // pre-init
     PANDA_INIT,               // initialize panda/qemu
     PANDA_RUN,                // run the emulate machine
     PANDA_FINISH}             // cleanup and exit
@@ -17,5 +16,7 @@ void main_panda_run(void);
 void main_loop(void);
 
 int main_aux(int argc, char **argv, char **envp, PandaMainMode pmm);
+
+void set_replay_name(char *name);
 
 #endif


### PR DESCRIPTION
* Adds pypanda support for taking a recording, then replaying the recording
* Adds pypanda support for using decorators to register callbacks
* New functions to stop RCU and TCG threads
* Upgrades to pypanda's asyncthread
* Fix race condition in panda_exit_loop by splitting into two variables for vl.c and cpu-exec.c/cpu.c