### PR TITLE
Add build date to version output

### DIFF
--- a/vl.c
+++ b/vl.c
@@ -2010,7 +2010,8 @@ static void main_loop(void)
 static void version(void)
 {
     printf("QEMU emulator version " QEMU_VERSION QEMU_PKGVERSION "\n"
-           QEMU_COPYRIGHT "\n");
+            "Build date " __DATE__ "\n"
+            QEMU_COPYRIGHT "\n");
 }
 
 static void help(int exitcode)


### PR DESCRIPTION
Added build date to output seen from "--version" and "--help".  This makes it easier to determine which build an installed version is (as we're not using PANDA specific version numbers).