### PR TITLE
Github CI: push to dockerhub

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -12,15 +12,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Docker login
-      run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
+    - name: Docker login # TODO: we need to get the pandare account on dockerhub or push to github
+      run: docker login -u fasano -p ${{secrets.fasano_dockerhub}}
+
     - name: Build Bionic container
-      run:  cd ${GITHUB_WORKSPACE}/panda/docker && docker build . -f Dockerfile_18_04 -t docker.pkg.github.com/panda-re/panda/panda_bionic:latest;
-            docker tag  docker.pkg.github.com/panda-re/panda/panda_bionic:latest docker.pkg.github.com/panda-re/panda/panda_bionic:${GITHUB_SHA};
-            docker push docker.pkg.github.com/panda-re/panda/panda_bionic:${GITHUB_SHA};
-            docker push docker.pkg.github.com/panda-re/panda/panda_bionic:latest
+      run:  cd ${GITHUB_WORKSPACE}/panda/docker && docker build . -f Dockerfile_18_04 -t fasano/panda_bionic:latest;
+            docker tag  fasano/panda_bionic:latest fasano/panda_bionic:${GITHUB_SHA};
+            docker push fasano/panda_bionic:${GITHUB_SHA};
+            docker push fasano/panda_bionic:latest
     - name: Build Xenial container
-      run:  cd ${GITHUB_WORKSPACE}/panda/docker && docker build . -f Dockerfile_16_04 -t docker.pkg.github.com/panda-re/panda/panda_xenial:latest;
-            docker tag  docker.pkg.github.com/panda-re/panda/panda_xenial:latest docker.pkg.github.com/panda-re/panda/panda_xenial:${GITHUB_SHA};
-            docker push docker.pkg.github.com/panda-re/panda/panda_xenial:${GITHUB_SHA};
-            docker push docker.pkg.github.com/panda-re/panda/panda_xenial:latest
+      run:  cd ${GITHUB_WORKSPACE}/panda/docker && docker build . -f Dockerfile_16_04 -t fasano/panda_xenial:latest;
+            docker tag  fasano/panda_xenial:latest fasano/panda_xenial:${GITHUB_SHA};
+            docker push fasano/panda_xenial:${GITHUB_SHA};
+            docker push fasano/panda_xenial:latest

--- a/.github/workflows/clean_build.yml
+++ b/.github/workflows/clean_build.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Docker login
-      run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
+    - name: Docker login # TODO: we need to get the pandare account on dockerhub or push to github
+      run: docker login -u fasano -p ${{secrets.fasano_dockerhub}}
 
     - name: Fetch pre-built bionic docker container
-      run: docker pull docker.pkg.github.com/panda-re/panda/panda_bionic:latest
+      run: docker pull fasano/panda_bionic:latest
 
     - name: Download docker/update.sh script from this commit
       run: wget "https://raw.githubusercontent.com/panda-re/panda/${GITHUB_SHA}/panda/docker/update.sh"
 
     - name: Inside container run update.sh to fetch this commit, make a *clean* build
-      run: docker run --rm -v $(pwd)/update.sh:/update.sh docker.pkg.github.com/panda-re/panda/panda_bionic bash /update.sh "$GITHUB_REF" clean
+      run: docker run --rm -v $(pwd)/update.sh:/update.sh fasano/panda_bionic bash /update.sh "$GITHUB_REF" clean

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Docker login
-      run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
+    - name: Docker login # TODO: we need to get the pandare account on dockerhub or push to github
+      run: docker login -u fasano -p ${{secrets.fasano_dockerhub}}
     - name: Fetch pre-built bionic docker container
-      run: docker pull docker.pkg.github.com/panda-re/panda/panda_bionic:latest
+      run: docker pull fasano/panda_bionic:latest
     - name: Download docker/update.sh script from this commit
       run: wget "https://raw.githubusercontent.com/panda-re/panda/${GITHUB_SHA}/panda/docker/update.sh"
     - name: Inside container run update.sh to fetch this commit and rebuild PANDA and run tests
-      run: docker run --rm -v $(pwd)/update.sh:/update.sh docker.pkg.github.com/panda-re/panda/panda_bionic bash /update.sh $GITHUB_SHA
+      run: docker run --rm -v $(pwd)/update.sh:/update.sh fasano/panda_bionic bash /update.sh $GITHUB_SHA

--- a/panda/docker/Makefile
+++ b/panda/docker/Makefile
@@ -13,13 +13,13 @@ push: bionic_push xenial_push
 SHA := $(shell git rev-parse HEAD)
 
 bionic_push: Dockerfile_18_04
-	docker build . -f Dockerfile_18_04 -t docker.pkg.github.com/panda-re/panda/panda_bionic:latest
-	docker tag docker.pkg.github.com/panda-re/panda/panda_bionic:latest docker.pkg.github.com/panda-re/panda/panda_bionic:$(SHA)
-	docker push docker.pkg.github.com/panda-re/panda/panda_bionic:$(SHA)
-	docker push docker.pkg.github.com/panda-re/panda/panda_bionic:latest
+	docker build . -f Dockerfile_18_04 -t fasano/panda_bionic:latest
+	docker tag fasano/panda_bionic:latest fasano/panda_bionic:$(SHA)
+	docker push fasano/panda_bionic:$(SHA)
+	docker push fasano/panda_bionic:latest
 
 xenial_push: Dockerfile_16_04
-	docker build . -f Dockerfile_16_04 -t docker.pkg.github.com/panda-re/panda/panda_xenial:latest
-	docker tag docker.pkg.github.com/panda-re/panda/panda_xenial:latest docker.pkg.github.com/panda-re/panda/panda_xenial:$(SHA)
-	docker push docker.pkg.github.com/panda-re/panda/panda_xenial:$(SHA)
-	docker push docker.pkg.github.com/panda-re/panda/panda_xenial:latest
+	docker build . -f Dockerfile_16_04 -t fasano/panda_xenial:latest
+	docker tag fasano/panda_xenial:latest fasano/panda_xenial:$(SHA)
+	docker push fasano/panda_xenial:$(SHA)
+	docker push fasano/panda_xenial:latest


### PR DESCRIPTION
Change CI to push to dockerhub because of permission issues pushing to github.

Will push to:
* https://hub.docker.com/repository/docker/fasano/panda_bionic
* https://hub.docker.com/repository/docker/fasano/panda_xenail


In the future we should find creds for the `pandare` account and push there