### PR TITLE
pandalog_taint_query free not freeing

### DIFF
--- a/panda/plugins/taint2/taint_api.cpp
+++ b/panda/plugins/taint2/taint_api.cpp
@@ -471,6 +471,7 @@ void pandalog_taint_query_free(Panda__TaintQuery *tq) {
         }
         free(tq->unique_label_set);
     }
+    free(tq);
 }
 
 extern bool taintEnabled;


### PR DESCRIPTION
Because of it there are plenty of memory leaks in plugins