### PR TITLE
Expose location of PEB structure.

### DIFF
--- a/panda/plugins/wintrospection/wintrospection.c
+++ b/panda/plugins/wintrospection/wintrospection.c
@@ -611,6 +611,10 @@ uint32_t handle_table_L3_entry(uint32_t table_vaddr, uint32_t L2_table, uint32_t
     return L2_table + HANDLE_TABLE_ENTRY_SIZE * L3;
 }
 
+uint32_t get_eproc_peb_off(void) {
+    return eproc_ppeb_off;
+}
+
 
 
 // Module stuff

--- a/panda/plugins/wintrospection/wintrospection_int_fns.h
+++ b/panda/plugins/wintrospection/wintrospection_int_fns.h
@@ -99,3 +99,4 @@ uint32_t handle_table_L2_entry(uint32_t table_vaddr, uint32_t L1_table, uint32_t
 
 uint32_t handle_table_L3_entry(uint32_t table_vaddr, uint32_t L2_table, uint32_t L3);
 
+uint32_t get_eproc_peb_off(void);


### PR DESCRIPTION
Wintrospection knows the location of the Process Environment Block (PEB)
within the EPROCESS structure.  The location of this structure is dependent
on the version of Windows running in the guest.  Exposing this location to
other plugins will allow other plugins to query details of the PEB structure
without having to know what version of windows is being used in the guest.