### PR TITLE
Stability fixes for file_faker

### DIFF
--- a/panda/python/core/setup.py
+++ b/panda/python/core/setup.py
@@ -112,7 +112,8 @@ setup(name='panda',
       author_email='fasano@mit.edu',
       url='https://github.com/panda-re/panda/',
       packages=['panda', 'panda.taint', 'panda.autogen',
-                'panda.images', 'panda.arm', 'panda.x86'],
+                'panda.images', 'panda.arm', 'panda.x86',
+                'panda.extras'],
       package_data = { 'panda': ['data/**/*', # Copy everything (fails?)
           'data/*/panda/plugins/*',    # Copy all plugins
           'data/*/panda/plugins/**/*', # Copy all plugin files


### PR DESCRIPTION
Change FakeFile->HyperFD mapping to more closely resemble how files and file descriptors are actually related.

Handle the case where ASID changes between entering and returning from a syscall.