### PR TITLE
Cache current task info in osi_linux

### DIFF
--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -137,6 +137,25 @@ static inline int panda_virtual_memory_write(CPUState *env, target_ulong addr,
 }
 
 /**
+ * @brief Obtains a host pointer for the given virtual address.
+ */
+static inline void *panda_map_virt_to_host(CPUState *env, target_ulong addr,
+                                           int len)
+{
+    hwaddr phys = panda_virt_to_phys(env, addr);
+    hwaddr l = len;
+    hwaddr addr1;
+    MemoryRegion *mr =
+        address_space_translate(&address_space_memory, phys, &addr1, &l, true);
+
+    if (!memory_access_is_direct(mr, true)) {
+        return NULL;
+    }
+
+    return qemu_map_ram_ptr(mr->ram_block, addr1);
+}
+
+/**
  * @brief Determines if guest is currently executes in kernel mode.
  */
 static inline bool panda_in_kernel(CPUState *cpu) {

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -302,7 +302,7 @@ void on_get_process_handles(CPUState *env, GArray **out) {
 void on_get_current_process(CPUState *env, OsiProc **out) {
     static target_ptr_t last_ts = 0x0;
     static target_ptr_t cached_taskd = 0x0;
-    static char *cached_name = NULL;
+    static char *cached_name = (char *)g_malloc0(ki.task.comm_size);
     static target_ptr_t cached_pid = -1;
     static target_ptr_t cached_ppid = -1;
     static void *cached_comm_ptr = NULL;
@@ -319,10 +319,8 @@ void on_get_current_process(CPUState *env, OsiProc **out) {
 
             // update the cache
             cached_taskd = p->taskd;
-            if (NULL != cached_name) {
-                g_free(cached_name);
-            }
-            cached_name = g_strdup(p->name);
+            memset(cached_name, 0, ki.task.comm_size);
+            strncpy(cached_name, p->name, ki.task.comm_size);
             cached_pid = p->pid;
             cached_ppid = p->ppid;
             cached_comm_ptr = panda_map_virt_to_host(

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -409,12 +409,24 @@ error0:
  * @brief PPP callback to retrieve current thread.
  */
 void on_get_current_thread(CPUState *env, OsiThread **out) {
-	OsiThread *t = NULL;
-	target_ptr_t ts = kernel_profile->get_current_task_struct(env);
-	if (ts) {
-		t = (OsiThread *)g_malloc(sizeof(OsiThread));
-		fill_osithread(env, t, ts);
-	}
+    static target_ptr_t last_ts = 0x0;
+    static target_pid_t cached_tid = 0;
+    static target_pid_t cached_pid = 0;
+
+    OsiThread *t = NULL;
+    target_ptr_t ts = kernel_profile->get_current_task_struct(env);
+    if (0x0 != ts) {
+        t = (OsiThread *)g_malloc(sizeof(OsiThread));
+        if (last_ts != ts) {
+            fill_osithread(env, t, ts);
+            cached_tid = t->tid;
+            cached_pid = t->pid;
+        } else {
+            t->tid = cached_tid;
+            t->pid = cached_pid;
+        }
+    }
+
 	*out = t;
 }
 

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -312,8 +312,9 @@ void on_get_current_process(CPUState *env, OsiProc **out) {
     target_ptr_t ts = kernel_profile->get_current_task_struct(env);
     if (0x0 != ts) {
         p = (OsiProc *)g_malloc(sizeof(*p));
-        if (ts != last_ts || 0 != strncmp((char *)cached_comm_ptr, cached_name,
-                                          ki.task.comm_size)) {
+        if ((ts != last_ts) || (NULL == cached_comm_ptr) ||
+            (0 != strncmp((char *)cached_comm_ptr, cached_name,
+                          ki.task.comm_size))) {
             last_ts = ts;
             fill_osiproc(env, p, ts);
 


### PR DESCRIPTION
To increase the performance of the get current process and thread API calls, this PR introduces a cache for the thread and process information that gets updated when the current task struct changes. This cache seems to greatly increase the overall performance, especially for live execution.

I also added a panda_map_virt_to_host function that returns a host pointer into the guest RAM at a given virtual address. This lets you access guest memory very quickly so long as you're in the same address space (the pointer would be invalid upon a task switch). This is used to quickly check the name of the process (to properly handle fork-exec).

I'm guessing @m000 will want to review this.