### PR TITLE
add cc update before insn exec callback

### DIFF
--- a/target/i386/translate.c
+++ b/target/i386/translate.c
@@ -8532,6 +8532,7 @@ generate_debug:
 
         // PANDA: ask if anyone wants execution notification
         if (unlikely(panda_callbacks_insn_translate(ENV_GET_CPU(env), pc_ptr))) {
+            gen_update_cc_op(dc);
             gen_helper_panda_insn_exec(tcg_const_tl(pc_ptr));
         }
 


### PR DESCRIPTION
Inserts a condition code update before executing instruction execution callbacks. This enables plugins using the instruction exec callback to compute an accurate eflags value.