### PR TITLE
Fix RR board-specific segfault

### DIFF
--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -42,6 +42,7 @@ void panda_set_os_name(char *os_name);
 void panda_before_find_fast(void);
 void panda_disas(FILE *out, void *code, unsigned long size);
 void panda_break_main_loop(void);
+MemoryRegion* panda_find_ram(void);
 
 extern bool panda_exit_loop;
 extern bool panda_break_vl_loop_req;

--- a/panda/src/common.c
+++ b/panda/src/common.c
@@ -194,13 +194,21 @@ MemoryRegion* panda_find_ram(void) {
     Int128 curr_max = 0;
     MemoryRegion *ram = NULL;   // Sentinel, deref segfault
     MemoryRegion *sys_mem = get_system_memory();
+    MemoryRegion *mr_check;
     MemoryRegion *mr_iter;
 
-    // Largest top-level subregion marked as random access
+    // Largest top-level subregion marked as random access memory, accounting for possible aliases
     QTAILQ_FOREACH(mr_iter, &(sys_mem->subregions), subregions_link) {
-        if (memory_region_is_ram(mr_iter) && (mr_iter->size > curr_max)) {
-            curr_max = mr_iter->size;
-            ram = mr_iter;
+
+        mr_check = mr_iter;
+
+        if (mr_iter->alias && (mr_iter->alias->size > mr_iter->size)) {
+           mr_check = mr_iter->alias;
+        }
+
+        if (memory_region_is_ram(mr_check) && (mr_check->size > curr_max)) {
+            curr_max = mr_check->size;
+            ram = mr_check;
         }
     }
 

--- a/panda/src/common.c
+++ b/panda/src/common.c
@@ -195,18 +195,12 @@ MemoryRegion* panda_find_ram(void) {
     MemoryRegion *ram = NULL;   // Sentinel, deref segfault
     MemoryRegion *sys_mem = get_system_memory();
     MemoryRegion *mr_iter;
-    const char* region_name;
 
-    // Hacky heuristic, but should work for most non-standard RAM names ("mach-virt.ram", "pc.ram", etc):
-    // - Iterate ONLY top-level subregion names (not depth-first exhaustive: faster and reduced chance of false pos)
-    // - Find LARGEST w/ case-insensitive substr match (largest b/c some boards have "sysram", "dram", "lowmem", etc)
+    // Largest top-level subregion marked as random access
     QTAILQ_FOREACH(mr_iter, &(sys_mem->subregions), subregions_link) {
-        region_name = memory_region_name(mr_iter);
-        if ((strcasestr(region_name, "ram") || strcasestr(region_name, "mem"))
-            && (mr_iter->size > curr_max))
-        {
-            ram = mr_iter;
+        if (memory_region_is_ram(mr_iter) && (mr_iter->size > curr_max)) {
             curr_max = mr_iter->size;
+            ram = mr_iter;
         }
     }
 

--- a/panda/src/rr/rr_log.c
+++ b/panda/src/rr/rr_log.c
@@ -1085,7 +1085,7 @@ void rr_replay_skipped_calls_internal(RR_callsite_id call_site)
             // point
             replay_done = 1;
         } else {
-            
+
             RR_skipped_call_args args = current_item->variant.call_args;
             switch (args.kind) {
             case RR_CALL_CPU_MEM_RW: {
@@ -1642,7 +1642,7 @@ void rr_do_end_replay(int is_error)
     rr_control.mode = RR_OFF;
 
     rr_replay_complete = true;
-    
+
     // mz XXX something more graceful?
     panda_cleanup();
     if (is_error) {
@@ -1683,7 +1683,13 @@ void rr_end_main_loop_wait(void) {
 
 #ifdef CONFIG_SOFTMMU
 static uint32_t rr_checksum_memory_internal(void) {
-    MemoryRegion *ram = memory_region_find(get_system_memory(), 0x2000000, 1).mr;
+    rcu_read_lock();
+    MemoryRegion *ram = panda_find_ram();
+    rcu_read_unlock();
+    if (!ram) {
+        printf("ERROR: could not find RAM start address!\n");
+        abort();
+    }
     rcu_read_lock();
     void *ptr = qemu_map_ram_ptr(ram->ram_block, 0);
     uint32_t crc = rr_chunked_crc32(ptr, ram_size);


### PR DESCRIPTION
Fixes #525 , board-agnostic way to find the RAM memory region for recording (instead of hardcoding it).