### PR TITLE
Virtual Memory Read type mismatch

### DIFF
--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -109,7 +109,7 @@ static inline int panda_virtual_memory_rw(CPUState *env, target_ulong addr,
     int l;
     int ret;
     hwaddr phys_addr;
-    target_ulong page;
+    vaddr page;
 
     while (len > 0) {
         page = addr & TARGET_PAGE_MASK;


### PR DESCRIPTION
`vaddr` is always a `uint64_t` according to qemu source. On 32 bit targets `target_ulong` leads to a `uint32_t` and therefore a type mismatch.