### PR TITLE
Add runtime plugin/plugin dependencies

### DIFF
--- a/panda/Makefile.panda.target
+++ b/panda/Makefile.panda.target
@@ -63,6 +63,10 @@ PANDA_CONFIG_FILES=$(SRC_PATH)/panda/plugins/config.panda \
 				   $(SRC_PATH)/panda/plugins/config.llvm.panda \
 				   $(if $(EXTRA_PLUGINS_PATH),$(EXTRA_PLUGINS_PATH)/panda/plugins/config.panda,)
 
+-include $(wildcard $(PLUGINS_PATH)/panda/plugins/*/plugin_plugin.d)
+
+-include $(wildcard $(EXTRA_PLUGINS_PATH)/panda/plugins/*/plugin_plugin.d)
+
 plog.proto: $(PROTO_FILES) $(PANDA_CONFIG_FILES)
 	$(call quiet-command,\
 		$(SRC_PATH)/panda/scripts/pp.py $@ $(PANDA_CONFIG_FILES),\

--- a/panda/Makefile.panda.target
+++ b/panda/Makefile.panda.target
@@ -63,7 +63,7 @@ PANDA_CONFIG_FILES=$(SRC_PATH)/panda/plugins/config.panda \
 				   $(SRC_PATH)/panda/plugins/config.llvm.panda \
 				   $(if $(EXTRA_PLUGINS_PATH),$(EXTRA_PLUGINS_PATH)/panda/plugins/config.panda,)
 
--include $(wildcard $(PLUGINS_PATH)/panda/plugins/*/plugin_plugin.d)
+-include $(wildcard $(SRC_PATH)/panda/plugins/*/plugin_plugin.d)
 
 -include $(wildcard $(EXTRA_PLUGINS_PATH)/panda/plugins/*/plugin_plugin.d)
 

--- a/panda/plugins/cppskeleton/Makefile
+++ b/panda/plugins/cppskeleton/Makefile
@@ -4,6 +4,14 @@
 # CFLAGS+=
 # LIBS+=
 
+# Example: this plugin has runtime symbol dependencies on plugin_x:
+# LIBS+=-L$(PLUGIN_TARGET_DIR) -l:panda_plugin_x.so
+# Also create a plugin_plugin.d file in this directory to ensure plugin_x
+# gets compiled before this plugin, example contents:
+# plugin-this_plugins_name : plugin-plugin_x
+# or if you're using the extra plugins dir:
+# extra-plugin-this_plugins_name : extra-plugin-plugin_x
+
 # The main rule for your plugin. List all object-file dependencies.
 $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
 	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o

--- a/panda/plugins/cskeleton/Makefile
+++ b/panda/plugins/cskeleton/Makefile
@@ -4,6 +4,14 @@
 # CFLAGS+=
 # LIBS+=
 
+# Example: this plugin has runtime symbol dependencies on plugin_x:
+# LIBS+=-L$(PLUGIN_TARGET_DIR) -l:panda_plugin_x.so
+# Also create a plugin_plugin.d file in this directory to ensure plugin_x
+# gets compiled before this plugin, example contents:
+# plugin-this_plugins_name : plugin-plugin_x
+# or if you're using the extra plugins dir:
+# extra-plugin-this_plugins_name : extra-plugin-plugin_x
+
 # The main rule for your plugin. List all object-file dependencies.
 $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
 	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o


### PR DESCRIPTION
Update the plugin build system to read an optional plugin_plugin.d file
in each plugin directory.  This file contains dependency information for
plugins that have runtime dependencies on other plugins.

Runtime dependencies can be required when using C++ classes in a plugin.
If plugin_1 wishes to make use of C++ classes that are defined in plugin_2,
one could update plugin_1's Makefile to add a runtime dependency on plugin_2
by modifying the LIBS symbol, such as:
LIBS+=-L$(PLUGIN_TARGET_DIR) -l:panda_plugin_2.so

However, this is not enough to guarantee a clean build.  The build system needs
to know to build panda_plugin_2.so prior to building panda_plugin_1.so.

Makefile.panda.target has been modified to look for an optional
plugin_plugin.d file in each plugin directory where these dependencies can
be defined.  In this case, a plugin_plugin.d file would be required in
plugin_1's source directory that contained:
plugin-plugin_1 : plugin-plugin_2
or if plugin_1 and plugin_2 live in the extra panda plugins directory:
extra-plugin-plugin_1 : extra-plugin-plugin_2