### PR TITLE
fixed edge covg so that it gives same results for same program and input

### DIFF
--- a/include/exec/exec-all.h
+++ b/include/exec/exec-all.h
@@ -408,7 +408,7 @@ struct TranslationBlock {
 //    uint8_t tcg_op_buf_full;
 
     // indicates if this block was split up abnormally
-//    uint8_t was_split;
+    uint8_t was_split;
 
 };
 

--- a/panda/plugins/edge_coverage/edge_coverage.cpp
+++ b/panda/plugins/edge_coverage/edge_coverage.cpp
@@ -167,6 +167,7 @@ done:
 }
 
 
+bool pandalog_trace = false;
 
 bool init_plugin(void *self) {
 
@@ -179,6 +180,7 @@ bool init_plugin(void *self) {
     // Set the default value to 1-edge or basic block coverage  
     n = panda_parse_uint64_opt(args, "n", 1, "collect up-to-and-including n-edges");
     //    no_kernel = panda_parse_bool_opt(args, "no_kernel", "disable kernel pcs"); 
+    pandalog_trace = panda_parse_bool_opt(args, "trace", "output trace to pandalog");
     const char *start_main_str = panda_parse_string_opt(args, "main", nullptr,
                                             "hex addr of main");
     if (start_main_str != nullptr) {

--- a/panda/plugins/edge_coverage/edge_coverage.cpp
+++ b/panda/plugins/edge_coverage/edge_coverage.cpp
@@ -14,16 +14,16 @@ extern "C" {
 #include "panda/plog.h"
 #include "osi/osi_types.h"
 #include "osi/osi_ext.h"
+#include "track_intexc/track_intexc_ext.h"
 
 }
 
-#include<fstream>
-#include<map>
-#include<set>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
 #include <iomanip>
 #include <vector>
-#include <iostream> 
-#include<string> 
 
 #ifdef CONFIG_SOFTMMU
 
@@ -34,121 +34,269 @@ using namespace std;
 typedef target_ulong Asid;
 typedef target_ulong Pc;
 
+target_ulong start_main = 0;
+
 map <Asid, vector<Pc>> asid_trace; 
+
+bool debug=false;
 
 // Up to n-edge coverage 
 int n;
-Pc first_instr;
-Pc last_instr;
-string program_name;
-Asid target_asid;
-bool no_kernel;
 
-vector<Pc> pc_trace;
-// Called before each block, we have PC and ASID
-void collect_edges(CPUState *env, TranslationBlock *tb) {
+
+map<target_ulong,target_ulong> last_bb_start;
+map<target_ulong,bool> last_bb_was_split;
+map<target_ulong,bool> last_bb_was_exception;
+map<target_ulong,bool> last_bb_intexc;
+map<target_ulong,target_ulong> last_bb_before_intexc;
+
+bool saw_main = false;
+
+
+void after_block(CPUState *env, TranslationBlock *tb, uint8_t exitCode) {
+
+    // only paying attention to one program and haven't seen main yet..
+    if (start_main && !saw_main) 
+        return;
 
     target_ulong asid = panda_current_asid(env);
-    target_ulong pc = panda_current_pc(env);
-    uint64_t instr = rr_get_guest_instr_count(); 
-
-    if (no_kernel && panda_in_kernel(env)) return;
-    //printf("asid: " TARGET_FMT_lx "pc: " TARGET_FMT_lx, asid, pc);  
-    if (target_asid == asid && instr >= first_instr && instr <= last_instr) {
-        //printf("asid: " TARGET_FMT_lx "pc: " TARGET_FMT_lx "\n", asid, pc);  
-        pc_trace.push_back(pc); 
-    }
-    // Gather the trace of pcs for this asid 
-    asid_trace[asid].push_back(pc); 
+    
+    // dont record pc if we are in exception or interrupt code
+    if (check_in_exception() || check_in_interrupt()) 
+        return;
+    
+    // dont record pc if last block was split
+    if (last_bb_was_split.count(asid) != 0 && !last_bb_was_split[asid])
+        last_bb_start[asid] = tb->pc;
+    
+    // keep track of if last bb was split
+    last_bb_was_split[asid] = tb->was_split; 
+    
 }
 
+
+void before_block(CPUState *env, TranslationBlock *tb) {
+    
+    if (start_main) {
+        // we are only paying attention to edges within some program
+        // and are waiting to see main
+        if (tb->pc == start_main) {
+            //   printf("saw main");
+            saw_main = true;
+        }
+        if (!saw_main)
+            return;
+    }
+    
+    target_ulong asid = panda_current_asid(env);
+    bool intexc = (check_in_exception() || check_in_interrupt());
+    
+    // we can only know transition if we know where we were for this asid last
+    if (last_bb_intexc.count(asid) != 0) {
+        
+        // four possibilities
+        
+        // 1. transition from reg to intexc code
+        if (!last_bb_intexc[asid] && intexc) {
+            // remember start pc of last bb before intexc
+            if (debug) 
+                cout << "trans from reg to intexc -- saving last_bb_before_intexc[" 
+                     << hex << asid << "]=" << last_bb_start[asid] << "\n";
+            last_bb_before_intexc[asid] = last_bb_start[asid];
+            goto done;
+        }
+        
+        // 2. transition from int/exc code to reg
+        if (last_bb_intexc[asid] && !intexc) {
+            // if this bb is just same as the last one before
+            // the int/exc, we ignore
+            if (debug) 
+                cout << "trans from intexc to reg\n";
+            if (tb->pc == last_bb_before_intexc[asid]) {
+                cout << "same last bb\n";
+                last_bb_start[asid] = tb->pc;
+                goto done;
+            }
+            // bbs have different start pc. 
+            // add bb so we'll get an edge that elides away all
+            // the intexc code
+            if (debug) {
+                cout << "not same last bb\n";
+                cout << "adding to trace last_bb_before_intexc["
+                     << hex << asid << "]=" << last_bb_before_intexc[asid] << "\n";
+                cout << "and setting last_bb_start[" << hex << asid << "]=" << tb->pc << "\n";
+            }
+
+            asid_trace[asid].push_back(last_bb_before_intexc[asid]);                     
+            // update pc in case we get longjmped
+            last_bb_start[asid] = tb->pc;
+        }
+        
+        // 3. no transition && we are in regular code
+        if (!last_bb_intexc[asid] && !intexc) {
+            // ugh last bb was split so we dont update trace yet
+            if (debug) 
+                cout << "no trans and in reg code\n";
+            if (last_bb_was_split[asid]) {
+                if (debug) 
+                    cout << "but last bb was split\n";
+                goto done;
+            }
+            if (debug) {
+                cout << "last bb not split\n";
+                cout << "adding to trace last_bb_start["
+                     << hex << asid << "]=" << last_bb_start[asid] << "\n";        
+                cout << "and setting last_bb_start[" << asid << "]=" << tb->pc << "\n";
+            }
+            
+            // update trace in normal way
+            asid_trace[asid].push_back(last_bb_start[asid]);                 
+            // update pc in case we get longjmped
+            last_bb_start[asid] = tb->pc; 
+        }
+    }
+    
+
+    // 4. last bb was intexc and so is this one
+    // -- nothing to do
+
+    // keep track of last intexc value to be able
+    // to observe transition
+done:
+    last_bb_intexc[asid] = intexc;
+}
+
+
+
 bool init_plugin(void *self) {
+
+    panda_require("track_intexc");
+    assert(init_track_intexc_api());
+
     panda_arg_list *args; 
     args = panda_get_args("edge_coverage");
 
     // Set the default value to 1-edge or basic block coverage  
     n = panda_parse_uint64_opt(args, "n", 1, "collect up-to-and-including n-edges");
-    first_instr = panda_parse_ulong_opt(args, "first_instr", 0, "first instruction");
-    last_instr = panda_parse_ulong_opt(args, "last_instr", 0, "last instruction"); 
-    target_asid = panda_parse_ulong_opt(args, "asid", 0, "asid");  
-    no_kernel = panda_parse_bool_opt(args, "no_kernel", "disable kernel pcs"); 
-
-    printf("n: %d, first_instr: " TARGET_FMT_lx " last_instr: " TARGET_FMT_lx " asid: "
-            TARGET_FMT_lx, n, first_instr, last_instr, target_asid); 
-    cout << " Program name: " << program_name << endl;;  
+    //    no_kernel = panda_parse_bool_opt(args, "no_kernel", "disable kernel pcs"); 
+    const char *start_main_str = panda_parse_string_opt(args, "main", nullptr,
+                                            "hex addr of main");
+    if (start_main_str != nullptr) {
+        start_main = strtoul(start_main_str, NULL, 16);
+        //        printf ("edge coverage for just one program: start_main = 0x%" PRIx64 "\n", (uint64_t) start_main);
+        printf ("edge coverage for just one program: start_main = 0x" TARGET_FMT_lx "\n", start_main);
+    }
+    else 
+        printf ("edge coverage for all asids and all code\n");
     
     panda_require("osi");
     assert(init_osi_api()); // Setup OSI inspection
     panda_cb pcb;
-    pcb.before_block_exec = collect_edges;
+    pcb.before_block_exec = before_block;
     panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+    pcb.after_block_exec = after_block;
+    panda_register_callback(self, PANDA_CB_AFTER_BLOCK_EXEC, pcb);
     printf("Initialized coverage plugin\n");
     return true;
 }
+
 
 
 void uninit_plugin(void *) {
 
     if (!pandalog) return; 
 
-    map<vector<Pc>, int> edges;
+    map<Asid, map<vector<Pc>, int>> final_map; 
 
-    for (int k = 1; k <= n; k++) { 
-        for (int i = 0; i < pc_trace.size(); i++) {
-            // Build the edge (vector) 
-            vector<Pc> edge;
-            for (int j = 0; j < k; j++) { 
-                edge.push_back(pc_trace[i + j]); 
+    // From the traces in each asid, collect up to n-edges 
+    for (auto kvp : asid_trace) { 
+        map<vector<Pc>, int> edges;
+        auto asid = kvp.first;
+        auto pc_trace = kvp.second; 
+        ofstream tracef;
+        for (int k = 1; k <= n; k++) { 
+            for (int i = 0; i < pc_trace.size(); i++) {
+                // Build the edge (vector) 
+                vector<Pc> edge;
+                for (int j = 0; j < k; j++) { 
+                    if (i+j < pc_trace.size()) 
+                        edge.push_back(pc_trace[i + j]);                     
+                }
+                // Add the edge to the map for this asid and update its count  
+                if (edges.find(edge) != edges.end())  edges[edge] += 1;
+                else  edges[edge] = 1; 
             }
-            // Add the edge to the map for this asid and update its count  
-            if (edges.find(edge) != edges.end())  edges[edge] += 1;
-            else  edges[edge] = 1; 
+        }
+        if (pandalog_trace) {
+            Panda__AsidTrace *at = (Panda__AsidTrace *) malloc (sizeof(Panda__AsidTrace));
+            *at = PANDA__ASID_TRACE__INIT;
+            at->pcs = (uint64_t *) malloc(sizeof(uint64_t) * pc_trace.size());
+            int i=0;
+            for (auto pc : pc_trace) 
+                at->pcs[i++] = pc;
+            at->n_pcs = pc_trace.size();	  
+            Panda__LogEntry ple = PANDA__LOG_ENTRY__INIT;
+            ple.has_asid = 1;
+            ple.asid = asid;
+            ple.trace = at;
+            pandalog_write_entry(&ple);
+            free(at->pcs);
+            free(at);
+            final_map[asid] = edges; 
         }
     }
 
-    Panda__AsidEdges * ae = (Panda__AsidEdges *) malloc (sizeof (Panda__AsidEdges)); 
-    *ae = PANDA__ASID_EDGES__INIT; 
+    // Write out each to a pandalog 
+    for (auto kvp: final_map) { 
+        auto asid = kvp.first;
+        auto edge_map = kvp.second; 
 
-    ae->n_edges = edges.size(); 
-    Panda__Edge ** e = (Panda__Edge **) malloc (sizeof (Panda__Edge *) * edges.size()); 
+        Panda__AsidEdges * ae = (Panda__AsidEdges *) malloc (sizeof (Panda__AsidEdges)); 
+        *ae = PANDA__ASID_EDGES__INIT; 
 
-    int i = 0;
-    for (auto kvp : edges) { 
-        auto n_edge = kvp.first;
-        auto hit_count = kvp.second;
+        ae->n_edges = edge_map.size(); 
+        Panda__Edge ** e = (Panda__Edge **) malloc (sizeof (Panda__Edge *) * edge_map.size()); 
 
-        e[i] = (Panda__Edge *) malloc (sizeof (Panda__Edge)); 
-        *(e[i]) = PANDA__EDGE__INIT;
+        int i = 0;
+        for (auto kvp : edge_map) { 
+            auto n_edge = kvp.first;
+            auto hit_count = kvp.second;
 
-        //e[i]->n = n_edge.size(); 
-        uint64_t *pc_list = (uint64_t *) malloc (sizeof (uint64_t) * (n_edge.size()));
-        int j = 0;
-        for (auto edge : n_edge) {
-            pc_list[j++] = edge; 
+            e[i] = (Panda__Edge *) malloc (sizeof (Panda__Edge)); 
+            *(e[i]) = PANDA__EDGE__INIT;
+
+            //e[i]->n = n_edge.size(); 
+            uint64_t *pc_list = (uint64_t *) malloc (sizeof (uint64_t) * (n_edge.size()));
+            int j = 0;
+            for (auto edge : n_edge) {
+                pc_list[j++] = edge; 
+            }
+            if (pc_list[0] == 0x7ffff7ad9810 && pc_list[1] == 0x7ffff7ad9810)
+                printf ("Blah blah blah\n");
+
+            e[i]->pc = pc_list;
+            e[i]->n_pc = n_edge.size();
+            e[i]->hit_count = hit_count; 
+            i++; 
+        } 
+        ae->edges = e; 
+
+
+        Panda__LogEntry ple = PANDA__LOG_ENTRY__INIT; 
+        ple.has_asid = 1;
+        ple.asid = asid; 
+        ple.edge_coverage = ae; 
+        pandalog_write_entry(&ple); 
+
+        // Free everything I used
+        for (int i = 0; i < edge_map.size(); i++) { 
+            free(e[i]->pc);
+            free(e[i]); 
         }
-        e[i]->pc = pc_list;
-        e[i]->n_pc = n_edge.size();
-        e[i]->hit_count = hit_count; 
-        i++; 
+        free(e); 
+        free(ae); 
     } 
-    ae->edges = e; 
 
-
-    Panda__LogEntry ple = PANDA__LOG_ENTRY__INIT; 
-    ple.has_asid = 1;
-    ple.asid = target_asid; 
-    ple.edge_coverage = ae; 
-    pandalog_write_entry(&ple); 
-
-    // Free everything I used
-    for (int i = 0; i < edges.size(); i++) { 
-        free(e[i]->pc);
-        free(e[i]); 
-    }
-    free(e); 
-    free(ae); 
-} 
-
-//}
+}
 
 

--- a/panda/plugins/edge_coverage/edge_coverage.proto
+++ b/panda/plugins/edge_coverage/edge_coverage.proto
@@ -8,3 +8,10 @@ message AsidEdges {
 }
 
 optional AsidEdges edge_coverage = 41;  
+
+
+message AsidTrace {
+    repeated uint64 pcs = 1; 
+}   
+
+optional AsidTrace trace = 43;

--- a/target/i386/translate.c
+++ b/target/i386/translate.c
@@ -8466,7 +8466,7 @@ void gen_intermediate_code(CPUX86State *env, TranslationBlock *tb)
 //            replay_interrupt = true;
         }
 //        tb->tcg_op_buf_full = false;
-//        tb->was_split = false;
+        tb->was_split = false;
     }
 
     uint64_t rr_updated_instr_count = rr_get_guest_instr_count();
@@ -8592,7 +8592,7 @@ generate_debug:
 //                tb->replay_interrupt = true;
 //            if (tcg_op_buf_full())
 //                tb->tcg_op_buf_full = true;
-//            tb->was_split = true;
+            tb->was_split = true;
             gen_jmp_im(pc_ptr - dc->cs_base);
             gen_eob(dc);
             break;


### PR DESCRIPTION
Makes use of track_intexc to tolerate interrupts and exceptions and task switches.  Works on xmllint on an input.  Run 10 times we get virtually same set of edges every time.  There is occasionally an extra self edge that shouldn't be there but weirdly thats not deterministic!  That is, if I run replay twice I get different edges output by just one edge.  Ugh. Pushing for now even if imperfect.