### PR TITLE
Better autogenerate callback functions using macros

### DIFF
--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -616,14 +616,14 @@ typedef union panda_cb {
        Helper call location: target/i386/helper.c
 
        Return value:
-        1 if the asid should be prevented from being changed
-        0 otherwise
+        true if the asid should be prevented from being changed
+        false otherwise
 
        Notes:
         The helper is only invoked for x86. This should break a lot of the
         plugins which rely on this callback to detect context switches.
     */
-    int (*asid_changed)(CPUState *env, target_ptr_t oldval, target_ptr_t newval);
+    bool (*asid_changed)(CPUState *env, target_ptr_t oldval, target_ptr_t newval);
 
     /* Callback ID:     PANDA_CB_REPLAY_HD_TRANSFER,
 

--- a/panda/include/panda/callbacks/cb-macros.h
+++ b/panda/include/panda/callbacks/cb-macros.h
@@ -1,0 +1,127 @@
+// Macros to help with cb-support.c
+
+// The COMBINE_TYPES series of macros will combine a list of
+// (type1, var1, type2, var2, ...) into (type1 var1, type2 var2...)
+// Supports up to 10 elements (5 pairs)
+// Given a list of types and variables, combine them - (int, b, bool, d) -> (int b, bool d)
+#define COMBINE_TYPES0(...)
+#define COMBINE_TYPES1_(second, ...) second
+#define COMBINE_TYPES1(first, ...) first COMBINE_TYPES1_(__VA_ARGS__)
+#define COMBINE_TYPES2_(second, ...) second, COMBINE_TYPES1(__VA_ARGS__)
+#define COMBINE_TYPES2(first, ...) first COMBINE_TYPES2_(__VA_ARGS__)
+#define COMBINE_TYPES3_(second, ...) second, COMBINE_TYPES2(__VA_ARGS__)
+#define COMBINE_TYPES3(first, ...) first COMBINE_TYPES3_(__VA_ARGS__)
+#define COMBINE_TYPES4_(second, ...) second, COMBINE_TYPES3(__VA_ARGS__)
+#define COMBINE_TYPES4(first, ...) first COMBINE_TYPES4_(__VA_ARGS__)
+#define COMBINE_TYPES5_(second, ...) second, COMBINE_TYPES4(__VA_ARGS__)
+#define COMBINE_TYPES5(first, ...) first COMBINE_TYPES5_(__VA_ARGS__)
+#define COUNT_PAIRS_COMBINE(_1,__1,_2,__2,_3,__3,_4,__4,_5,__5,num,...) COMBINE_TYPES ## num
+#define COMBINE_TYPES(...) COUNT_PAIRS_COMBINE(__VA_ARGS__,5,ERROR,4,ERROR,3,ERROR,2,ERROR,1,ERROR)(__VA_ARGS__)
+
+// The EVERY_SECOND series of macros will subselect from a list of
+// (type1, var1, type2, var2, ...) into (var1, var2, ...)
+// Supports up to 10 elements (5 pairs)
+// Inspired by https://stackoverflow.com/a/45758785
+#define EVERY_SECOND0(...)
+#define EVERY_SECOND1_(second, ...) second 
+#define EVERY_SECOND1(first, ...) EVERY_SECOND1_(__VA_ARGS__)
+#define EVERY_SECOND2_(second, ...) second, EVERY_SECOND1(__VA_ARGS__)
+#define EVERY_SECOND2(first, ...) EVERY_SECOND2_(__VA_ARGS__)
+#define EVERY_SECOND3_(second, ...) second, EVERY_SECOND2(__VA_ARGS__)
+#define EVERY_SECOND3(first, ...) EVERY_SECOND3_(__VA_ARGS__)
+#define EVERY_SECOND4_(second, ...) second, EVERY_SECOND3(__VA_ARGS__)
+#define EVERY_SECOND4(first, ...) EVERY_SECOND4_(__VA_ARGS__)
+#define EVERY_SECOND5_(second, ...) second, EVERY_SECOND4(__VA_ARGS__)
+#define EVERY_SECOND5(first, ...) EVERY_SECOND5_(__VA_ARGS__)
+#define COUNT_PAIRS_SECOND(_1,__1,_2,__2,_3,__3,_4,__4,_5,__5,num,...) EVERY_SECOND ## num
+#define EVERY_SECOND(...) COUNT_PAIRS_SECOND(__VA_ARGS__,5,5,4,4,3,3,2,2,1,0)(__VA_ARGS__)
+
+#define ENTRY_NAME(name, ...) \
+         name (__VA_ARGS__)
+
+#define ENTRY_NAME0(name) \
+         name ()
+
+// TODO: These require name and name_upper so we can both use entry.name(...) and
+//       panda_cbs[NAME]. Unfortunatley the preprocessor can't do the case conversion
+//       for us. Is there a better way?
+
+// Normal callbacks. if enabled, call the function. No return values
+#define MAKE_VOID_CALLBACK(name_upper, name, ...) \
+    void panda_callbacks_ ## name(COMBINE_TYPES(__VA_ARGS__)) { \
+        panda_cb_list *plist; \
+        for (plist = panda_cbs[PANDA_CB_ ## name_upper]; \
+             plist != NULL; \
+             plist = panda_cb_list_next(plist)) { \
+              if (plist->enabled) \
+                plist->entry. ENTRY_NAME(name, EVERY_SECOND(__VA_ARGS__)); \
+        } \
+    }
+
+// Same as above, but the funciton takes no args
+// TODO, modify MAKE_VOID_CALLBACK to work with no arguments
+#define MAKE_VOID_CALLBACK0(name_upper, name, ...) \
+    void panda_callbacks_ ## name(void) { \
+        panda_cb_list *plist; \
+        for (plist = panda_cbs[PANDA_CB_ ## name_upper]; \
+             plist != NULL; \
+             plist = panda_cb_list_next(plist)) { \
+              if (plist->enabled) \
+                plist->entry. ENTRY_NAME0(name); \
+        } \
+    }
+
+// Normal callback. If enabled, call the function. OR all results together
+// and return true if any called function returns true
+#define MAKE_BOOL_CALLBACK(name_upper, name, ...) \
+    bool panda_callbacks_ ## name(COMBINE_TYPES(__VA_ARGS__)) { \
+        panda_cb_list *plist; \
+        bool any_true = false; \
+        for (plist = panda_cbs[PANDA_CB_ ## name_upper]; \
+             plist != NULL; \
+             plist = panda_cb_list_next(plist)) { \
+              if (plist->enabled) \
+                any_true |= plist->entry. ENTRY_NAME(name, EVERY_SECOND(__VA_ARGS__)); \
+        } \
+        return any_true; \
+    }
+
+// Callback only to be checked if in replay. These are all void because they can't change execution
+#define MAKE_REPLAY_ONLY_CALLBACK(name_upper, name, ...) \
+    void panda_callbacks_ ## name(COMBINE_TYPES(__VA_ARGS__)) { \
+        if (rr_in_replay()) { \
+          panda_cb_list *plist; \
+          for (plist = panda_cbs[PANDA_CB_ ## name_upper]; \
+               plist != NULL; \
+               plist = panda_cb_list_next(plist)) { \
+                if (plist->enabled) \
+                  plist->entry. ENTRY_NAME(name, EVERY_SECOND(__VA_ARGS__)); \
+          } \
+        } \
+    }
+
+
+#if 0
+// Coming soon
+// Memory-callbacks call both virt_mem_xyz then phys_mem_xyz
+#define MAKE_VOID_MEM_CALLBACK(name_upper, name, ...) \
+    void panda_callbacks_ ## name(COMBINE_TYPES(__VA_ARGS__)) { \
+        panda_cb_list *plist; \
+        for (plist = panda_cbs[PANDA_CB_ ## name_upper]; \
+             plist != NULL; \
+             plist = panda_cb_list_next(plist)) { \
+              if (plist->enabled) \
+                plist->entry. MEM_ENTRY_NAME(virt, name, EVERY_SECOND(__VA_ARGS__)); \
+        } \
+        if (panda_cbs[PANDA_CB_PHYS_ ## name_upper]) { \
+          hwaddr paddr = get_paddr(env, addr, ram_ptr); \
+          for(plist = panda_cbs[PANDA_CB_PHYS_ ## name_upper]; plist != NULL;
+              plist = panda_cb_list_next(plist)) {
+              if (plist->enabled) plist->entry.phys_mem_before_read(env, env->panda_guest_pc,
+                                                                    paddr, data_size);
+          }
+
+        } \
+    }
+
+#endif

--- a/panda/include/panda/callbacks/cb-macros.h
+++ b/panda/include/panda/callbacks/cb-macros.h
@@ -19,7 +19,7 @@
 // Edge case: when we get a single argument we want fn(void) which is called as fn()
 #define COMBINE_TYPES_void(...) void
 #define COUNT_PAIRS_COMBINE(_1,__1,_2,__2,_3,__3,_4,__4,_5,__5,num,...) COMBINE_TYPES ## num
-#define COMBINE_TYPES(...) COUNT_PAIRS_COMBINE(__VA_ARGS__,5,ERROR,4,ERROR,3,ERROR,2,ERROR,1,void)(__VA_ARGS__)
+#define COMBINE_TYPES(...) COUNT_PAIRS_COMBINE(__VA_ARGS__,5,ERROR,4,ERROR,3,ERROR,2,ERROR,1,_void)(__VA_ARGS__)
 
 // The EVERY_SECOND series of macros will subselect from a list of
 // (type1, var1, type2, var2, ...) into (var1, var2, ...)

--- a/panda/include/panda/callbacks/cb-macros.h
+++ b/panda/include/panda/callbacks/cb-macros.h
@@ -15,8 +15,11 @@
 #define COMBINE_TYPES4(first, ...) first COMBINE_TYPES4_(__VA_ARGS__)
 #define COMBINE_TYPES5_(second, ...) second, COMBINE_TYPES4(__VA_ARGS__)
 #define COMBINE_TYPES5(first, ...) first COMBINE_TYPES5_(__VA_ARGS__)
+
+// Edge case: when we get a single argument we want fn(void) which is called as fn()
+#define COMBINE_TYPES_void(...) void
 #define COUNT_PAIRS_COMBINE(_1,__1,_2,__2,_3,__3,_4,__4,_5,__5,num,...) COMBINE_TYPES ## num
-#define COMBINE_TYPES(...) COUNT_PAIRS_COMBINE(__VA_ARGS__,5,ERROR,4,ERROR,3,ERROR,2,ERROR,1,ERROR)(__VA_ARGS__)
+#define COMBINE_TYPES(...) COUNT_PAIRS_COMBINE(__VA_ARGS__,5,ERROR,4,ERROR,3,ERROR,2,ERROR,1,void)(__VA_ARGS__)
 
 // The EVERY_SECOND series of macros will subselect from a list of
 // (type1, var1, type2, var2, ...) into (var1, var2, ...)
@@ -55,19 +58,6 @@
              plist = panda_cb_list_next(plist)) { \
               if (plist->enabled) \
                 plist->entry. ENTRY_NAME(name, EVERY_SECOND(__VA_ARGS__)); \
-        } \
-    }
-
-// Same as above, but the funciton takes no args
-// TODO, modify MAKE_VOID_CALLBACK to work with no arguments
-#define MAKE_VOID_CALLBACK0(name_upper, name, ...) \
-    void panda_callbacks_ ## name(void) { \
-        panda_cb_list *plist; \
-        for (plist = panda_cbs[PANDA_CB_ ## name_upper]; \
-             plist != NULL; \
-             plist = panda_cb_list_next(plist)) { \
-              if (plist->enabled) \
-                plist->entry. ENTRY_NAME0(name); \
         } \
     }
 

--- a/panda/include/panda/callbacks/cb-support.h
+++ b/panda/include/panda/callbacks/cb-support.h
@@ -123,7 +123,7 @@ bool panda_callbacks_insn_translate(CPUState *env, target_ptr_t pc);
 bool panda_callbacks_after_insn_translate(CPUState *env, target_ptr_t pc);
 
 /* invoked from target/i386/helper.c */
-int panda_callbacks_asid_changed(CPUState *env, target_ptr_t oldval, target_ptr_t newval);
+bool panda_callbacks_asid_changed(CPUState *env, target_ptr_t oldval, target_ptr_t newval);
 
 /* invoked from target/i386/misc_helper.c */
 bool panda_callbacks_guest_hypercall(CPUState *env);

--- a/panda/plugins/asid_instr_count/asid_instr_count.cpp
+++ b/panda/plugins/asid_instr_count/asid_instr_count.cpp
@@ -80,9 +80,9 @@ void update_asid_rr_sub_factor(target_ulong old_asid, InstrRange rri) {
   update info about what instruction intervals belong to each asid
   which is, in turn, used to be able to know instruction count by asid
 */
-int asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
+bool asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
     // XXX I wonder why this is in here?
-    if (new_asid < 10) return 0;
+    if (new_asid < 10) return false;
     Instr instr = rr_get_guest_instr_count();
     if (old_asid != new_asid) {
         auto rri = std::make_pair(ac_instr_start, instr-1);
@@ -90,7 +90,7 @@ int asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
     }
     ac_instr_start = rr_get_guest_instr_count();        
     current_asid = new_asid;
-    return 0;
+    return false;
 }
 
 /*

--- a/panda/plugins/asidstory/asidstory.cpp
+++ b/panda/plugins/asidstory/asidstory.cpp
@@ -366,9 +366,9 @@ void saw_proc_range(CPUState *env, OsiProc *proc, uint64_t i1, uint64_t i2) {
 // block until we succeed in determining current proc. 
 // also, if proc has changed, we record the fact that a process was seen to be running
 // from now back to last asid change
-int asidstory_asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
+bool asidstory_asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
     // some fool trying to use asidstory for boot? 
-    if (new_asid == 0) return 0;
+    if (new_asid == 0) return false;
     
     uint64_t curr_instr = rr_get_guest_instr_count();
     
@@ -403,7 +403,7 @@ int asidstory_asid_changed(CPUState *env, target_ulong old_asid, target_ulong ne
     
     if (debug) printf ("asid_changed: process_mode unknown\n");
 
-    return 0;
+    return false;
 }
 
 

--- a/panda/plugins/filereadmon/filereadmon.cpp
+++ b/panda/plugins/filereadmon/filereadmon.cpp
@@ -157,12 +157,12 @@ void my_NtCreateFile_return(CPUState *cpu, target_ulong pc, uint32_t FileHandle,
 /*
   called whenever asid changes
 */
-int asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
+bool asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
     // XXX I wonder why this is in here?
-    if (new_asid < 10) return 0;
+    if (new_asid < 10) return false;
 
     current_asid = new_asid;
-    return 0;
+    return false;
 }
 
 #endif

--- a/panda/plugins/loaded_libs/loaded_libs.cpp
+++ b/panda/plugins/loaded_libs/loaded_libs.cpp
@@ -21,18 +21,18 @@ using namespace std;
 typedef target_ulong Asid;
 map<Asid, vector<vector<OsiModule>>> asid_module_list; 
 
-int asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd);
+bool asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd);
 
 const char* program_name; 
 
-int asid_changed(CPUState *env, target_ulong old_pgd, target_ulong new_pgd) {
+bool asid_changed(CPUState *env, target_ulong old_pgd, target_ulong new_pgd) {
     OsiProc *current =  get_current_process(env); 
     target_ulong asid = panda_current_asid(env); 
     GArray *ms = get_libraries(env, current); 
 
     //if (current) printf("current->name: %s  asid: " TARGET_FMT_lx "\n", current->name, asid);
-    if (program_name != NULL && strcmp(current->name, program_name) != 0) return 0; 
-    if (ms == NULL) return 0; 
+    if (program_name != NULL && strcmp(current->name, program_name) != 0) return false; 
+    if (ms == NULL) return false; 
 
     vector<OsiModule> module_list;
     for (int i = 0; i < ms->len; i++) { 
@@ -49,7 +49,7 @@ int asid_changed(CPUState *env, target_ulong old_pgd, target_ulong new_pgd) {
     }
     asid_module_list[asid].push_back(module_list); 
 
-    return 0;
+    return false;
 }
 
 bool init_plugin(void *self) {

--- a/panda/plugins/osi_test/osi_test.c
+++ b/panda/plugins/osi_test/osi_test.c
@@ -27,7 +27,7 @@ PANDAENDCOMMENT */
 bool init_plugin(void *);
 void uninit_plugin(void *);
 
-int asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd);
+bool asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd);
 void before_block_exec(CPUState *cpu, TranslationBlock *tb);
 void after_block_exec(CPUState *cpu, TranslationBlock *tb, uint8_t exitCode);
 
@@ -103,11 +103,11 @@ void after_block_exec(CPUState *cpu, TranslationBlock *tb, uint8_t exitCode) {
     return;
 }
 
-int asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd) {
+bool asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd) {
     // tb argument is not used by before_block_exec()
     before_block_exec(cpu, NULL);
     after_block_exec(cpu, NULL, TB_EXIT_IDX0);
-    return 0;
+    return false;
 }
 
 bool init_plugin(void *self) {

--- a/panda/plugins/taint2/taint2.cpp
+++ b/panda/plugins/taint2/taint2.cpp
@@ -113,7 +113,7 @@ target_ulong savedEflags;
 // CPUArchState->eflags is marked irrelevant, so it will never have taint
 #endif
 
-int asid_changed_callback(CPUState *env, target_ulong oldval, target_ulong newval);
+bool asid_changed_callback(CPUState *env, target_ulong oldval, target_ulong newval);
 }
 
 ShadowState *shadow = nullptr; // Global shadow memory

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -10,166 +10,67 @@
 #include "exec/cpu-common.h"
 #include "exec/ram_addr.h"
 
-#define PCB(n) panda_callbacks_ ## n
+// For each callback, use MAKE_CALLBACK or MAKE_REPLAY_ONLY_CALLBACK as defined in
+#include "panda/callbacks/cb-macros.h"
 
-void PCB(replay_hd_transfer)(CPUState *cpu, Hd_transfer_type type, target_ptr_t src_addr, target_ptr_t dest_addr, size_t num_bytes) {
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-        for (plist = panda_cbs[PANDA_CB_REPLAY_HD_TRANSFER];
-             plist != NULL;
-             plist = panda_cb_list_next(plist)) {
-                 if (plist->enabled) plist->entry.replay_hd_transfer(cpu, type, src_addr, dest_addr, num_bytes);
-        }
-    }
-}
+#define PCB(name) panda_callbacks_ ## name
 
-void PCB(replay_handle_packet)(CPUState *cpu, uint8_t *buf, size_t size, uint8_t direction, uint64_t buf_addr_rec) {
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-        for (plist = panda_cbs[PANDA_CB_REPLAY_HANDLE_PACKET];
-             plist != NULL;
-             plist = panda_cb_list_next(plist)) {
-                 if (plist->enabled) plist->entry.replay_handle_packet(cpu, buf, size, direction, buf_addr_rec);
-        }
-    }
-}
-void PCB(replay_net_transfer)(CPUState *cpu, Net_transfer_type type, uint64_t src_addr, uint64_t dst_addr, size_t num_bytes) {
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-        for (plist = panda_cbs[PANDA_CB_REPLAY_NET_TRANSFER];
-             plist != NULL;
-             plist = panda_cb_list_next(plist)) {
-                 if (plist->enabled) plist->entry.replay_net_transfer(cpu, type, src_addr, dst_addr, num_bytes);
-        }
-    }
-}
+// TODO: macro names should be include return type - bools |= all cb fns, voids don't
+
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_HD_TRANSFER, replay_hd_transfer,
+                    CPUState*, cpu, Hd_transfer_type, type,
+                    target_ptr_t, src_addr, target_ptr_t, dest_addr,
+                    size_t, num_bytes)
+
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_HANDLE_PACKET, replay_handle_packet,
+                  CPUState*, cpu, uint8_t*, buf,
+                  size_t, size, uint8_t, direction,
+                  uint64_t, buf_addr_rec)
+
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_NET_TRANSFER, replay_net_transfer,
+                    CPUState*, cpu, Net_transfer_type, type,
+                    uint64_t, src_addr, uint64_t, dst_addr,
+                    size_t, num_bytes);
 
 // These are used in exec.c
-void PCB(replay_before_dma)(CPUState *cpu, const uint8_t *buf, hwaddr addr, size_t size, bool is_write) {
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-        for (plist = panda_cbs[PANDA_CB_REPLAY_BEFORE_DMA];
-             plist != NULL; plist = panda_cb_list_next(plist)) {
-            if (plist->enabled) plist->entry.replay_before_dma(cpu, buf, addr, size, is_write);
-        }
-    }
-}
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_BEFORE_DMA, replay_before_dma,
+                    CPUState*, cpu, const uint8_t*, buf,
+                    hwaddr, addr, size_t, size,
+                    bool, is_write);
 
-void PCB(replay_after_dma)(CPUState *cpu, const uint8_t *buf, hwaddr addr, size_t size, bool is_write) {
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-       for (plist = panda_cbs[PANDA_CB_REPLAY_AFTER_DMA];
-            plist != NULL; plist = panda_cb_list_next(plist)) {
-            if (plist->enabled) plist->entry.replay_after_dma(cpu, buf, addr, size, is_write);
-        }
-    }
-}
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_AFTER_DMA, replay_after_dma,
+                    CPUState*, cpu, const uint8_t*, buf,
+                    hwaddr, addr, size_t ,size,
+                    bool, is_write)
 
 // These are used in cpu-exec.c
-void PCB(before_block_exec)(CPUState *cpu, TranslationBlock *tb) {
-    panda_cb_list *plist;
-    for (plist = panda_cbs[PANDA_CB_BEFORE_BLOCK_EXEC];
-         plist != NULL; plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.before_block_exec(cpu, tb);
-    }
-}
+MAKE_VOID_CALLBACK(BEFORE_BLOCK_EXEC, before_block_exec,
+                    CPUState*, cpu, TranslationBlock*, tb);
 
+MAKE_VOID_CALLBACK(AFTER_BLOCK_EXEC, after_block_exec,
+                    CPUState*, cpu, TranslationBlock*, tb,
+                    uint8_t, exitCode);
 
-void PCB(after_block_exec)(CPUState *cpu, TranslationBlock *tb, uint8_t exitCode) {
-    panda_cb_list *plist;
-    for (plist = panda_cbs[PANDA_CB_AFTER_BLOCK_EXEC];
-         plist != NULL; plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.after_block_exec(cpu, tb, exitCode);
-    }
-}
+MAKE_VOID_CALLBACK(BEFORE_BLOCK_TRANSLATE, before_block_translate,
+                    CPUState*, cpu, target_ptr_t, pc);
 
+MAKE_VOID_CALLBACK(AFTER_BLOCK_TRANSLATE, after_block_translate,
+                    CPUState*, cpu, TranslationBlock*, tb);
 
-void PCB(before_block_translate)(CPUState *cpu, target_ptr_t pc) {
-    panda_cb_list *plist;
-    for (plist = panda_cbs[PANDA_CB_BEFORE_BLOCK_TRANSLATE];
-         plist != NULL; plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.before_block_translate(cpu, pc);
-    }
-}
+MAKE_VOID_CALLBACK(AFTER_CPU_EXEC_ENTER, after_cpu_exec_enter,
+                    CPUState*, cpu);
 
-
-void PCB(after_block_translate)(CPUState *cpu, TranslationBlock *tb) {
-    panda_cb_list *plist;
-    for (plist = panda_cbs[PANDA_CB_AFTER_BLOCK_TRANSLATE];
-         plist != NULL; plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.after_block_translate(cpu, tb);
-    }
-}
-
-void PCB(before_find_fast)(void) {
-    if (panda_plugin_to_unload) {
-        panda_plugin_to_unload = false;
-        for (int i = 0; i < MAX_PANDA_PLUGINS; i++) {
-            if (panda_plugins_to_unload[i]) {
-                panda_do_unload_plugin(i);
-                panda_plugins_to_unload[i] = false;
-            }
-        }
-    }
-    if (panda_flush_tb()) {
-        tb_flush(first_cpu);
-    }
-}
-
-bool PCB(after_find_fast)(CPUState *cpu, TranslationBlock *tb,
-                          bool bb_invalidate_done, bool *invalidate) {
-    panda_cb_list *plist;
-    if (!bb_invalidate_done) {
-        for (plist = panda_cbs[PANDA_CB_BEFORE_BLOCK_EXEC_INVALIDATE_OPT];
-             plist != NULL; plist = panda_cb_list_next(plist)) {
-            if (plist->enabled)
-              *invalidate |=
-                  plist->entry.before_block_exec_invalidate_opt(cpu, tb);
-        }
-        return true;
-    }
-    return false;
-}
-
-void PCB(after_cpu_exec_enter)(CPUState *cpu) {
-    panda_cb_list *plist;
-    for (plist = panda_cbs[PANDA_CB_AFTER_CPU_EXEC_ENTER];
-         plist != NULL; plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.after_cpu_exec_enter(cpu);
-    }
-}
-
-void PCB(before_cpu_exec_exit)(CPUState *cpu, bool ranBlock) {
-    panda_cb_list *plist;
-    for (plist = panda_cbs[PANDA_CB_BEFORE_CPU_EXEC_EXIT];
-         plist != NULL; plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.before_cpu_exec_exit(cpu, ranBlock);
-    }
-}
+MAKE_VOID_CALLBACK(BEFORE_CPU_EXEC_EXIT, before_cpu_exec_exit,
+                    CPUState*, cpu, bool, ranBlock);
 
 // These are used in target-i386/translate.c
-bool PCB(insn_translate)(CPUState *env, target_ptr_t pc) {
-    panda_cb_list *plist;
-    bool panda_exec_cb = false;
-    for(plist = panda_cbs[PANDA_CB_INSN_TRANSLATE]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled)
-          panda_exec_cb |= plist->entry.insn_translate(env, pc);
-    }
-    return panda_exec_cb;
-}
+MAKE_BOOL_CALLBACK(INSN_TRANSLATE, insn_translate,
+                    CPUState*, env, target_ptr_t, pc);
 
-bool PCB(after_insn_translate)(CPUState *env, target_ptr_t pc) {
-    panda_cb_list *plist;
-    bool panda_exec_cb = false;
-    for(plist = panda_cbs[PANDA_CB_AFTER_INSN_TRANSLATE]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled)
-          panda_exec_cb |= plist->entry.after_insn_translate(env, pc);
-    }
-    return panda_exec_cb;
-}
+MAKE_BOOL_CALLBACK(AFTER_INSN_TRANSLATE, after_insn_translate,
+                    CPUState*, env, target_ptr_t, pc);
 
+// Custom CB
 static inline hwaddr get_paddr(CPUState *cpu, target_ptr_t addr, void *ram_ptr) {
     if (!ram_ptr) {
         return panda_virt_to_phys(cpu, addr);
@@ -185,7 +86,143 @@ static inline hwaddr get_paddr(CPUState *cpu, target_ptr_t addr, void *ram_ptr) 
     }
 }
 
-// These are used in softmmu_template.h
+// These are used in cputlb.c
+MAKE_VOID_CALLBACK(MMIO_AFTER_READ, mmio_after_read,
+                    CPUState*, env, target_ptr_t, physaddr,
+                    target_ptr_t, vaddr, size_t, size,
+                    uint64_t*, val);
+
+MAKE_VOID_CALLBACK(MMIO_BEFORE_WRITE, mmio_before_write,
+                    CPUState*, env, target_ptr_t, physaddr,
+                    target_ptr_t, vaddr, size_t, size,
+                    uint64_t*, val);
+
+// vl.c
+MAKE_VOID_CALLBACK(AFTER_MACHINE_INIT, after_machine_init,
+                    CPUState*, env);
+
+MAKE_VOID_CALLBACK(DURING_MACHINE_INIT, during_machine_init,
+                    MachineState*, machine);
+
+// Returns true if any registered&enabled callback returns non-zero.
+// If so, we'll silence the memory write error.
+MAKE_BOOL_CALLBACK(UNASSIGNED_IO_WRITE, unassigned_io_write,
+                    CPUState*, env, target_ptr_t, pc,
+                    hwaddr, addr, size_t, size,
+                   uint64_t, val);
+
+// Returns true if any registered&enabled callback returns non-zero,
+// if so, we'll silence the invalid memory read error and return
+// the value provided by the last callback in `val`
+// Note if multiple callbacks run they can each mutate val
+MAKE_BOOL_CALLBACK(UNASSIGNED_IO_READ, unassigned_io_read,
+                    CPUState*, env, target_ptr_t, pc,
+                    hwaddr, addr, size_t, size,
+                   uint64_t*, val);
+
+MAKE_VOID_CALLBACK(TOP_LOOP, top_loop,
+                    CPUState*, cpu);
+
+// Returns true if any registered + enabled callback returns nonzero.
+// If so, it doesn't let the asid change
+MAKE_BOOL_CALLBACK(ASID_CHANGED, asid_changed,
+                    CPUState*, env, target_ulong, old_asid,
+                    target_ulong, new_asid);
+
+
+// target-i386/misc_helpers.c
+MAKE_BOOL_CALLBACK(GUEST_HYPERCALL, guest_hypercall,
+                    CPUState*, env);
+
+MAKE_VOID_CALLBACK(CPU_RESTORE_STATE, cpu_restore_state,
+                    CPUState*, env, TranslationBlock*, tb);
+
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_SERIAL_RECEIVE, replay_serial_receive,
+                    CPUState*, env, target_ptr_t, fifo_addr,
+                    uint8_t, value);
+
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_SERIAL_READ, replay_serial_read,
+                    CPUState*, env, target_ptr_t, fifo_addr,
+                    uint32_t, port_addr, uint8_t, value);
+
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_SERIAL_SEND, replay_serial_send,
+                    CPUState*, env, target_ptr_t, fifo_addr,
+                    uint8_t, value);
+
+MAKE_REPLAY_ONLY_CALLBACK(REPLAY_SERIAL_WRITE, replay_serial_write,
+                    CPUState*, env, target_ptr_t, fifo_addr,
+                    uint32_t, port_addr, uint8_t, value);
+
+// XXX Callbacks with no arguments
+MAKE_VOID_CALLBACK0(MAIN_LOOP_WAIT, main_loop_wait);
+
+MAKE_VOID_CALLBACK0(PRE_SHUTDOWN, pre_shutdown);
+
+
+// Non-standard callbacks below
+
+void PCB(before_find_fast)(void) {
+    if (panda_plugin_to_unload) {
+        panda_plugin_to_unload = false;
+        for (int i = 0; i < MAX_PANDA_PLUGINS; i++) {
+            if (panda_plugins_to_unload[i]) {
+                panda_do_unload_plugin(i);
+                panda_plugins_to_unload[i] = false;
+            }
+        }
+    }
+    if (panda_flush_tb()) {
+        tb_flush(first_cpu);
+    }
+}
+bool PCB(after_find_fast)(CPUState *cpu, TranslationBlock *tb,
+                          bool bb_invalidate_done, bool *invalidate) {
+    panda_cb_list *plist;
+    if (!bb_invalidate_done) {
+        for (plist = panda_cbs[PANDA_CB_BEFORE_BLOCK_EXEC_INVALIDATE_OPT];
+             plist != NULL; plist = panda_cb_list_next(plist)) {
+            if (plist->enabled)
+              *invalidate |=
+                  plist->entry.before_block_exec_invalidate_opt(cpu, tb);
+        }
+        return true;
+    }
+    return false;
+}
+
+
+// this callback allows us to swallow exceptions
+//
+// first callback that returns an exception index that *differs* from
+// the one passed as an arg wins. That is, that is what we return as
+// the new exception index, which will replace cpu->exception_index
+//
+// Note: We still run all of the callbacks, but only one of them can
+// change the current cpu exception.  Sorry.
+
+int32_t PCB(before_handle_exception)(CPUState *cpu, int32_t exception_index) {
+    panda_cb_list *plist;
+    bool got_new_exception = false;
+    int32_t new_exception;
+
+    for (plist = panda_cbs[PANDA_CB_BEFORE_HANDLE_EXCEPTION]; plist != NULL;
+         plist = panda_cb_list_next(plist)) {
+        if (plist->enabled) {
+            int32_t new_e = plist->entry.before_handle_exception(cpu, exception_index);
+            if (!got_new_exception && new_e != exception_index) {
+                got_new_exception = true;
+                new_exception = new_e;
+            }
+        }
+    }
+
+    if (got_new_exception)
+        return new_exception;
+
+    return exception_index;
+}
+
+// These are used in softmmu_template.h. They are distinct from MAKE_VOID_CALLBACK.
 // ram_ptr is a possible pointer into host memory from the TLB code. Can be NULL.
 void PCB(mem_before_read)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
                           size_t data_size, void *ram_ptr) {
@@ -268,224 +305,3 @@ void PCB(mem_after_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     }
 }
 
-// These are used in cputlb.c
-void PCB(mmio_after_read)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
-
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_MMIO_AFTER_READ]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.mmio_after_read(env, physaddr, vaddr, size, val);
-    }
-}
-
-void PCB(mmio_before_write)(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
-
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_MMIO_BEFORE_WRITE]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.mmio_before_write(env, physaddr, vaddr, size, val);
-    }
-}
-
-// vl.c
-void PCB(after_machine_init)(CPUState *env) {
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_AFTER_MACHINE_INIT]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.after_machine_init(env);
-    }
-}
-
-void PCB(during_machine_init)(MachineState *machine) {
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_DURING_MACHINE_INIT]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.during_machine_init(machine);
-     }
-}
-
-bool PCB(unassigned_io_write)(CPUState *env, target_ptr_t pc, hwaddr addr, size_t size,
-       uint64_t val) {
-    // Returns true if any registered&enabled callback returns non-zero.
-    // If so, we'll silence the memory write error.
-
-    bool allow_invalid_write = false;
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_UNASSIGNED_IO_WRITE]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) {
-            if (0 != plist->entry.unassigned_io_write(env, pc, addr, size,
-                                                        val)) {
-                // If any callbacks return nonzero, we've silenced
-                // the error and we should pretend it's a valid write
-                allow_invalid_write  = true;
-            }
-        }
-    }
-
-    return allow_invalid_write;
-}
-
-bool PCB(unassigned_io_read)(CPUState *env, target_ptr_t pc, hwaddr addr,
-        size_t size, uint64_t *val) {
-    // Returns true if any registered&enabled callback returns non-zero,
-    // if so, we'll silence the invalid memory read error and return
-    // the value provided by the last callback in `val`
-    // Note if multiple callbacks run they can each mutate val
-
-    bool changed = false; // Did a callback change this value or should we leave it as invalid?
-
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_UNASSIGNED_IO_READ]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) {
-            if (0 != plist->entry.unassigned_io_read(env, pc, addr,
-                                                        size, val)) {
-                // If any callbacks return nonzero, that should indicate that they've written
-                // a value to val. As such, we should avoid error-processing logic in memory.c
-                changed = true;
-            }
-        }
-    }
-
-    return changed;
-}
-
-void PCB(top_loop)(CPUState *env) {
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_TOP_LOOP]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.top_loop(env);
-    }
-}
-
-// Returns 1 if any registered + enabled callback returns nonzero. If so, it doesn't let the asid change
-int PCB(asid_changed)(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
-    panda_cb_list *plist;
-    int any_nonzero = 0;
-    for(plist = panda_cbs[PANDA_CB_ASID_CHANGED]; plist != NULL; plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) {
-            if (0 != plist->entry.asid_changed(env, old_asid, new_asid))  {
-                //printf ("SOME asid_changed callback returned != 0\n");
-                // Note we don't immediately return here because we allow all registered CBs to run
-                any_nonzero = 1;
-            }
-        }
-    }
-    return any_nonzero;
-}
-
-// target-i386/misc_helpers.c
-bool PCB(guest_hypercall)(CPUState *env) {
-    int nprocessed = 0;
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_GUEST_HYPERCALL]; plist != NULL; plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) nprocessed += plist->entry.guest_hypercall(env);
-    }
-    if (nprocessed > 1) {
-        LOG_WARNING("Hypercall processed by %d > 1 plugins.", nprocessed);
-    }
-    return nprocessed ? true : false;
-}
-
-
-void PCB(cpu_restore_state)(CPUState *env, TranslationBlock *tb) {
-    panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_CPU_RESTORE_STATE]; plist != NULL;
-        plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.cpu_restore_state(env, tb);
-    }
-}
-
-void PCB(replay_serial_receive)(CPUState *cpu, target_ptr_t fifo_addr, uint8_t value)
-{
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-        for (plist = panda_cbs[PANDA_CB_REPLAY_SERIAL_RECEIVE]; plist != NULL;
-             plist = panda_cb_list_next(plist)) {
-            if (plist->enabled) plist->entry.replay_serial_receive(cpu, fifo_addr, value);
-        }
-    }
-}
-
-void PCB(replay_serial_read)(CPUState *cpu, target_ptr_t fifo_addr, uint32_t port_addr, uint8_t value)
-{
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-        for (plist = panda_cbs[PANDA_CB_REPLAY_SERIAL_READ]; plist != NULL;
-             plist = panda_cb_list_next(plist)) {
-            if (plist->enabled) plist->entry.replay_serial_read(cpu, fifo_addr, port_addr, value);
-        }
-    }
-}
-
-void PCB(replay_serial_send)(CPUState *cpu, target_ptr_t fifo_addr, uint8_t value)
-{
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-        for (plist = panda_cbs[PANDA_CB_REPLAY_SERIAL_SEND]; plist != NULL;
-             plist = panda_cb_list_next(plist)) {
-            if (plist->enabled) plist->entry.replay_serial_send(cpu, fifo_addr, value);
-        }
-    }
-}
-
-void PCB(replay_serial_write)(CPUState *cpu, target_ptr_t fifo_addr, uint32_t port_addr, uint8_t value)
-{
-    if (rr_in_replay()) {
-        panda_cb_list *plist;
-        for (plist = panda_cbs[PANDA_CB_REPLAY_SERIAL_WRITE]; plist != NULL;
-             plist = panda_cb_list_next(plist)) {
-            if (plist->enabled) plist->entry.replay_serial_write(cpu, fifo_addr, port_addr, value);
-        }
-    }
-}
-
-void PCB(main_loop_wait)(void) {
-    panda_cb_list *plist;
-    for (plist = panda_cbs[PANDA_CB_MAIN_LOOP_WAIT]; plist != NULL;
-         plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.main_loop_wait();
-    }
-}
-
-void PCB(pre_shutdown)(void) {
-    panda_cb_list *plist;
-    for (plist = panda_cbs[PANDA_CB_PRE_SHUTDOWN]; plist != NULL;
-         plist = panda_cb_list_next(plist)) {
-        plist->entry.pre_shutdown();
-    }
-}
-
-
-
-// this callback allows us to swallow exceptions
-//
-// first callback that returns an exception index that *differs* from
-// the one passed as an arg wins. That is, that is what we return as
-// the new exception index, which will replace cpu->exception_index
-//
-// Note: We still run all of the callbacks, but only one of them can
-// change the current cpu exception.  Sorry.
-//
-int32_t PCB(before_handle_exception)(CPUState *cpu, int32_t exception_index) {
-    panda_cb_list *plist;
-    bool got_new_exception = false;
-    int32_t new_exception;
-
-    for (plist = panda_cbs[PANDA_CB_BEFORE_HANDLE_EXCEPTION]; plist != NULL;
-         plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) {
-            int32_t new_e = plist->entry.before_handle_exception(cpu, exception_index);
-            if (!got_new_exception && new_e != exception_index) {
-                got_new_exception = true;
-                new_exception = new_e;
-            }
-        }
-    }
-
-    if (got_new_exception)
-        return new_exception;
-
-    return exception_index;
-}

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -44,31 +44,31 @@ MAKE_REPLAY_ONLY_CALLBACK(REPLAY_AFTER_DMA, replay_after_dma,
                     bool, is_write)
 
 // These are used in cpu-exec.c
-MAKE_VOID_CALLBACK(BEFORE_BLOCK_EXEC, before_block_exec,
+MAKE_CALLBACK(void, BEFORE_BLOCK_EXEC, before_block_exec,
                     CPUState*, cpu, TranslationBlock*, tb);
 
-MAKE_VOID_CALLBACK(AFTER_BLOCK_EXEC, after_block_exec,
+MAKE_CALLBACK(void, AFTER_BLOCK_EXEC, after_block_exec,
                     CPUState*, cpu, TranslationBlock*, tb,
                     uint8_t, exitCode);
 
-MAKE_VOID_CALLBACK(BEFORE_BLOCK_TRANSLATE, before_block_translate,
+MAKE_CALLBACK(void, BEFORE_BLOCK_TRANSLATE, before_block_translate,
                     CPUState*, cpu, target_ptr_t, pc);
 
-MAKE_VOID_CALLBACK(AFTER_BLOCK_TRANSLATE, after_block_translate,
+MAKE_CALLBACK(void, AFTER_BLOCK_TRANSLATE, after_block_translate,
                     CPUState*, cpu, TranslationBlock*, tb);
 
-MAKE_VOID_CALLBACK(AFTER_CPU_EXEC_ENTER, after_cpu_exec_enter,
+MAKE_CALLBACK(void, AFTER_CPU_EXEC_ENTER, after_cpu_exec_enter,
                     CPUState*, cpu);
 
-MAKE_VOID_CALLBACK(BEFORE_CPU_EXEC_EXIT, before_cpu_exec_exit,
+MAKE_CALLBACK(void, BEFORE_CPU_EXEC_EXIT, before_cpu_exec_exit,
                     CPUState*, cpu, bool, ranBlock);
 
 // These are used in target-i386/translate.c
-MAKE_BOOL_CALLBACK(INSN_TRANSLATE, insn_translate,
+MAKE_CALLBACK(bool, INSN_TRANSLATE, insn_translate,
                     CPUState*, env, target_ptr_t, pc);
 
-MAKE_BOOL_CALLBACK(AFTER_INSN_TRANSLATE, after_insn_translate,
-                    CPUState*, env, target_ptr_t, pc);
+MAKE_CALLBACK(bool, AFTER_INSN_TRANSLATE, after_insn_translate,
+                    CPUState*, env, target_ptr_t, pc)
 
 // Custom CB
 static inline hwaddr get_paddr(CPUState *cpu, target_ptr_t addr, void *ram_ptr) {
@@ -87,26 +87,26 @@ static inline hwaddr get_paddr(CPUState *cpu, target_ptr_t addr, void *ram_ptr) 
 }
 
 // These are used in cputlb.c
-MAKE_VOID_CALLBACK(MMIO_AFTER_READ, mmio_after_read,
+MAKE_CALLBACK(void, MMIO_AFTER_READ, mmio_after_read,
                     CPUState*, env, target_ptr_t, physaddr,
                     target_ptr_t, vaddr, size_t, size,
                     uint64_t*, val);
 
-MAKE_VOID_CALLBACK(MMIO_BEFORE_WRITE, mmio_before_write,
+MAKE_CALLBACK(void, MMIO_BEFORE_WRITE, mmio_before_write,
                     CPUState*, env, target_ptr_t, physaddr,
                     target_ptr_t, vaddr, size_t, size,
                     uint64_t*, val);
 
 // vl.c
-MAKE_VOID_CALLBACK(AFTER_MACHINE_INIT, after_machine_init,
+MAKE_CALLBACK(void, AFTER_MACHINE_INIT, after_machine_init,
                     CPUState*, env);
 
-MAKE_VOID_CALLBACK(DURING_MACHINE_INIT, during_machine_init,
+MAKE_CALLBACK(void, DURING_MACHINE_INIT, during_machine_init,
                     MachineState*, machine);
 
 // Returns true if any registered&enabled callback returns non-zero.
 // If so, we'll silence the memory write error.
-MAKE_BOOL_CALLBACK(UNASSIGNED_IO_WRITE, unassigned_io_write,
+MAKE_CALLBACK(bool, UNASSIGNED_IO_WRITE, unassigned_io_write,
                     CPUState*, env, target_ptr_t, pc,
                     hwaddr, addr, size_t, size,
                    uint64_t, val);
@@ -115,26 +115,26 @@ MAKE_BOOL_CALLBACK(UNASSIGNED_IO_WRITE, unassigned_io_write,
 // if so, we'll silence the invalid memory read error and return
 // the value provided by the last callback in `val`
 // Note if multiple callbacks run they can each mutate val
-MAKE_BOOL_CALLBACK(UNASSIGNED_IO_READ, unassigned_io_read,
+MAKE_CALLBACK(bool, UNASSIGNED_IO_READ, unassigned_io_read,
                     CPUState*, env, target_ptr_t, pc,
                     hwaddr, addr, size_t, size,
                    uint64_t*, val);
 
-MAKE_VOID_CALLBACK(TOP_LOOP, top_loop,
+MAKE_CALLBACK(void, TOP_LOOP, top_loop,
                     CPUState*, cpu);
 
 // Returns true if any registered + enabled callback returns nonzero.
 // If so, it doesn't let the asid change
-MAKE_BOOL_CALLBACK(ASID_CHANGED, asid_changed,
+MAKE_CALLBACK(bool, ASID_CHANGED, asid_changed,
                     CPUState*, env, target_ulong, old_asid,
                     target_ulong, new_asid);
 
 
 // target-i386/misc_helpers.c
-MAKE_BOOL_CALLBACK(GUEST_HYPERCALL, guest_hypercall,
+MAKE_CALLBACK(bool, GUEST_HYPERCALL, guest_hypercall,
                     CPUState*, env);
 
-MAKE_VOID_CALLBACK(CPU_RESTORE_STATE, cpu_restore_state,
+MAKE_CALLBACK(void, CPU_RESTORE_STATE, cpu_restore_state,
                     CPUState*, env, TranslationBlock*, tb);
 
 MAKE_REPLAY_ONLY_CALLBACK(REPLAY_SERIAL_RECEIVE, replay_serial_receive,
@@ -153,12 +153,12 @@ MAKE_REPLAY_ONLY_CALLBACK(REPLAY_SERIAL_WRITE, replay_serial_write,
                     CPUState*, env, target_ptr_t, fifo_addr,
                     uint32_t, port_addr, uint8_t, value);
 
-MAKE_VOID_CALLBACK(MAIN_LOOP_WAIT, main_loop_wait, void);
+MAKE_CALLBACK(void, MAIN_LOOP_WAIT, main_loop_wait, void);
 
-MAKE_VOID_CALLBACK(PRE_SHUTDOWN, pre_shutdown, void);
+MAKE_CALLBACK(void, PRE_SHUTDOWN, pre_shutdown, void);
 
 
-// Non-standard callbacks below
+// Non-standard callbacks below here
 
 void PCB(before_find_fast)(void) {
     if (panda_plugin_to_unload) {
@@ -221,7 +221,7 @@ int32_t PCB(before_handle_exception)(CPUState *cpu, int32_t exception_index) {
     return exception_index;
 }
 
-// These are used in softmmu_template.h. They are distinct from MAKE_VOID_CALLBACK.
+// These are used in softmmu_template.h. They are distinct from MAKE_CALLBACK's standard form.
 // ram_ptr is a possible pointer into host memory from the TLB code. Can be NULL.
 void PCB(mem_before_read)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
                           size_t data_size, void *ram_ptr) {
@@ -303,4 +303,3 @@ void PCB(mem_after_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
         }
     }
 }
-

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -153,10 +153,9 @@ MAKE_REPLAY_ONLY_CALLBACK(REPLAY_SERIAL_WRITE, replay_serial_write,
                     CPUState*, env, target_ptr_t, fifo_addr,
                     uint32_t, port_addr, uint8_t, value);
 
-// XXX Callbacks with no arguments
-MAKE_VOID_CALLBACK0(MAIN_LOOP_WAIT, main_loop_wait);
+MAKE_VOID_CALLBACK(MAIN_LOOP_WAIT, main_loop_wait, void);
 
-MAKE_VOID_CALLBACK0(PRE_SHUTDOWN, pre_shutdown);
+MAKE_VOID_CALLBACK(PRE_SHUTDOWN, pre_shutdown, void);
 
 
 // Non-standard callbacks below

--- a/target/i386/helper.c
+++ b/target/i386/helper.c
@@ -644,8 +644,8 @@ void cpu_x86_update_cr3(CPUX86State *env, target_ulong new_cr3)
 {
     X86CPU *cpu = x86_env_get_cpu(env);
 
-    // ret val !=0 means *dont* allow cr3 to change
-    if (0 == (panda_callbacks_asid_changed(ENV_GET_CPU(env), env->cr[3], new_cr3))) {
+    // ret false means *dont* allow cr3 to change
+    if (!panda_callbacks_asid_changed(ENV_GET_CPU(env), env->cr[3], new_cr3)) {
 
         env->cr[3] = new_cr3;
         if (env->cr[0] & CR0_PG_MASK) {


### PR DESCRIPTION
Most of cb-support.c was duplicated code with slight differences. This PR moves the commonly used patterns into macros.

This also changes `asid_changed` to be a bool instead of an int because we were just checking if it was zero or non-zero before.

I tested the macros with gcc (5.4) and clang (3.3). Assuming they'll behave the same in other versions.