### PR TITLE
MMIO callback and plugin updates

### DIFF
--- a/cputlb.c
+++ b/cputlb.c
@@ -832,6 +832,8 @@ static void io_writex(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
     cpu->mem_io_vaddr = addr;
     cpu->mem_io_pc = retaddr;
 
+    panda_callbacks_mmio_before_write(cpu, physaddr, addr, size, &val);
+
     if (mr->name && !strcmp(mr->name, "watch")){
         memory_region_dispatch_write(mr, physaddr, val, size, iotlbentry->attrs);
         return;
@@ -847,8 +849,6 @@ static void io_writex(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
     } else {
         memory_region_dispatch_write(mr, physaddr, val, size, iotlbentry->attrs);
     }
-
-    panda_callbacks_mmio_after_write(cpu, physaddr, addr, size, &val);
 }
 
 /* Return true if ADDR is present in the victim tlb, and has been copied

--- a/cputlb.c
+++ b/cputlb.c
@@ -811,7 +811,7 @@ static uint64_t io_readx(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
         /* replay= */ rr_input_8(&val),
         /* location= */ RR_CALLSITE_IO_READ_ALL);
 
-    panda_callbacks_mmio_after_read(cpu, physaddr, size, &val);
+    panda_callbacks_mmio_after_read(cpu, physaddr, addr, size, &val);
 
     return val;
 }
@@ -848,7 +848,7 @@ static void io_writex(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
         memory_region_dispatch_write(mr, physaddr, val, size, iotlbentry->attrs);
     }
 
-    panda_callbacks_mmio_after_write(cpu, physaddr, size, val);
+    panda_callbacks_mmio_after_write(cpu, physaddr, addr, size, &val);
 }
 
 /* Return true if ADDR is present in the victim tlb, and has been copied

--- a/cputlb.c
+++ b/cputlb.c
@@ -811,7 +811,7 @@ static uint64_t io_readx(CPUArchState *env, CPUIOTLBEntry *iotlbentry,
         /* replay= */ rr_input_8(&val),
         /* location= */ RR_CALLSITE_IO_READ_ALL);
 
-    panda_callbacks_mmio_after_read(cpu, physaddr, size, val);
+    panda_callbacks_mmio_after_read(cpu, physaddr, size, &val);
 
     return val;
 }

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -607,7 +607,7 @@ PANDA_CB_VIRT_MEM_AFTER_WRITE,  // After write to virtual memory
 PANDA_CB_PHYS_MEM_AFTER_READ,   // After read of physical memory
 PANDA_CB_PHYS_MEM_AFTER_WRITE,  // After write to physical memory
 PANDA_CB_MMIO_AFTER_READ,       // After each MMIO read
-PANDA_CB_MMIO_AFTER_WRITE,      // After each MMIO write
+PANDA_CB_MMIO_BEFORE_WRITE,     // Before each MMIO write
 PANDA_CB_HD_READ,               // Each HDD read
 PANDA_CB_HD_WRITE,              // Each HDD write
 PANDA_CB_GUEST_HYPERCALL,       // Hypercall from the guest (e.g. CPUID)

--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -463,14 +463,14 @@ typedef union panda_cb {
         CPUState *env:     the current CPU state
         target_ptr_t addr: the (physical) address being read from
         size_t size:       the size of the read
-        uin64_t val:       the value being read
+        uin64_t *val:      the value being read
 
        Helper call location: cputlb.c
 
        Return value:
         none
     */
-    void (*mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t val);
+    void (*mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val);
 
     /* Callback ID: PANDA_CB_MMIO_AFTER_WRITE
 

--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -50,7 +50,7 @@ typedef enum panda_cb_type {
     PANDA_CB_PHYS_MEM_AFTER_WRITE,  // After write of physical memory
 
     PANDA_CB_MMIO_AFTER_READ,       // After each MMIO read
-    PANDA_CB_MMIO_AFTER_WRITE,      // After each MMIO write
+    PANDA_CB_MMIO_BEFORE_WRITE,     // Before each MMIO write
 
     PANDA_CB_HD_READ,               // Each HDD read
     PANDA_CB_HD_WRITE,              // Each HDD write
@@ -473,9 +473,9 @@ typedef union panda_cb {
     */
     void (*mmio_after_read)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 
-    /* Callback ID: PANDA_CB_MMIO_AFTER_WRITE
+    /* Callback ID: PANDA_CB_MMIO_BEFORE_WRITE
 
-       mmio_after_write:
+       mmio_before_write:
         Called after MMIO memory is written to.
 
        Arguments:
@@ -490,7 +490,7 @@ typedef union panda_cb {
        Return value:
         none
     */
-    void (*mmio_after_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
+    void (*mmio_before_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 
     /* Callback ID: PANDA_CB_HD_READ
        hd_read : called when there is a hard drive read

--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -460,17 +460,18 @@ typedef union panda_cb {
         Called after MMIO memory is read.
 
        Arguments:
-        CPUState *env:     the current CPU state
-        target_ptr_t addr: the (physical) address being read from
-        size_t size:       the size of the read
-        uin64_t *val:      the value being read
+        CPUState *env:          the current CPU state
+        target_ptr_t physaddr:  the physical address being read from
+        target_ptr_t vaddr:     the virtual address being read from
+        size_t size:            the size of the read
+        uin64_t *val:           the value being read
 
        Helper call location: cputlb.c
 
        Return value:
         none
     */
-    void (*mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val);
+    void (*mmio_after_read)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 
     /* Callback ID: PANDA_CB_MMIO_AFTER_WRITE
 
@@ -478,17 +479,18 @@ typedef union panda_cb {
         Called after MMIO memory is written to.
 
        Arguments:
-        CPUState *env:     the current CPU state
-        target_ptr_t addr: the (physical) address being written to
-        size_t size:       the size of the write
-        uin64_t val:       the value being written
+        CPUState *env:          the current CPU state
+        target_ptr_t physaddr:  the physical address being written to
+        target_ptr_t vaddr:     the virtual address being written to
+        size_t size:            the size of the write
+        uin64_t *val:           the value being written
 
        Helper call location: cputlb.c
 
        Return value:
         none
     */
-    void (*mmio_after_write)(CPUState *env, target_ptr_t addr, size_t size, uint64_t val);
+    void (*mmio_after_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 
     /* Callback ID: PANDA_CB_HD_READ
        hd_read : called when there is a hard drive read
@@ -716,7 +718,7 @@ typedef union panda_cb {
         produced by a 32bit of PANDA, and vice-versa.
         There are more internal structs that suffer from the same issue.
         This is an oversight that will eventually be fixed. But as the
-        real impact is minimal (virtually nobody uses 32bit builds), 
+        real impact is minimal (virtually nobody uses 32bit builds),
         the fix has a very low priority in the bugfix list.
     */
     void (*replay_handle_packet)(CPUState *env, uint8_t *buf, size_t size, uint8_t direction, uint64_t buf_addr_rec);

--- a/panda/include/panda/callbacks/cb-support.h
+++ b/panda/include/panda/callbacks/cb-support.h
@@ -101,8 +101,8 @@ int32_t panda_callbacks_before_handle_exception(CPUState *cpu, int32_t exception
 void panda_callbacks_cbaddr(void);
 
 /* invoked from cputlb.c */
-void panda_callbacks_mmio_after_read(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val);
-void panda_callbacks_mmio_after_write(CPUState *env, target_ptr_t addr, size_t size, uint64_t val);
+void panda_callbacks_mmio_after_read(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
+void panda_callbacks_mmio_after_write(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 void panda_callbacks_hd_read(CPUState *env);
 void panda_callbacks_hd_write(CPUState *env);
 

--- a/panda/include/panda/callbacks/cb-support.h
+++ b/panda/include/panda/callbacks/cb-support.h
@@ -102,7 +102,7 @@ void panda_callbacks_cbaddr(void);
 
 /* invoked from cputlb.c */
 void panda_callbacks_mmio_after_read(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
-void panda_callbacks_mmio_after_write(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
+void panda_callbacks_mmio_before_write(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 void panda_callbacks_hd_read(CPUState *env);
 void panda_callbacks_hd_write(CPUState *env);
 

--- a/panda/include/panda/callbacks/cb-support.h
+++ b/panda/include/panda/callbacks/cb-support.h
@@ -101,7 +101,7 @@ int32_t panda_callbacks_before_handle_exception(CPUState *cpu, int32_t exception
 void panda_callbacks_cbaddr(void);
 
 /* invoked from cputlb.c */
-void panda_callbacks_mmio_after_read(CPUState *env, target_ptr_t addr, size_t size, uint64_t val);
+void panda_callbacks_mmio_after_read(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val);
 void panda_callbacks_mmio_after_write(CPUState *env, target_ptr_t addr, size_t size, uint64_t val);
 void panda_callbacks_hd_read(CPUState *env);
 void panda_callbacks_hd_write(CPUState *env);

--- a/panda/plugins/callfunc/README.md
+++ b/panda/plugins/callfunc/README.md
@@ -1,4 +1,4 @@
-Plugin: NAME
+Plugin: callfunc
 ===========
 
 Summary

--- a/panda/plugins/mmio_trace/README.md
+++ b/panda/plugins/mmio_trace/README.md
@@ -19,7 +19,7 @@ None
 APIs and Callbacks
 ------------------
 
-As an alternative to the optional log file output in `uninit_plugin`, API for retrieval of sequential MMIO event tuples (`access_type`, `prog_counter`, `phys_addr`, `size`, `value`).
+As an alternative to the optional log file output in `uninit_plugin`, API for retrieval of sequential MMIO event tuples (`access_type`, `prog_counter`, `phys_addr`, `size`, `value`, `dev_name`).
 
 
 ```c

--- a/panda/plugins/mmio_trace/README.md
+++ b/panda/plugins/mmio_trace/README.md
@@ -35,6 +35,6 @@ Testing with the Debian ARM image used by PANDA's `run_debian.py --arch arm`, lo
 ```
 arm-softmmu/panda-system-arm -M versatilepb -kernel ~/.panda/vmlinuz-3.2.0-4-versatile \
     -initrd ~/.panda/initrd.img-3.2.0-4-versatile -hda ~/.panda/arm_wheezy.qcow \
-    -serial stdio -display none \
+    -monitor stdio -loadvm root \
     -panda mmio_trace:out_log="mmio.json"
 ```

--- a/panda/plugins/mmio_trace/README.md
+++ b/panda/plugins/mmio_trace/README.md
@@ -9,7 +9,7 @@ Log MMIO interactions within the guest.
 Arguments
 ---------
 
-* out_log (string): File to log MMIO R/Ws to (optional)
+* out_log (string): JSON file to log MMIO R/Ws to (optional)
 
 Dependencies
 ------------
@@ -35,6 +35,6 @@ Testing with the Debian ARM image used by PANDA's `run_debian.py --arch arm`, lo
 ```
 arm-softmmu/panda-system-arm -M versatilepb -kernel ~/.panda/vmlinuz-3.2.0-4-versatile \
     -initrd ~/.panda/initrd.img-3.2.0-4-versatile -hda ~/.panda/arm_wheezy.qcow \
-    -serial stdio -loadvm root -display none \
-    -panda mmio_trace:out_log="mmio.log"
+    -serial stdio -display none \
+    -panda mmio_trace:out_log="mmio.json"
 ```

--- a/panda/plugins/mmio_trace/README.md
+++ b/panda/plugins/mmio_trace/README.md
@@ -19,7 +19,7 @@ None
 APIs and Callbacks
 ------------------
 
-As an alternative to the optional log file output in `uninit_plugin`, API for retrieval of sequential MMIO event tuples (`access_type`, `prog_counter`, `phys_addr`, `size`, `value`, `dev_name`).
+As an alternative to the optional log file output in `uninit_plugin`, API for retrieval of sequential MMIO event tuples (`access_type`, `pc`, `phys_addr`, `virt_addr`, `size`, `value`, `dev_name`).
 
 
 ```c

--- a/panda/plugins/mmio_trace/mmio_trace.cpp
+++ b/panda/plugins/mmio_trace/mmio_trace.cpp
@@ -22,6 +22,7 @@ PANDAENDCOMMENT */
 
 const char* fn_str;
 MMIOEventList mmio_events;
+const char* default_dev_name = "[NONE]";
 
 // These need to be extern "C" so that the ABI is compatible with QEMU/PANDA, which is written in C
 extern "C" {
@@ -33,16 +34,88 @@ extern "C" {
 
 // PANDA_CB_MMIO_AFTER_READ callback
 void buffer_mmio_read(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
-    mmio_event_t new_event{'R', env->panda_guest_pc, physaddr, vaddr, size, *val, "TEMP"};
+    mmio_event_t new_event{'R', env->panda_guest_pc, physaddr, vaddr, size, *val, default_dev_name};
     mmio_events.push_back(new_event);
     return;
 }
 
 // PANDA_CB_MMIO_AFTER_WRITE callback
 void buffer_mmio_write(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
-    mmio_event_t new_event{'W', env->panda_guest_pc, physaddr, vaddr, size, *val, "TEMP"};
+    mmio_event_t new_event{'W', env->panda_guest_pc, physaddr, vaddr, size, *val, default_dev_name};
     mmio_events.push_back(new_event);
     return;
+}
+
+// DEVICE NAME ANNOTATIONS ---------------------------------------------------------------------------------------------
+
+// Named device range collection, helper
+void add_mmio_device(MemoryRegion* mr, MMIODevList* dev_list) {
+    mmio_device_t new_dev{memory_region_name(mr), mr->addr, (hwaddr)(mr->addr + mr->size)};
+    (*dev_list).push_back(new_dev);
+}
+
+// Named device range collection, worker
+// Creates list most-to-least specific per subtree, so later O(n) lookup will find most specific match, example:
+//  0x0000 - 0xFFFF: system
+//      0x00AA - 0x00BB: bus_1
+//          0x00AD - 0x00AE: device_1
+//          0x00AE - 0x00AF: device_2
+//      0x00BB - 0x00CC: bus_2
+//          0x00BD - 0x00BE: device_3
+//          0x00BE - 0x00BF: device_4
+//  MMIODevList -> {device_1, device_2, bus_1, device_3, device_4, bus_2, system}
+void collect_mmio_dev_ranges(MemoryRegion* mr, MMIODevList* dev_list) {
+
+    MemoryRegion *subregion;
+
+    // Leaf hit
+    if QTAILQ_EMPTY(&(mr->subregions)) {
+
+        add_mmio_device(mr, dev_list);
+
+    // Search children
+    } else {
+
+        QTAILQ_FOREACH(subregion, &(mr->subregions), subregions_link) {
+            collect_mmio_dev_ranges(subregion, dev_list);
+        }
+        add_mmio_device(mr, dev_list);
+    }
+}
+
+// Named device range collection, wrapper
+MMIODevList get_mmio_dev_ranges(void) {
+
+    MemoryRegion *mr = get_system_memory();
+    MMIODevList dev_list;
+
+    while (mr->container) {
+        mr = mr->container;
+    }
+
+    collect_mmio_dev_ranges(mr, &dev_list);
+    return dev_list;
+}
+
+// Annotate every event with the name of the corresponding MMIO device
+void annotate_dev_names() {
+
+    MMIODevList dev_list = get_mmio_dev_ranges();
+
+    for (auto& event : mmio_events) {
+
+        auto it = std::find_if(
+            dev_list.begin(),
+            dev_list.end(),
+            [event](mmio_device_t dev) {
+                return (dev.start_addr <= event.phys_addr) && (event.phys_addr <= dev.end_addr);
+            }
+        );
+
+        if (it != dev_list.end()) {
+            event.dev_name = (*it).name;
+        }
+    }
 }
 
 // FILE I/O ------------------------------------------------------------------------------------------------------------
@@ -52,13 +125,20 @@ void flush_to_mmio_log_file() {
 
     if (!fn_str) { return; }    // Pre-condition
 
+    annotate_dev_names();
+
     std::ofstream out_log_file(fn_str);
     int hex_width = (sizeof(target_ulong) << 1);
+    auto delim = ",\n";
+    auto optional_delim = "";
+
+    out_log_file << "[" << std::endl;
 
     for (auto const& event : mmio_events) {
 
         // Write log line, hacky JSON
         out_log_file
+            << optional_delim
             << std::hex << std::setfill('0') << "{ "
             << "\"type\": \"" << event.access_type << "\", "
             << "\"guest_pc\": \"0x" << std::setw(hex_width) << event.pc << "\", "
@@ -67,15 +147,18 @@ void flush_to_mmio_log_file() {
             << "\"size\": \"0x" << std::setw(hex_width) << event.size << "\", "
             << "\"value\": \"0x" << std::setw(hex_width) << event.value << "\", "
             << "\"device\": \"" << event.dev_name << "\""
-            << " } " << std::endl;
+            << " }";
 
         // Validate write
         if (!out_log_file.good()) {
             std::cerr << "Error writing to " << fn_str << std::endl;
             return;
         }
+
+        optional_delim = delim;
     }
 
+    out_log_file << std::endl << "]" << std::endl;
     out_log_file.close();
 }
 
@@ -83,6 +166,8 @@ void flush_to_mmio_log_file() {
 
 // C-compatible external API, caller responsible for freeing memory
 mmio_event_t* get_mmio_events(int* arr_size_ret) {
+
+    annotate_dev_names();
 
     // Note: mmio_events might be added to asynchronously as this function is executing! (but is never subtracted from)
     //  - We cannot use mmio_events.end() as a race may cause heap overflow
@@ -105,7 +190,7 @@ bool init_plugin(void* self) {
     panda_cb pcb;
     panda_arg_list* panda_args = panda_get_args("mmio_trace");
 
-    fn_str = panda_parse_string_opt(panda_args, "out_log", nullptr, "File to write MMIO trace log to.");
+    fn_str = panda_parse_string_opt(panda_args, "out_log", nullptr, "JSON file to write MMIO trace log to.");
     if (!fn_str) {
         std::cerr << "No \'out_log\' specified, MMIO R/W will not be logged!" << std::endl;
     }

--- a/panda/plugins/mmio_trace/mmio_trace.cpp
+++ b/panda/plugins/mmio_trace/mmio_trace.cpp
@@ -39,7 +39,7 @@ void buffer_mmio_read(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, 
     return;
 }
 
-// PANDA_CB_MMIO_AFTER_WRITE callback
+// PANDA_CB_MMIO_BEFORE_WRITE callback
 void buffer_mmio_write(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
     mmio_event_t new_event{'W', env->panda_guest_pc, physaddr, vaddr, size, *val, default_dev_name};
     mmio_events.push_back(new_event);
@@ -52,6 +52,7 @@ void buffer_mmio_write(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr,
 void add_mmio_device(MemoryRegion* mr, MMIODevList* dev_list) {
     mmio_device_t new_dev{memory_region_name(mr), mr->addr, (hwaddr)(mr->addr + mr->size)};
     (*dev_list).push_back(new_dev);
+    printf("Found: %s\n", memory_region_name(mr));
 }
 
 // Named device range collection, worker
@@ -200,8 +201,8 @@ bool init_plugin(void* self) {
     pcb.mmio_after_read = buffer_mmio_read;
     panda_register_callback(self, PANDA_CB_MMIO_AFTER_READ, pcb);
 
-    pcb.mmio_after_write = buffer_mmio_write;
-    panda_register_callback(self, PANDA_CB_MMIO_AFTER_WRITE, pcb);
+    pcb.mmio_before_write = buffer_mmio_write;
+    panda_register_callback(self, PANDA_CB_MMIO_BEFORE_WRITE, pcb);
 
     return true;
 }

--- a/panda/plugins/mmio_trace/mmio_trace.cpp
+++ b/panda/plugins/mmio_trace/mmio_trace.cpp
@@ -33,8 +33,8 @@ extern "C" {
 // CALLBACKS -----------------------------------------------------------------------------------------------------------
 
 // PANDA_CB_MMIO_AFTER_READ callback
-void buffer_mmio_read(CPUState *env, target_ptr_t addr, size_t size, uint64_t val) {
-    mmio_event_t new_event{'R', env->panda_guest_pc, addr, size, val, default_dev_name};
+void buffer_mmio_read(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val) {
+    mmio_event_t new_event{'R', env->panda_guest_pc, addr, size, *val};
     mmio_events.push_back(new_event);
     return;
 }

--- a/panda/plugins/mmio_trace/mmio_trace.h
+++ b/panda/plugins/mmio_trace/mmio_trace.h
@@ -1,11 +1,23 @@
+#include <vector>
 #include "panda/plugin.h"
 #include "panda/common.h"
 
-// Struct instead of std::tuple for C-compatible API
+// Structs instead of std::tuple for C-compatible API
+
 typedef struct mmio_event_t {
     char access_type;
     vaddr prog_counter;
     target_ptr_t phys_addr;
     size_t size;
     uint64_t value;
+    const char* dev_name;
 } mmio_event_t;
+
+typedef struct mmio_device_t {
+    const char* name;
+    hwaddr start_addr;
+    hwaddr end_addr;
+} mmio_device_t;
+
+typedef std::vector<mmio_event_t> MMIOEventList;
+typedef std::vector<mmio_device_t> MMIODevList;

--- a/panda/plugins/mmio_trace/mmio_trace.h
+++ b/panda/plugins/mmio_trace/mmio_trace.h
@@ -14,4 +14,11 @@ typedef struct mmio_event_t {
     const char* dev_name;
 } mmio_event_t;
 
+typedef struct mmio_device_t {
+    const char* name;
+    hwaddr start_addr;
+    hwaddr end_addr;
+} mmio_device_t;
+
+typedef std::vector<mmio_device_t> MMIODevList;
 typedef std::vector<mmio_event_t> MMIOEventList;

--- a/panda/plugins/mmio_trace/mmio_trace.h
+++ b/panda/plugins/mmio_trace/mmio_trace.h
@@ -6,18 +6,12 @@
 
 typedef struct mmio_event_t {
     char access_type;
-    vaddr prog_counter;
+    vaddr pc;
     target_ptr_t phys_addr;
+    target_ptr_t virt_addr;
     size_t size;
     uint64_t value;
     const char* dev_name;
 } mmio_event_t;
 
-typedef struct mmio_device_t {
-    const char* name;
-    hwaddr start_addr;
-    hwaddr end_addr;
-} mmio_device_t;
-
 typedef std::vector<mmio_event_t> MMIOEventList;
-typedef std::vector<mmio_device_t> MMIODevList;

--- a/panda/pypanda/panda/include/panda_datatypes.h
+++ b/panda/pypanda/panda/include/panda_datatypes.h
@@ -447,17 +447,18 @@ typedef union panda_cb {
         Called after MMIO memory is read.
 
        Arguments:
-        CPUState *env:     the current CPU state
-        target_ptr_t addr: the (physical) address being read from
-        size_t size:       the size of the read
-        uin64_t *val:      the value being read
+        CPUState *env:          the current CPU state
+        target_ptr_t physaddr:  the physical address being read from
+        target_ptr_t vaddr:     the virtual address being read from
+        size_t size:            the size of the read
+        uin64_t *val:           the value being read
 
        Helper call location: cputlb.c
 
        Return value:
         none
     */
-    void (*mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val);
+    void (*mmio_after_read)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 
     /* Callback ID: PANDA_CB_MMIO_AFTER_WRITE
 
@@ -465,17 +466,18 @@ typedef union panda_cb {
         Called after MMIO memory is written to.
 
        Arguments:
-        CPUState *env:     the current CPU state
-        target_ptr_t addr: the (physical) address being written to
-        size_t size:       the size of the write
-        uin64_t val:       the value being written
+        CPUState *env:          the current CPU state
+        target_ptr_t physaddr:  the physical address being written to
+        target_ptr_t vaddr:     the virtual address being written to
+        size_t size:            the size of the write
+        uin64_t *val:           the value being written
 
        Helper call location: cputlb.c
 
        Return value:
         none
     */
-    void (*mmio_after_write)(CPUState *env, target_ptr_t addr, size_t size, uint64_t val);
+    void (*mmio_after_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 
     /* Callback ID: PANDA_CB_HD_READ
        hd_read : called when there is a hard drive read
@@ -703,7 +705,7 @@ typedef union panda_cb {
         produced by a 32bit of PANDA, and vice-versa.
         There are more internal structs that suffer from the same issue.
         This is an oversight that will eventually be fixed. But as the
-        real impact is minimal (virtually nobody uses 32bit builds), 
+        real impact is minimal (virtually nobody uses 32bit builds),
         the fix has a very low priority in the bugfix list.
     */
     void (*replay_handle_packet)(CPUState *env, uint8_t *buf, size_t size, uint8_t direction, uint64_t buf_addr_rec);

--- a/panda/pypanda/panda/include/panda_datatypes.h
+++ b/panda/pypanda/panda/include/panda_datatypes.h
@@ -37,7 +37,7 @@ typedef enum panda_cb_type {
     PANDA_CB_PHYS_MEM_AFTER_WRITE,  // After write of physical memory
 
     PANDA_CB_MMIO_AFTER_READ,       // After each MMIO read
-    PANDA_CB_MMIO_AFTER_WRITE,      // After each MMIO write
+    PANDA_CB_MMIO_BEFORE_WRITE,     // Before each MMIO write
 
     PANDA_CB_HD_READ,               // Each HDD read
     PANDA_CB_HD_WRITE,              // Each HDD write
@@ -460,9 +460,9 @@ typedef union panda_cb {
     */
     void (*mmio_after_read)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 
-    /* Callback ID: PANDA_CB_MMIO_AFTER_WRITE
+    /* Callback ID: PANDA_CB_MMIO_BEFORE_WRITE
 
-       mmio_after_write:
+       mmio_before_write:
         Called after MMIO memory is written to.
 
        Arguments:
@@ -477,7 +477,7 @@ typedef union panda_cb {
        Return value:
         none
     */
-    void (*mmio_after_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
+    void (*mmio_before_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val);
 
     /* Callback ID: PANDA_CB_HD_READ
        hd_read : called when there is a hard drive read

--- a/panda/pypanda/panda/include/panda_datatypes.h
+++ b/panda/pypanda/panda/include/panda_datatypes.h
@@ -450,14 +450,14 @@ typedef union panda_cb {
         CPUState *env:     the current CPU state
         target_ptr_t addr: the (physical) address being read from
         size_t size:       the size of the read
-        uin64_t val:       the value being read
+        uin64_t *val:      the value being read
 
        Helper call location: cputlb.c
 
        Return value:
         none
     */
-    void (*mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t val);
+    void (*mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val);
 
     /* Callback ID: PANDA_CB_MMIO_AFTER_WRITE
 

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -278,12 +278,12 @@ void PCB(mmio_after_read)(CPUState *env, target_ptr_t physaddr, target_ptr_t vad
     }
 }
 
-void PCB(mmio_after_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
+void PCB(mmio_before_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
 
     panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_MMIO_AFTER_WRITE]; plist != NULL;
+    for(plist = panda_cbs[PANDA_CB_MMIO_BEFORE_WRITE]; plist != NULL;
         plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.mmio_after_write(env, physaddr, vaddr, size, val);
+        if (plist->enabled) plist->entry.mmio_before_write(env, physaddr, vaddr, size, val);
     }
 }
 

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -153,7 +153,7 @@ bool PCB(insn_translate)(CPUState *env, target_ptr_t pc) {
     bool panda_exec_cb = false;
     for(plist = panda_cbs[PANDA_CB_INSN_TRANSLATE]; plist != NULL;
         plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) 
+        if (plist->enabled)
           panda_exec_cb |= plist->entry.insn_translate(env, pc);
     }
     return panda_exec_cb;
@@ -164,7 +164,7 @@ bool PCB(after_insn_translate)(CPUState *env, target_ptr_t pc) {
     bool panda_exec_cb = false;
     for(plist = panda_cbs[PANDA_CB_AFTER_INSN_TRANSLATE]; plist != NULL;
         plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) 
+        if (plist->enabled)
           panda_exec_cb |= plist->entry.after_insn_translate(env, pc);
     }
     return panda_exec_cb;
@@ -269,21 +269,21 @@ void PCB(mem_after_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
 }
 
 // These are used in cputlb.c
-void PCB(mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val) {
+void PCB(mmio_after_read)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
 
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_MMIO_AFTER_READ]; plist != NULL;
         plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.mmio_after_read(env, addr, size, val);
+        if (plist->enabled) plist->entry.mmio_after_read(env, physaddr, vaddr, size, val);
     }
 }
 
-void PCB(mmio_after_write)(CPUState *env, target_ptr_t addr, size_t size, uint64_t val) {
+void PCB(mmio_after_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
 
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_MMIO_AFTER_WRITE]; plist != NULL;
         plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.mmio_after_write(env, addr, size, val);
+        if (plist->enabled) plist->entry.mmio_after_write(env, physaddr, vaddr, size, val);
     }
 }
 
@@ -460,14 +460,14 @@ void PCB(pre_shutdown)(void) {
 
 
 // this callback allows us to swallow exceptions
-// 
+//
 // first callback that returns an exception index that *differs* from
 // the one passed as an arg wins. That is, that is what we return as
 // the new exception index, which will replace cpu->exception_index
-// 
-// Note: We still run all of the callbacks, but only one of them can 
+//
+// Note: We still run all of the callbacks, but only one of them can
 // change the current cpu exception.  Sorry.
-// 
+//
 int32_t PCB(before_handle_exception)(CPUState *cpu, int32_t exception_index) {
     panda_cb_list *plist;
     bool got_new_exception = false;
@@ -481,10 +481,10 @@ int32_t PCB(before_handle_exception)(CPUState *cpu, int32_t exception_index) {
                 got_new_exception = true;
                 new_exception = new_e;
             }
-        }                
+        }
     }
 
-    if (got_new_exception) 
+    if (got_new_exception)
         return new_exception;
 
     return exception_index;

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -269,7 +269,7 @@ void PCB(mem_after_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
 }
 
 // These are used in cputlb.c
-void PCB(mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t val) {
+void PCB(mmio_after_read)(CPUState *env, target_ptr_t addr, size_t size, uint64_t *val) {
 
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_MMIO_AFTER_READ]; plist != NULL;


### PR DESCRIPTION
* Cherry picks 3a0b1c31c22979 from `pypanda-dev` (updates `PANDA_CB_MMIO_AFTER_READ` so that plugins can modify values read)
* Updates `PANDA_CB_MMIO_AFTER_WRITE` so that plugins can modify values written. This keeps the signatures of MMIO read and write callbacks consistent, and adds some additional flexibility
* Adds virtual address to both MMIO read and write callbacks (this came up in testing a specific firmware)
* Updates `mmio-trace` plugin to log to JSON, with every access annotated with the name of the MMIO device being accessed
