### PR TITLE
Add plugin config files to /etc/panda directory.

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -272,7 +272,7 @@ endif
 	for p in $(PANDA_PLUGINS) $(EXTRA_PANDA_PLUGINS); do \
 		echo $$p; \
 		$(INSTALL_LIB) panda/plugins/panda_$$p.so "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)"; \
-		for f in $$(find panda/plugins/$$p -type f -not -name '*.d' -not -name '*.o' -not -name '*.h' -not -name '*.conf'); do \
+		for f in $$(find panda/plugins/$$p -type f -not -name '*.d' -not -name '*.o' -not -name '*.h' -not -name '*.conf' -not -name '*.ini'); do \
 			$(INSTALL_DIR) "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \
 			$(INSTALL_DATA) $$f "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \
 		done; \

--- a/Makefile.target
+++ b/Makefile.target
@@ -276,7 +276,7 @@ endif
 			$(INSTALL_DIR) "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \
 			$(INSTALL_DATA) $$f "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \
 		done; \
-		for f in $$(find panda/plugins/$$p -type f -name '*.conf'); do \
+		for f in $$(find panda/plugins/$$p -type f -name '*.conf' -o -name '*.ini'); do \
 			$(INSTALL_DIR) "$(DESTDIR)$(qemu_confdir)/$$p"; \
 			$(INSTALL_DATA) $$f "$(DESTDIR)$(qemu_confdir)/$$p"; \
 		done; \

--- a/Makefile.target
+++ b/Makefile.target
@@ -270,12 +270,16 @@ endif
 	$(INSTALL_LIB) plog_pb2.py "$(DESTDIR)$(libdir)/python2.7/site-packages"
 	$(INSTALL_DIR) "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)"
 	for p in $(PANDA_PLUGINS) $(EXTRA_PANDA_PLUGINS); do \
+		echo $$p; \
 		$(INSTALL_LIB) panda/plugins/panda_$$p.so "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)"; \
-		for f in $$(find panda/plugins/$$p -type f -not -name '*.d' -not -name '*.o' -not -name '*.h'); do \
+		for f in $$(find panda/plugins/$$p -type f -not -name '*.d' -not -name '*.o' -not -name '*.h' -not -name '*.conf'); do \
 			$(INSTALL_DIR) "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \
 			$(INSTALL_DATA) $$f "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)/$$p"; \
 		done; \
-		echo $$p; \
+		for f in $$(find panda/plugins/$$p -type f -name '*.conf'); do \
+			$(INSTALL_DIR) "$(DESTDIR)$(qemu_confdir)/$$p"; \
+			$(INSTALL_DATA) $$f "$(DESTDIR)$(qemu_confdir)/$$p"; \
+		done; \
 	done
 
 GENERATED_FILES += config-target.h plog_pb2.py

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -142,9 +142,9 @@ bool init_plugin(void *self) {
             LOG_INFO("Looking for kconffile attempt %u: %s", kconffile_try++, kconffile);
             kconffile_canon = realpath(kconffile, NULL);
         }
-        if (kconffile_canon == NULL) {  // from lib dir (installed location)
+        if (kconffile_canon == NULL) {  // from etc dir (installed location)
             if (kconffile != NULL) g_free(kconffile);
-            kconffile = g_build_filename(progdir, "..", "lib", "panda", TARGET_NAME, "osi_linux", "kernelinfo.conf", NULL);
+            kconffile = g_build_filename(CONFIG_QEMU_CONFDIR, "osi_linux", "kernelinfo.conf", NULL);
             LOG_INFO("Looking for kconffile attempt %u: %s", kconffile_try++, kconffile);
             kconffile_canon = realpath(kconffile, NULL);
         }


### PR DESCRIPTION
Some plugins have their own configuration files (`osi_linux` comes to mind). By convention, these files should be installed in the system configuration folder (/etc) when using `make install`.