### PR TITLE
Fix Callstack Consistency Issues

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -315,101 +315,55 @@ void after_block_translate(CPUState *cpu, TranslationBlock *tb) {
 }
 
 void before_block_exec(CPUState *cpu, TranslationBlock *tb) {
-    CPUArchState* env = (CPUArchState*)cpu->env_ptr;
-
-    // if the block a call returns to was interrupted before it completed, this
-    // function will be called twice - only want to remove the return value from
-    // the stack once
-    // the return value will have been removed before the attempt to run which
-    // was stopped (as we didn't know it would be stopped then), so skip it on
-    // the retry
-    bool needToCheck = true;
-    stackid curStackid = get_stackid(env);
-    std::map<stackid, target_ulong>::const_iterator it;
-    it = stoppedInfo.find(curStackid);
-    if (it != stoppedInfo.end()) {
-        target_ulong stoppedPC = stoppedInfo[curStackid];
-        if (stoppedPC == tb->pc) {
-            stoppedInfo.erase(it);
-            needToCheck = false;
-            verbose_log("callstack_instr skipping return check", tb, curStackid,
-                    false);
-        }
-    }
-
-    if (needToCheck) {
-        std::vector<stack_entry> &v = callstacks[get_stackid(env)];
-        std::vector<target_ulong> &w = function_stacks[get_stackid(env)];
-        if (v.empty()) return;
-
-        // Search up to 10 down
-        for (int i = v.size()-1; i > ((int)(v.size()-10)) && i >= 0; i--) {
-            if (tb->pc == v[i].pc) {
-                //printf("Matched at depth %d\n", v.size()-i);
-                //v.erase(v.begin()+i, v.end());
-
-                PPP_RUN_CB(on_ret, cpu, w[i]);
-                v.erase(v.begin()+i, v.end());
-                w.erase(w.begin()+i, w.end());
-
-                break;
-            }
-        }
-    }
-
-
+  CPUArchState *env = static_cast<CPUArchState *>(cpu->env_ptr);
+  std::vector<stack_entry> &v = callstacks[get_stackid(env)];
+  std::vector<target_ulong> &w = function_stacks[get_stackid(env)];
+  if (v.empty()) {
     return;
+  }
+
+  // Search up to 10 down
+  for (int i = v.size() - 1; i > ((int)(v.size() - 10)) && i >= 0; i--) {
+    if (tb->pc == v[i].pc) {
+      // printf("Matched at depth %d\n", v.size()-i);
+      // v.erase(v.begin()+i, v.end());
+
+      PPP_RUN_CB(on_ret, cpu, w[i]);
+      v.erase(v.begin() + i, v.end());
+      w.erase(w.begin() + i, w.end());
+
+      break;
+    }
+  }
 }
 
 void after_block_exec(CPUState* cpu, TranslationBlock *tb, uint8_t exitCode) {
-    target_ulong pc;
-    target_ulong cs_base;
-    uint32_t flags;
+    target_ulong pc = 0x0;
+    target_ulong cs_base = 0x0;
+    uint32_t flags = 0x0;
 
-    CPUArchState* env = (CPUArchState*)cpu->env_ptr;
+    if (TB_EXIT_IDX1 < exitCode) {
+        return;
+    }
+
+    CPUArchState *env = (CPUArchState *)cpu->env_ptr;
     instr_type tb_type = call_cache[tb->pc];
     stackid curStackid = get_stackid(env);
 
-    // sometimes an attempt to run a block is interrupted, but this callback is
-    // still made - only update the callstack if the block ran to completion
-    if (exitCode <= TB_EXIT_IDX1) {
-        // this attempt is OK, so remove it from the Stopped list, if there
-        stoppedInfo.erase(curStackid);
+    if (tb_type == INSTR_CALL) {
+        stack_entry se = {tb->pc + tb->size, tb_type};
+        callstacks[curStackid].push_back(se);
 
-        if (tb_type == INSTR_CALL) {
-            stack_entry se = {tb->pc+tb->size,tb_type};
-            callstacks[curStackid].push_back(se);
-
-            // Also track the function that gets called
-            // This retrieves the pc in an architecture-neutral way
-            cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
-            function_stacks[curStackid].push_back(pc);
-
-            PPP_RUN_CB(on_call, cpu, pc);
-        }
-        else if (tb_type == INSTR_RET) {
-            //printf("Just executed a RET in TB " TARGET_FMT_lx "\n", tb->pc);
-            //if (next) printf("Next TB: " TARGET_FMT_lx "\n", next->pc);
-        }
-    }
-    // in case this block is one that a call returns to, need to note that its
-    // execution was interrupted, so don't try to remove it from the callstack
-    // when retry (as already removed it before this attempt)
-    else {
-        // verbose output is helpful in regression testing
-        if (tb_type == INSTR_CALL) {
-            verbose_log("callstack_instr not adding Stopped caller to stack",
-                    tb, curStackid, true);
-        }
-
+        // Also track the function that gets called
+        // This retrieves the pc in an architecture-neutral way
         cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
-        // C++ maps don't let you replace value of an existing key (grr)
-        // erase nicely does nothing if key DNE
-        stoppedInfo.erase(curStackid);
-        stoppedInfo[curStackid] = pc;
-    }
+        function_stacks[curStackid].push_back(pc);
 
-    return;
+        PPP_RUN_CB(on_call, cpu, pc);
+    } else if (tb_type == INSTR_RET) {
+        //printf("Just executed a RET in TB " TARGET_FMT_lx "\n", tb->pc);
+        //if (next) printf("Next TB: " TARGET_FMT_lx "\n", next->pc);
+    }
 }
 
 


### PR DESCRIPTION
After merging PyPANDA, the callbacks made in the CPU loop were changed, however there was already a fix in `callstack_instr` for the issue the PyPANDA changes were trying to solve. It turns out, these two changes were in conflict with each other which was causing very intermittent callstack inconsistencies from run to run of the same replay.

This change removes (at least in part) the callstack fix from a year ago. I've run two of our tests where we had known intermittent callstack inconsistencies 60 times and had no issues.