### PR TITLE
CI: For PRs, don't do a docker login

### DIFF
--- a/.github/workflows/clean_build.yml
+++ b/.github/workflows/clean_build.yml
@@ -19,9 +19,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Docker login
-      run: docker login -u pandare -p ${{secrets.pandare_dockerhub}}
-
     - name: Fetch pre-built bionic docker container
       run: docker pull pandare/panda:latest
 


### PR DESCRIPTION
Github CI for PRs has been failing (e.g., https://github.com/panda-re/panda/pull/530/checks?check_run_id=432712332) because the dockerhub secret can't be used in a CI job from users who aren't a part of the panda-re organization.

The docker login was unnecessary so this PR removes it and now some more CI tests might pass