### PR TITLE
Adjust RPATH in .so files during "make install"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       #- sourceline: 'deb http://ppa.launchpad.net/phulin/panda/ubuntu xenial main'
     packages:
       # Build dependencies
+      - chrpath
       - libaio-dev
       - libattr1-dev
       - libbrlapi-dev

--- a/Makefile
+++ b/Makefile
@@ -597,8 +597,24 @@ ifneq (,$(findstring qemu-ga,$(TOOLS)))
 endif
 endif
 
+# The install target won't succeed if the RPATH in the .so files is longer than
+# the value need to change it to for installation purposes.  It does not matter
+# which architecture is used for the comparison - it shows up once in both the
+# new and old RPATHs, so the differences cancel out.
+# Calculate length of new RPATH.
+newrplen=$(shell newrp="$(panda_plugindir)/$(ARCH)" ; eval echo $${\#newrp})
+# Fetch current RPATH from an .so file - doesn't matter which plugin it is for.
+archdir=$(filter $(ARCH)-%,$(TARGET_DIRS))
+pwdvar=$(shell pwd)
+pathtoso=$(shell echo "$(pwdvar)/$(archdir)/panda/plugins/panda_stringsearch.so")
+cpout=$(shell chrpath -l "$(pathtoso)")
+# The old RPATH will include a "RPATH=" prefix - the size calculation will
+# adjust for that later.
+rppart=$(lastword $(cpout))
+newtoobig=$(shell oldrp="$(rppart)" ; oldrplen=`expr $${\#oldrp} - 6` ; if [ $$oldrplen -lt $(newrplen) ] ; then echo true ; else echo false ; fi)
 
 install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir
+ifeq ($(newtoobig), false)
 ifneq ($(TOOLS),)
 	$(call install-prog,$(subst qemu-ga,qemu-ga$(EXESUF),$(TOOLS)),$(DESTDIR)$(bindir))
 endif
@@ -629,6 +645,9 @@ endif
 	for d in $(TARGET_DIRS); do \
 	$(MAKE) $(SUBDIR_MAKEFLAGS) TARGET_DIR=$$d/ -C $$d $@ || exit 1 ; \
         done
+else
+	$(error new RPATH too long - cannot adjust .so files for installation)
+endif
 
 # various test targets
 test speed: all

--- a/Makefile.target
+++ b/Makefile.target
@@ -269,8 +269,10 @@ endif
 	$(INSTALL_DIR) "$(DESTDIR)$(libdir)/python2.7/site-packages"
 	$(INSTALL_LIB) plog_pb2.py "$(DESTDIR)$(libdir)/python2.7/site-packages"
 	$(INSTALL_DIR) "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)"
+# N.B. the new rpath must not be longer than the old rpath or chrpath will fail
 	for p in $(PANDA_PLUGINS) $(EXTRA_PANDA_PLUGINS); do \
 		$(INSTALL_LIB) panda/plugins/panda_$$p.so "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)"; \
+		chrpath -r "$(libdir)/panda/$(TARGET_NAME)" "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/panda_$$p.so"; \
 		for f in $$(find panda/plugins/$$p -type f -not -name '*.d' -not -name '*.o' -not -name '*.h'); do \
 			$(INSTALL_DIR) "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \
 			$(INSTALL_DATA) $$f "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \

--- a/Makefile.target
+++ b/Makefile.target
@@ -272,7 +272,7 @@ endif
 # N.B. the new rpath must not be longer than the old rpath or chrpath will fail
 	for p in $(PANDA_PLUGINS) $(EXTRA_PANDA_PLUGINS); do \
 		$(INSTALL_LIB) panda/plugins/panda_$$p.so "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)"; \
-		chrpath -r "$(libdir)/panda/$(TARGET_NAME)" "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/panda_$$p.so"; \
+		chrpath -r "$(libdir)/panda/$(TARGET_NAME)" "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/panda_$$p.so" >/dev/null; \
 		for f in $$(find panda/plugins/$$p -type f -not -name '*.d' -not -name '*.o' -not -name '*.h'); do \
 			$(INSTALL_DIR) "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \
 			$(INSTALL_DATA) $$f "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ build, or `docker pull thawsystems/panda` for a third-party
 After successfully building PANDA, you can copy the build to a system-wide
 location by running `make install`. The default installation path is `/usr/local`.
 You can specify an alternate installation path through the `prefix` configuration
-option. E.g. `--prefix=/opt/panda`.
+option. E.g. `--prefix=/opt/panda`.  Note that your system must have `chrpath`
+installed in order for `make install` to succeed.
 
 If the `bin` directory containing the PANDA binaries is in your `PATH` environment
 variable, then you can run PANDA similarly to QEMU:


### PR DESCRIPTION
Certain plugins cannot be loaded when using a build of PANDA created using "make install".  This is because in some situations the RPATH in an .so file is used to load plugins, but the RPATH does not refer to where the .so files for the plugins were installed, but instead to where they were built.  The "chrpath" utility is used during "build install" to adjust the RPATH in the .so files that are placed in the deb package.
Of course, this means you need to have chrpath installed on your machine if you ever use "make install".