### PR TITLE
API & misc bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -597,14 +597,18 @@ ifneq (,$(findstring qemu-ga,$(TOOLS)))
 endif
 endif
 
+ifneq ($(CONFIG_LINUX),)
 # The install target won't succeed if the RPATH in the .so files is longer than
 # the value need to change it to for installation purposes.  It does not matter
 # which architecture is used for the comparison - it shows up once in both the
 # new and old RPATHs, so the differences cancel out.
 # Calculate length of new RPATH.
 newrplen=$(shell newrp="$(panda_plugindir)/$(ARCH)" ; eval echo $${\#newrp})
-# Fetch current RPATH from an .so file - doesn't matter which plugin it is for.
-archdir=$(filter $(ARCH)-%,$(TARGET_DIRS))
+# Fetch current RPATH from an .so file - doesn't matter which plugin/arch it is for.
+archdir=$(lastword $(TARGET_DIRS))
+ifeq ($(archdir),)
+$(error Failed to find arch directory ${archdir})
+endif
 pwdvar=$(shell pwd)
 pathtoso=$(shell echo "$(pwdvar)/$(archdir)/panda/plugins/panda_stringsearch.so")
 cpout=$(shell chrpath -l "$(pathtoso)")
@@ -612,6 +616,7 @@ cpout=$(shell chrpath -l "$(pathtoso)")
 # adjust for that later.
 rppart=$(lastword $(cpout))
 newtoobig=$(shell oldrp="$(rppart)" ; oldrplen=`expr $${\#oldrp} - 6` ; if [ $$oldrplen -lt $(newrplen) ] ; then echo true ; else echo false ; fi)
+endif
 
 install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir
 ifeq ($(newtoobig), false)

--- a/panda/include/panda/panda_api.h
+++ b/panda/include/panda/panda_api.h
@@ -57,5 +57,6 @@ char* panda_monitor_run(char* buf);// Redefinition from monitor.h
 // Map a region of memory in the guest. WIP
 //int panda_map_physical_mem(target_ulong addr, int len);
 
+CPUState* get_cpu(void);
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 #endif

--- a/panda/plugins/taint2/taint2_int_fns.h
+++ b/panda/plugins/taint2/taint2_int_fns.h
@@ -53,6 +53,7 @@ uint32_t taint2_query(Addr a);
 uint32_t taint2_query_ram(uint64_t pa);
 uint32_t taint2_query_reg(int reg_num, int offset);
 uint32_t taint2_query_io(uint64_t ia);
+uint32_t taint2_query_laddr(uint64_t ia, uint64_t offset);
 
 // query with automatic allocation of the required memory
 uint32_t taint2_query_set_a(Addr a, uint32_t **out, uint32_t *outsz);
@@ -127,6 +128,13 @@ void taint2_query_reg_full(uint32_t reg_num, uint32_t offset, QueryResult *qr);
 // is no need to call taint2_query_results_iter unless you want to
 // iterate through labels more than once).
 void taint2_query_ram_full(uint64_t pa, QueryResult *qr);
+
+// Places taint query results for this laaddress in
+// returned qr.  qr's label set iterator is pre initialized, so there
+// is no need to call taint2_query_results_iter unless you want to
+// iterate through labels more than once).
+void taint2_query_laddr_full(uint64_t la, uint64_t offset, QueryResult *qr);
+
 
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 

--- a/panda/plugins/taint2/taint_api.h
+++ b/panda/plugins/taint2/taint_api.h
@@ -36,6 +36,7 @@ void pandalog_taint_query_free(Panda__TaintQuery *tq);
 
 uint32_t taint2_query(Addr a);
 uint32_t taint2_query_ram(uint64_t pa);
+uint32_t taint2_query_laddr(uint64_t la, uint64_t off);
 uint32_t taint2_query_reg(int reg_num, int offset);
 uint32_t taint2_query_io(uint64_t ia);
 uint32_t taint2_query_llvm(int reg_num, int offset);
@@ -70,6 +71,8 @@ void taint2_track_taint_state(void);
 void taint2_query_results_iter(QueryResult *qr);
 
 uint32_t taint2_query_result_next(QueryResult *qr, bool *done);
+
+void taint2_query_laddr_full(uint64_t reg_num, uint64_t offset, QueryResult *qr);
 
 void taint2_query_reg_full(uint32_t reg_num, uint32_t offset, QueryResult *qr);
 

--- a/panda/python/core/panda/libpanda_mixins.py
+++ b/panda/python/core/panda/libpanda_mixins.py
@@ -148,3 +148,7 @@ class libpanda_mixins():
 
     def current_asid(self, cpustate):
         return self.libpanda.panda_current_asid(cpustate)
+
+    def get_cpu(self):
+        # XXX: You rarely want this
+        return self.libpanda.get_cpu()

--- a/panda/python/core/panda/main.py
+++ b/panda/python/core/panda/main.py
@@ -231,12 +231,12 @@ class Panda(libpanda_mixins, blocking_mixins, osi_mixins, hooking_mixins, callba
         '''
         Find build directory containing ARCH-softmmu/libpanda-ARCH.so and ARCH-softmmu/panda/plugins/
         1) check relative to file (in the case of installed packages)
-        2) Check in ../../../build/
+        2) Check in../ ../../../build/
         3) raise RuntimeError
         '''
         archs = ['i386', 'x86_64', 'arm', 'ppc']
         python_package = pjoin(*[dirname(__file__), "data"])
-        local_build = realpath(pjoin(dirname(__file__), "../../../build"))
+        local_build = realpath(pjoin(dirname(__file__), "../../../../build"))
         path_end = "{0}-softmmu/libpanda-{0}.so".format(self.arch)
 
         pot_paths = [python_package, local_build]

--- a/panda/python/core/panda/main.py
+++ b/panda/python/core/panda/main.py
@@ -335,6 +335,16 @@ class Panda(libpanda_mixins, blocking_mixins, osi_mixins, hooking_mixins, callba
             self.libpanda.panda_disable_tb_chaining()
 
     def run(self):
+        '''
+        Start execution of guest. Blocks until guest finishes.
+        Initializes panda object, clears main_loop_wait fns, sets up internal callbacks
+        '''
+
+        if len(self.main_loop_wait_fnargs):
+            if debug:
+                print("Clearing prior main_loop_wait fns:", self.main_loop_wait_fnargs)
+            self.main_loop_wait_fnargs = [] # [(fn, args), ...]
+
         if debug:
             progress ("Running")
 

--- a/panda/python/core/panda/taint_mixins.py
+++ b/panda/python/core/panda/taint_mixins.py
@@ -78,3 +78,19 @@ class taint_mixins():
             return tq
         else:
             return None
+
+    # returns true if this laddr is tainted
+    def taint_check_laddr(self, addr, off):
+        if self.plugins['taint2'].taint2_query_laddr(addr, off) > 0:
+            return True
+
+    # returns array of results, one for each byte in this laddr
+    # None if no taint.  QueryResult struct otherwise
+    def taint_get_laddr(self, addr, offset):
+        if self.plugins['taint2'].taint2_query_laddr(addr, offset) > 0:
+            query_res = ffi.new("QueryResult *")
+            self.plugins['taint2'].taint2_query_laddr_full(addr, offset, query_res)
+            tq = TaintQuery(query_res, self.plugins['taint2'])
+            return tq
+        else:
+            return None

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -239,3 +239,7 @@ void map_memory(char* name, uint64_t size, uint64_t address) {
     // Add memory region to sysmem
     memory_region_add_subregion(sysmem, address, ram);
 }
+
+CPUState* get_cpu(void) {
+  return first_cpu;
+}

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -90,7 +90,11 @@ bool panda_was_aborted(void) {
 extern const char *qemu_file;
 
 void panda_set_qemu_path(char* filepath) {
-    qemu_file=filepath;
+    // *copy* filepath into a new buffer, also free & update qemu_file
+    if (qemu_file != NULL)
+      free((void*)qemu_file);
+
+    qemu_file=strdup(filepath);
 }
 
 int panda_init_plugin(char *plugin_name, char **plugin_args, uint32_t num_args) {


### PR DESCRIPTION
Bugfixes
* Fix issue with chrpath logic in makefile for when `x86_64` isn't being built and only run when building on Linux (in theory we support macs).
* Panda API: copy argument string to `panda_set_qemu_path` to fix a use-after-free.
* Pypanda: clear main_loop_wait queue before starting a new run. This was causing some issues with running a recording and then switching to a replay or live systems.
* Pypanda: fix issue with search path caused by our recent relocation of the pypanda code


This also adds two small updates:
* Panda API: Add get_cpu to panda library feature to return `first_cpu`. 
* Taint2: Add `laddr`-style interface to taint2 and in pypanda.