### PR TITLE
Modified to use asidstory to work better  

### DIFF
--- a/panda/plugins/loaded_libs/loaded_libs.cpp
+++ b/panda/plugins/loaded_libs/loaded_libs.cpp
@@ -13,26 +13,31 @@ extern "C" {
 #include "osi/osi_ext.h"
 } 
 
+#include "asidstory/asidstory.h"
+
 #include<map>
-#include <vector> 
+#include<vector> 
 #include<set>
+#include<iostream>
 using namespace std; 
 
 typedef target_ulong Asid;
 map<Asid, vector<vector<OsiModule>>> asid_module_list; 
 
-bool asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd);
+//bool asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd);
 
 const char* program_name; 
 
-bool asid_changed(CPUState *env, target_ulong old_pgd, target_ulong new_pgd) {
-    OsiProc *current =  get_current_process(env);
-    target_ulong asid = panda_current_asid(env);
-    GArray *ms = get_mappings(env, current);
+
+
+void get_libs(CPUState *env) {
+    OsiProc *current =  get_current_process(env); 
+    target_ulong asid = panda_current_asid(env); 
+    GArray *ms = get_mappings(env, current); 
 
     //if (current) printf("current->name: %s  asid: " TARGET_FMT_lx "\n", current->name, asid);
-    if (program_name != NULL && strcmp(current->name, program_name) != 0) return false; 
-    if (ms == NULL) return false; 
+    if (program_name != NULL && strcmp(current->name, program_name) != 0) return; 
+    if (ms == NULL) return; 
 
     vector<OsiModule> module_list;
     for (int i = 0; i < ms->len; i++) { 
@@ -49,17 +54,41 @@ bool asid_changed(CPUState *env, target_ulong old_pgd, target_ulong new_pgd) {
     }
     asid_module_list[asid].push_back(module_list); 
 
-    return false;
 }
+
+
+void asidstory_proc_changed(CPUState *env, target_ulong asid, OsiProc *proc) {
+    get_libs(env);
+}
+
+bool asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
+    get_libs(env);
+    return false; // allow OS to change ASID
+}
+
+void before_block(CPUState *env, TranslationBlock *tb) {
+    // check up on module list ever 50 bb
+    if (((float)(random())) / RAND_MAX < 0.02) 
+        get_libs(env);
+}
+
 
 bool init_plugin(void *self) {
     panda_require("osi"); 
     assert(init_osi_api());
+    panda_require("asidstory");
 
     panda_cb pcb;
     pcb.asid_changed = asid_changed;
     panda_register_callback(self, PANDA_CB_ASID_CHANGED, pcb);
 
+    // we'll let asidstory tell us when the process changes
+    // which should catch execv as well 
+    PPP_REG_CB("asidstory", on_proc_change, asidstory_proc_changed);
+    
+    pcb.before_block_exec = before_block;
+    panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+    
     panda_arg_list *args; 
     args = panda_get_args("general"); 
     program_name = panda_parse_string_opt(args, "program_name", NULL, "program name to collect libraries for"); 
@@ -70,9 +99,12 @@ void uninit_plugin(void *self) {
     //size_t nm = asid_module_list.size(); 
     if (!pandalog) return; 
 
+    cout << "asid_module_list is " << asid_module_list.size() << " items\n";
+
     for (auto kvp : asid_module_list) { 
         auto asid = kvp.first;
         auto all_module_list = kvp.second; // vector<vector<OsiModule>>
+        cout << "asid=" << hex << asid << " has " << dec << all_module_list.size() << "modules\n";
         int max_size = 0; 
         int i, idx;
         i = idx = 0; 


### PR DESCRIPTION
We were missing libs for programs that run via execv and complete quickly thus never seeing an asid change.  Fix uses fix to asidstory that also addressed this execv issue.  Here we also probe every 50 bb to see if libs have changed.  Seems to work much better