### PR TITLE
Fix more network callback issues introduced recently

### DIFF
--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -689,8 +689,8 @@ typedef union panda_cb {
        Arguments:
         CPUState *env:          pointer to CPUState
         uint32_t type:          type of transfer  (Net_transfer_type)
-        target_ptr_t src_addr:  address for src
-        target_ptr_t dest_addr: address for dest
+        uint64_t src_addr:      address for src
+        uint64_t dest_addr:     address for dest
         size_t num_bytes:       size of transfer in bytes
 
        Helper call location: panda/src/rr/rr_log.c
@@ -702,8 +702,10 @@ typedef union panda_cb {
         Unlike most callbacks, this is neither a "before" or "after" callback.
         In replay the transfer doesn't really happen. We are *at* the point at
         which it happened, really.
+        Also, the src_addr and dest_addr may be for either host (ie. a location
+        in the emulated network device) or guest, depending upon the type.
     */
-    void (*replay_net_transfer)(CPUState *env, uint32_t type, target_ptr_t src_addr, target_ptr_t dest_addr, size_t num_bytes);
+    void (*replay_net_transfer)(CPUState *env, uint32_t type, uint64_t src_addr, uint64_t dest_addr, size_t num_bytes);
 
     /* Callback ID:     PANDA_CB_REPLAY_SERIAL_RECEIVE,
 

--- a/panda/include/panda/callbacks/cb-support.h
+++ b/panda/include/panda/callbacks/cb-support.h
@@ -101,7 +101,7 @@ void panda_callbacks_replay_after_dma(CPUState *env, const uint8_t *buf, hwaddr 
 
 /* invoked from panda/src/rr/rr_log.c */
 void panda_callbacks_replay_handle_packet(CPUState *env, uint8_t *buf, size_t size, uint8_t direction, uint64_t buf_addr_rec);
-void panda_callbacks_replay_net_transfer(CPUState *env, uint32_t type, target_ptr_t src_addr, target_ptr_t dest_addr, size_t num_bytes);
+void panda_callbacks_replay_net_transfer(CPUState *env, uint32_t type, uint64_t src_addr, uint64_t dest_addr, size_t num_bytes);
 void panda_callbacks_replay_serial_receive(CPUState *env, target_ptr_t fifo_addr, uint8_t value);
 void panda_callbacks_replay_serial_read(CPUState *env, target_ptr_t fifo_addr, uint32_t port_addr, uint8_t value);
 void panda_callbacks_replay_serial_send(CPUState *env, target_ptr_t fifo_addr, uint8_t value);

--- a/panda/plugins/net/net.cpp
+++ b/panda/plugins/net/net.cpp
@@ -22,13 +22,13 @@ PANDAENDCOMMENT */
 extern "C" {
 bool init_plugin(void *);
 void uninit_plugin(void *);
-void on_replay_net_transfer(CPUState *env, uint32_t type, target_ptr_t src_addr, target_ptr_t dst_addr, size_t num_bytes);
+void on_replay_net_transfer(CPUState *env, uint32_t type, uint64_t src_addr, uint64_t dst_addr, size_t num_bytes);
 void on_replay_handle_packet(CPUState *env, uint8_t *buf, size_t size, uint8_t direction, uint64_t buf_addr_rec);
 }
 
-void on_replay_net_transfer(CPUState* env, uint32_t type, target_ptr_t src_addr,
-                            target_ptr_t dst_addr, size_t num_bytes) {
-    printf("net transfer: src: " TARGET_PTR_FMT ", dst: " TARGET_PTR_FMT ", n: %zu\n",
+void on_replay_net_transfer(CPUState* env, uint32_t type, uint64_t src_addr,
+                            uint64_t dst_addr, size_t num_bytes) {
+    printf("net transfer: src: %" PRIx64 ", dst: %" PRIx64 ", n: %zu\n",
            src_addr, dst_addr, num_bytes);
     return;
 }

--- a/panda/plugins/net/net.cpp
+++ b/panda/plugins/net/net.cpp
@@ -36,7 +36,7 @@ void on_replay_net_transfer(CPUState* env, uint32_t type, uint64_t src_addr,
 void on_replay_handle_packet(CPUState *env, uint8_t *buf, size_t size,
                              uint8_t direction, uint64_t buf_addr_rec) {
     printf("handle packets: buf: %p, size: %zu, direction: %u, "
-           "buf_addr_rec: %" PRIu64 "\n", buf, size, direction, buf_addr_rec);
+           "buf_addr_rec: %" PRIx64 "\n", buf, size, direction, buf_addr_rec);
         printf("start content: \n");
         for (int i = 0; i < size; i++) {
             printf("%c, ", buf[i]);

--- a/panda/plugins/taint2/taint2.cpp
+++ b/panda/plugins/taint2/taint2.cpp
@@ -78,7 +78,7 @@ void phys_mem_write_callback(CPUState *cpu, target_ptr_t pc, target_ulong addr, 
 void phys_mem_read_callback(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf);
 
 // network related callbacks
-void on_replay_net_transfer(CPUState *cpu, uint32_t type, target_ptr_t src_addr, target_ptr_t dst_addr, size_t num_bytes);
+void on_replay_net_transfer(CPUState *cpu, uint32_t type, uint64_t src_addr, uint64_t dst_addr, size_t num_bytes);
 void on_replay_before_dma(CPUState *cpu, const uint8_t *src_addr, hwaddr dest_addr, size_t num_bytes, bool is_write);
 void taint_state_changed(Shad *, uint64_t, uint64_t);
 PPP_PROT_REG_CB(on_taint_change);
@@ -195,8 +195,8 @@ void replay_hd_transfer_callback(CPUState *cpu, uint32_t type,
 }
 
 // network data has been transfered - transfer the associated taint too
-void on_replay_net_transfer(CPUState *cpu, uint32_t type, target_ptr_t src_addr,
-                            target_ptr_t dst_addr, size_t num_bytes) {
+void on_replay_net_transfer(CPUState *cpu, uint32_t type, uint64_t src_addr,
+                            uint64_t dst_addr, size_t num_bytes) {
     if (!taintEnabled)
     {
         return;

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -33,7 +33,7 @@ void PCB(replay_handle_packet)(CPUState *cpu, uint8_t *buf, size_t size, uint8_t
         }
     }
 }
-void PCB(replay_net_transfer)(CPUState *cpu, Net_transfer_type type, target_ptr_t src_addr, target_ptr_t dst_addr, size_t num_bytes) {
+void PCB(replay_net_transfer)(CPUState *cpu, Net_transfer_type type, uint64_t src_addr, uint64_t dst_addr, size_t num_bytes) {
     if (rr_in_replay()) {
         panda_cb_list *plist;
         for (plist = panda_cbs[PANDA_CB_REPLAY_NET_TRANSFER];


### PR DESCRIPTION
The changes for pull request #505 were incomplete, as the buf_addr_rec passed into the handle packets callback in the tainted_net plugin was used in various contexts that also needed to revert their types to uint64_t to avoid truncating host addresses.
Also, the PANDA_CB_REPLAY_NET_TRANSFER callback had a similar problem (to what PANDA_REPLAY_HANDLE_PACKET originally had) with the source and destination addresses sometimes being for a host (thus 64-bit on a 64-bit host) address and sometimes being for a guest address, and sometimes both being a host address.  This caused host addresses to get truncated, and so taint did not go where it was supposed to.  So, I fixed that.
Could you please take a look @m000, after Travis has blessed it (and hopefully add your blessing as well).