### PR TITLE
Ubuntu install script support for 20.04

### DIFF
--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -11,7 +11,7 @@ UBUNTU_FALLBACK="xenial"
 # system information
 vendor=$(lsb_release --id | awk -F':[\t ]+' '{print $2}')
 codename=$(lsb_release --codename | awk -F':[\t ]+' '{print $2}')
-version=$(lsb_release -d | awk '{print $3}'| awk -F'.' '{print $1}')
+version=$(lsb_release -r| awk '{print $2}' | awk -F'.' '{print $1}')
 
 progress() {
   echo
@@ -44,11 +44,18 @@ apt_enable_src
 
 progress "Installing qemu dependencies..."
 sudo apt-get update || true
-sudo apt-get -y build-dep qemu
+if [ "$version" -le "19" ]; then
+  sudo apt-get -y build-dep qemu
+fi
 
 progress "Installing PANDA dependencies..."
-if [ "$version" -ge "19" ]; then
-  progress "Ubuntu 19 or higher"
+if [ "$version" -ge "20" ]; then
+  progress "Ubuntu 20 or higher"
+  sudo apt-get -y install git protobuf-compiler protobuf-c-compiler \
+    libprotobuf-c-dev libprotoc-dev python-protobuf libelf-dev libc++-dev pkg-config \
+    libwiretap-dev libwireshark-dev flex bison python3-pip python3 \
+    libglib2.0-dev libpixman-1-dev libsdl2-dev
+elif [ "$version" -eq "19" ]; then
   sudo apt-get -y install python-pip git protobuf-compiler protobuf-c-compiler \
     libprotobuf-c-dev libprotoc-dev python-protobuf libelf-dev libc++-dev pkg-config \
     libwiretap-dev libwireshark-dev flex bison python3-pip python3
@@ -56,6 +63,7 @@ else
   sudo apt-get -y install python-pip git protobuf-compiler protobuf-c-compiler \
     libprotobuf-c0-dev libprotoc-dev python-protobuf libelf-dev libc++-dev pkg-config \
     libwiretap-dev libwireshark-dev flex bison python3-pip python3
+
 fi
 pushd /tmp
 
@@ -125,8 +133,9 @@ EOF
 fi
 
 # Upgrading protocol buffers python support
-sudo pip install --upgrade protobuf
-
+if [ "$version" -le "19" ]; then
+  sudo pip install --upgrade protobuf
+fi
 progress "Trying to install LLVM 3.3..."
 if ! sudo apt-get -y install llvm-3.3-dev clang-3.3
 then
@@ -160,7 +169,13 @@ fi
 progress "Building PANDA..."
 mkdir build
 cd build
-if [ "$version" -ge "19" ]; then
+if [ "$version" -eq "20" ]; then
+  if [ -z "$@" ]; then
+    ../build.sh "x86_64-softmmu,i386-softmmu,arm-softmmu,ppc-softmmu --disable-werror --disable-pyperipheral3" 
+  else
+    ../build.sh "$@" 
+  fi
+elif [ "$version" -eq "19" ]; then
   if [ -z "$@" ]; then
     ../build.sh "x86_64-softmmu,i386-softmmu,arm-softmmu,ppc-softmmu --disable-werror" 
   else


### PR DESCRIPTION
Tested to 'work' on 16.04 18.04 19.04 and 20.04 (assuming #605 is applied).

'work' means successful installation/compilation and boot of a 20.04 live DVD as guest.


