### PR TITLE
Feat/pyperipheral

### DIFF
--- a/configure
+++ b/configure
@@ -333,6 +333,7 @@ jemalloc="no"
 replication="yes"
 #AVATAR
 pyperipheral2="no"
+pyperipheral3="yes"
 
 
 supported_cpu="no"
@@ -1208,6 +1209,12 @@ for opt do
   --disable-pyperipheral2) pyperipheral2="no"
   ;;
   --enable-pyperipheral2) pyperipheral2="yes"
+      pyperipheral3="no"
+  ;;
+  --disable-pyperipheral3) pyperipheral3="no"
+  ;;
+  --enable-pyperipheral3) pyperipheral3="yes"
+      pyperipheral2="no"
   ;;
   *)
       echo "ERROR: unknown option $opt"
@@ -1457,7 +1464,8 @@ disabled with --disable-FEATURE, default is enabled if available:
   xfsctl          xfsctl support
   qom-cast-debug  cast debugging support
   tools           build qemu-io, qemu-nbd and qemu-image tools
-  pyperipheral2   avatars pyththon peripheral (based on python2.7)
+  pyperipheral2   avatar's python peripheral (based on python2.7)
+  pyperipheral3   avatar's python peripheral (based on python3.x)
 
 NOTE: The object files are built at the place where configure is launched
 EOF
@@ -5926,7 +5934,12 @@ fi
 
 if test "$pyperipheral2" = "yes" ; then
   QEMU_INCLUDES="`pkg-config --cflags-only-I python2` $QEMU_INCLUDES"
-  LIBS="-lpython2.7 $LIBS"
+  LIBS="`pkg-config --libs-only-l python2` $LIBS"
+fi
+
+if test "$pyperipheral3" = "yes" ; then
+  QEMU_INCLUDES="`pkg-config --cflags-only-I python3` $QEMU_INCLUDES"
+  LIBS="`pkg-config --libs-only-l python3` $LIBS"
 fi
 
 
@@ -6448,7 +6461,7 @@ if test "$ccache_cpp2" = "yes"; then
 fi
 
 
-if test "$pyperipheral2" = "yes" ; then
+if test "$pyperipheral2" = "yes" || test "$pyperipheral3" = "yes" ; then
   echo "CONFIG_PYPERIPHERAL=y" >> $config_target_mak
 
 fi

--- a/hw/avatar/python_peripheral.c
+++ b/hw/avatar/python_peripheral.c
@@ -43,7 +43,12 @@ static uint64_t avatar_pyperipheral_read(void *opaque, hwaddr offset,
         exit(-1);
     }
 
+#if PY_MAJOR_VERSION >= 3
+    res =  PyLong_AsUnsignedLongMask(pRes);
+#else
     res =  PyInt_AsUnsignedLongMask(pRes);
+#endif
+
 
     Py_DECREF(pRes);
     //TODO Evaluate Response
@@ -92,7 +97,15 @@ static void avatar_pyperipheral_realize(DeviceState *dev, Error **errp)
     AvatarPyPeripheralState *s = AVATAR_PYPERIPHERAL(dev);
 
     Py_Initialize();
+    PyObject* sysPath = PySys_GetObject((char*)"path");
+
+#if PY_MAJOR_VERSION >= 3
+    PyList_Append(sysPath, PyUnicode_FromString("."));
+    pFile = PyUnicode_FromString(s->python_file);
+#else
+    PyList_Append(sysPath, PyString_FromString("."));
     pFile = PyString_FromString(s->python_file);
+#endif
 
     pModule = PyImport_Import(pFile);
     if (pModule == NULL){

--- a/panda/pypanda/panda/pypanda.py
+++ b/panda/pypanda/panda/pypanda.py
@@ -31,13 +31,14 @@ from .hooking_mixins    import hooking_mixins
 from .callback_mixins   import callback_mixins
 from .taint_mixins      import taint_mixins
 from .volatility_mixins import volatility_mixins
+from .pyperiph_mixins   import pyperipheral_mixins
 
 import pdb
 
 # location of panda build dir
 panda_build = realpath(pjoin(abspath(__file__), "../../../../build"))
 
-class Panda(libpanda_mixins, blocking_mixins, osi_mixins, hooking_mixins, callback_mixins, taint_mixins, volatility_mixins):
+class Panda(libpanda_mixins, blocking_mixins, osi_mixins, hooking_mixins, callback_mixins, taint_mixins, volatility_mixins, pyperipheral_mixins):
     def __init__(self, arch="i386", mem="128M",
             expect_prompt=None, os_version=None,
             qcow=None, os="linux",

--- a/panda/pypanda/panda/pyperiph_mixins.py
+++ b/panda/pypanda/panda/pyperiph_mixins.py
@@ -1,0 +1,178 @@
+from inspect import signature
+from struct import pack_into
+
+from .ffi_importer import ffi
+
+
+class pyperipheral_mixins:
+    """
+    Pyperipherals are objects which handle mmio read/writes using the PANDA
+    callback infrastructure.
+    Under the hood, they use the cb_unassigned_io_read/cb_unassigned_io_write
+    callbacks.
+    A python peripheral itself is an object which exposes the following
+    functions:
+        write_memory(self, address, size, value)
+        read_memory(self, address, size)
+    And has at least the following attributes:
+        address
+        size
+
+    One example for such a python object are avatar2's AvatarPeripheral.
+    """
+
+    def _addr_to_pyperipheral(self, address):
+        """
+        Returns the python peripheral for a given address, or None if no
+        peripheral is registered for that address
+        """
+
+        for pp in self.pyperipherals:
+            if pp.address <= address < pp.address + pp.size:
+                return pp
+        return None
+
+    def _validate_object(self, object):
+        # This function makes sure that the object exposes the right interfaces
+
+        if not hasattr(object, "address") or not isinstance(object.address, int):
+            raise RuntimeError(
+                (
+                    "Registering PyPeripheral %s failed:\n"
+                    "Missing or non-int `address` attribute"
+                ).format(object.__repr__())
+            )
+
+        if not hasattr(object, "size") or not isinstance(object.size, int):
+            raise RuntimeError(
+                (
+                    "Registering PyPeripheral %s failed:\n"
+                    "Missing or non-int `address` attribute"
+                ).format(object.__repr__())
+            )
+
+        if not hasattr(object, "read_memory"):
+            raise RuntimeError(
+                (
+                    "Registering PyPeripheral %s failed:\n"
+                    "Missing read_memory function"
+                ).format(object.__repr__())
+            )
+
+        params = list(signature(object.read_memory).parameters)
+        if params[0] != "address" or params[1] != "size":
+            raise RuntimeError(
+                (
+                    "Registering PyPeripheral %s failed:\n"
+                    "Invalid function signature for read_memory"
+                ).format(object.__repr__())
+            )
+
+        if not hasattr(object, "write_memory"):
+            raise RuntimeError(
+                (
+                    "Registering PyPeripheral %s failed:\n"
+                    "Missing write_memory function"
+                ).format(object.__repr__())
+            )
+
+        params = list(signature(object.write_memory).parameters)
+        if params[0] != "address" or params[1] != "size" or params[2] != "value":
+            raise RuntimeError(
+                (
+                    "Registering PyPeripheral %s failed:\n"
+                    "Invalid function signature for write_memory"
+                ).format(object.__repr__())
+            )
+
+        # Ensure object is not overlapping with any other pyperipheral
+        if (
+            self._addr_to_pyperipheral(object.address) is not None
+            or self._addr_to_pyperipheral(object.address + object.size) is not None
+        ):
+            raise RuntimeError(
+                (
+                    "Registering PyPeripheral %s failed:\n" "Overlapping memories!"
+                ).format(object.__repr__())
+            )
+
+        return True
+
+    def pyperiph_read_cb(self, cpu, pc, physaddr, size, val_ptr):
+        pp = self._addr_to_pyperipheral(physaddr)
+        if pp is None:
+            return False
+
+        val = pp.read_memory(physaddr, size)
+        buf = ffi.buffer(val_ptr, size)
+
+        fmt = "{}{}".format(self._end2fmt[self.endianness], self._num2fmt[size])
+
+        pack_into(fmt, buf, 0, val)
+
+        return True
+
+    def pyperiph_write_cb(self, cpu, pc, physaddr, size, val):
+        pp = self._addr_to_pyperipheral(physaddr)
+        if pp is None:
+            return False
+
+        pp.write_memory(physaddr, size, val)
+        return True
+
+    def register_pyperipheral(self, object):
+        """
+        Registers a python peripheral, and the necessary attributes to the
+        panda-object, if not present yet.
+        """
+
+        # if we are the first pyperipheral, register the pp-dict
+        if not hasattr(self, "pyperipherals"):
+            self.pyperipherals = []
+            self.pyperipherals_registered_cb = False
+            self._num2fmt = {1: "B", 2: "H", 4: "I", 8: "Q"}
+            self._end2fmt = {"little": "<", "big": ">"}
+
+        self._validate_object(object)
+
+        if self.pyperipherals_registered_cb is False:
+            self.register_callback(
+                self.callback.unassigned_io_read,
+                self.callback.unassigned_io_read(self.pyperiph_read_cb),
+                "pyperipheral_read_callback",
+            )
+
+            self.register_callback(
+                self.callback.unassigned_io_write,
+                self.callback.unassigned_io_write(self.pyperiph_write_cb),
+                "pyperipheral_write_callback",
+            )
+
+            self.pyperipherals_registered_cb = True
+
+        self.pyperipherals.append(object)
+
+    def unregister_pyperipheral(self, pyperiph):
+        """
+        deregisters a python peripheral.
+        The pyperiph parameter can be either an object, or an address
+        Returns true if the pyperipheral was successfully removed, else false.
+        """
+
+        if isinstance(pyperiph, int) is True:
+            pp = self._addr_to_pyperipheral(pyperiph)
+            if pp is None:
+                return False
+        else:
+            if pyperiph not in self.pyperipherals:
+                return False
+            pp = pyperiph
+
+        self.pyperipherals.remove(pp)
+
+        # If we dont have any pyperipherals left, unregister callbacks
+        if len(self.pyperipherals) == 0:
+            self.disable_callback("pyperipheral_read_callback", forever=True)
+            self.disable_callback("pyperipheral_write_callback", forever=True)
+            self.pyperipherals_registered_cb = False
+        return True


### PR DESCRIPTION
This PR adds a pyperipheral compat-layer to pypanda.
This allows registering python peripherals, which are objects defined by size, address, and two functions for memory_read and memory_write, such as the [avatar2-peripherals](https://github.com/avatartwo/avatar2/blob/master/avatar2/peripherals/avatar_peripheral.py).

It also adds python3 support for classic python-peripherals which work on inlining the python-interpreter. (This, however, is not supported for pypanda.)