### PR TITLE
Fix for #500

### DIFF
--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -709,10 +709,8 @@ void debug_counter(void) {
         counter_128k++;
 }
 #endif
-__attribute__((always_inline))
-    inline void debug_checkpoint(CPUState *cpu);
-    __attribute__((always_inline))
-    inline void debug_checkpoint(CPUState *cpu) {
+
+__attribute__((always_inline)) static inline void debug_checkpoint(CPUState *cpu) {
 #ifdef CONFIG_DEBUG_TCG
     if (rr_on() && cpu->rr_guest_instr_count >> 17 > counter_128k) {
         debug_counter();
@@ -720,7 +718,7 @@ __attribute__((always_inline))
 #endif
 }
 
-static void detect_infinite_loops(void) {
+__attribute__((always_inline)) static inline void detect_infinite_loops(void) {
     if (!rr_in_replay()) return;
 
     static uint64_t last_instr_count = 0;

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -21,6 +21,7 @@
     - [Precise program counter](#precise-program-counter)
     - [Memory access](#memory-access)
     - [LLVM control](#llvm-control)
+    - [Record control](#record-control)
     - [Miscellany](#miscellany)
 - [Record/Replay Details](#recordreplay-details)
   - [Introduction](#introduction)
@@ -310,6 +311,29 @@ translation step is added from the TCG IR to the LLVM IR, and that is executed
 on the LLVM JIT.  Currently, this only works when QEMU is starting up, but we
 are hoping to support dynamic configuration of code generation soon.
 
+#### Record control
+```C
+int panda_record_begin(const char *name, const char *snapshot);
+int panda_record_end(void);
+int panda_replay_begin(const char *name);
+int panda_replay_end(void);
+```
+These functions can be used to programatically start/stop recording on PANDA.
+Starting/stopping does not happen imediatelly at the time the functions are
+called. Instead, a request to start/stop recording is registered to be applied
+at the end of the currently executing basic block. Only one request can be
+queued at any time.
+The `name` argument is mandatory and is used to derive the snapshot/log
+filenames to be created/used.
+The `snapshot` argument is optional (i.e. can be `NULL`). If supplied,
+the state of the VM will be reverted to the QEMU snapshot with that name.
+
+Possible return values are:
+  * `RRCTRL_OK`: Request registered successfully.
+  * `RRCTRL_EPENDING`: Request ignored because another record/replay state
+    change request is pending.
+  * `RRCTRL_ERROR`: Request is invalid. E.g. because you are trying to end
+    a recording during a replay.
 
 #### Miscellany
   * ```C

--- a/vl.c
+++ b/vl.c
@@ -1964,8 +1964,7 @@ static void main_loop(void)
 
 	if (likely(rr_control.next == RR_NOCHANGE)) {
 	    // nop
-	}
-	else if (unlikely(rr_control.next == RR_RECORD)) {
+	} else if (unlikely(rr_control.next == RR_RECORD)) {
             //block signals
             sigprocmask(SIG_BLOCK, &blockset, &oldset);
             rr_do_begin_record(rr_control.name, first_cpu);


### PR DESCRIPTION
Declared two functions defined and used locally in `cpu-exec.c` as `static inline`. This should fix #500.