### PR TITLE
Github Docker CI: Use less disk space

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -18,7 +18,9 @@ jobs:
       run:  cd ${GITHUB_WORKSPACE}/panda/docker && docker build . -f Dockerfile_18_04 -t pandare/panda:latest;
             docker tag  pandare/panda:latest pandare/panda:${GITHUB_SHA};
             docker push pandare/panda:${GITHUB_SHA};
-            docker push pandare/panda:latest
+            docker push pandare/panda:latest;
+            docker system prune -a;
+            docker rmi $(docker images -a -q)
 
     - name: Build Xenial container
       run:  cd ${GITHUB_WORKSPACE}/panda/docker && docker build . -f Dockerfile_16_04 -t pandare/panda_xenial:latest;


### PR DESCRIPTION
Github CI is limited by disk space and we just started running out (see [here](https://github.com/panda-re/panda/runs/596752623)). This PR adds some code to clean up our docker builds after publishing the Bionic containers to DockerHub. Hopefully this change means the jobs will be able to complete without running out of space