### PR TITLE
ARM OSI

### DIFF
--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -537,13 +537,13 @@ static inline bool cpu_handle_exception(CPUState *cpu, int *ret)
             *ret = cpu->exception_index;
             cpu->exception_index = -1;
             return true;
-#else  
-            if (replay_exception()) {          // *
+#else
+            if (replay_exception()) {
 #ifdef TARGET_PPC
                 rr_exception_index_at(RR_CALLSITE_CPU_EXCEPTION_INDEX, &cpu->exception_index);
 #endif
-                CPUClass *cc = CPU_GET_CLASS(cpu);   /// *
-                cc->do_interrupt(cpu); 
+                CPUClass *cc = CPU_GET_CLASS(cpu);
+                cc->do_interrupt(cpu);
                 cpu->exception_index = -1;
             } else if (!replay_has_interrupt()) {
                 /* give a chance to iothread in replay mode */
@@ -569,7 +569,7 @@ static inline bool cpu_handle_interrupt(CPUState *cpu,
                                         TranslationBlock **last_tb)
 {
     CPUClass *cc = CPU_GET_CLASS(cpu);
-    
+
     int interrupt_request = cpu->interrupt_request;
 
 #ifdef CONFIG_SOFTMMU
@@ -782,7 +782,6 @@ int cpu_exec(CPUState *cpu)
 
     /* prepare setjmp context for exception handling */
     if (sigsetjmp(cpu->jmp_env, 0) != 0) {
-
 #if defined(__clang__) || !QEMU_GNUC_PREREQ(4, 6)
         /* Some compilers wrongly smash all local variables after
          * siglongjmp. There were bug reports for gcc 4.5.0 and clang.

--- a/include/exec/exec-all.h
+++ b/include/exec/exec-all.h
@@ -403,10 +403,6 @@ struct TranslationBlock {
     struct TranslationBlock* llvm_tb_next[2];
 #endif
 
-    // to support panda callbacks on interrupts
-//    uint8_t replay_interrupt;
-//    uint8_t tcg_op_buf_full;
-
     // indicates if this block was split up abnormally
     uint8_t was_split;
 

--- a/panda/Makefile.panda.target
+++ b/panda/Makefile.panda.target
@@ -103,6 +103,8 @@ GENERATED_FILES += $(PANDA_API_EXT)
 		$(SRC_PATH)/panda/scripts/apigen.py $< $@ -I$(SRC_PATH)/panda/include/fake_libc_include $(QEMU_INCLUDES),\
 		"API     $(TARGET_DIR)$(subst $(BUILD_DIR)/,,$@)")
 
+panda/src/callbacks.o: $(SRC_PATH)/panda/include/panda/callbacks/cb-support.h $(SRC_PATH)/panda/include/panda/callbacks/cb-defs.h
+
 # All of these will be generated according to rules in rules.mak
 obj-y += panda/src/callbacks.o
 obj-y += panda/src/cb-support.o

--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -617,15 +617,16 @@ typedef union panda_cb {
         target_ptr_t oldval: old asid value
         target_ptr_t newval: new asid value
 
-       Helper call location: target/i386/helper.c
+       Helper call location: target/i386/helper.c, target/arm/helper.c
 
        Return value:
         true if the asid should be prevented from being changed
         false otherwise
 
        Notes:
-        The helper is only invoked for x86. This should break a lot of the
-        plugins which rely on this callback to detect context switches.
+        The callback is only invoked implemented for x86 and ARM.
+        This should break plugins which rely on it to detect context
+        switches in any other architecture.
     */
     bool (*asid_changed)(CPUState *env, target_ptr_t oldval, target_ptr_t newval);
 

--- a/panda/plugins/osi/README.md
+++ b/panda/plugins/osi/README.md
@@ -29,6 +29,10 @@ The key is that you can swap out the bottom layer to support a new operating sys
   };
   ```
 
+## Plugin Arguments
+
+* `disable-autoload`: bool, defaults to false. OSI will try to automatically load an OSI provider plugin unless this set. Useful if you need to initialize an OSI provider plugin with non-default arguments.
+
 ## Dependencies
 Depends on some OS-specific plugin to register callbacks that implement the various APIs OSI exposes. Otherwise, any call to OSI will simply fail to return any useful data, as the OSI plugin itself does not know anything about specific operating systems.
 

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -127,6 +127,15 @@ bool init_plugin(void *self) {
     // No os supplied on command line? E.g. -os linux-32-ubuntu:4.4.0-130-generic
     assert (!(panda_os_familyno == OS_UNKNOWN));
 
+    bool disable_os_autoload;
+    panda_arg_list *plugin_args = panda_get_args(PLUGIN_NAME);
+    disable_os_autoload = panda_parse_bool_opt(plugin_args, "disable-autoload", "When set, OSI won't automatically load osi_linux/wintrospection");
+    panda_free_args(plugin_args);
+
+    if (disable_os_autoload) {
+        return true;
+    }
+
     // figure out what kind of os introspection is needed and grab it? 
     if (panda_os_familyno == OS_LINUX) {
         // sadly, all of this is to find kernelinfo.conf file

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -195,3 +195,10 @@ OsiModule* get_one_module(GArray *osimodules, unsigned int idx) {
     OsiModule *m = &g_array_index(osimodules, OsiModule, idx);
     return m;
 }
+
+// Helper function to get a single element. Should only be used with library mode
+// when g_array_index can't be used directly.
+OsiProc* get_one_proc(GArray *osiprocs, unsigned int idx) {
+    OsiProc *m = &g_array_index(osiprocs, OsiProc, idx);
+    return m;
+}

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -136,58 +136,11 @@ bool init_plugin(void *self) {
         return true;
     }
 
-    // figure out what kind of os introspection is needed and grab it? 
+    // If not disabled_os_autoload, load OSI_linux or wintrospection (with no arguments) automatically
     if (panda_os_familyno == OS_LINUX) {
-        // sadly, all of this is to find kernelinfo.conf file
-        gchar *progname = realpath(qemu_file, NULL);
-        gchar *progdir = g_path_get_dirname(progname);
-        gchar *kconffile = NULL;
-        gchar *kconffile_canon = NULL;
-        uint8_t UNUSED(kconffile_try) = 1;
-
-        if (kconffile_canon == NULL) {  // from build dir
-            if (kconffile != NULL) g_free(kconffile);
-            kconffile = g_build_filename(progdir, "panda", "plugins", "osi_linux", "kernelinfo.conf", NULL);
-            LOG_INFO("Looking for kconffile attempt %u: %s", kconffile_try++, kconffile);
-            kconffile_canon = realpath(kconffile, NULL);
-        }
-        if (kconffile_canon == NULL) {  // from etc dir (installed location)
-            if (kconffile != NULL) g_free(kconffile);
-            kconffile = g_build_filename(CONFIG_QEMU_CONFDIR, "osi_linux", "kernelinfo.conf", NULL);
-            LOG_INFO("Looking for kconffile attempt %u: %s", kconffile_try++, kconffile);
-            kconffile_canon = realpath(kconffile, NULL);
-        }
-
-        g_free(progdir);
-        free(progname);
-        assert(kconffile_canon != NULL);
-
-        // convert stdlib buffer to glib buffer
-        g_free(kconffile);
-        kconffile = g_strdup(kconffile_canon);
-        free(kconffile_canon);
-
-        // get kconfgroup
-        gchar *kconfgroup = g_strdup_printf("%s:%d", panda_os_variant, panda_os_bits);
-
-        // add arguments to panda
-        gchar *plugin_arg;
-        plugin_arg = g_strdup_printf("kconf_file=%s", kconffile);
-        panda_add_arg("osi_linux", plugin_arg);
-        g_free(plugin_arg);
-        plugin_arg = g_strdup_printf("kconf_group=%s", kconfgroup);
-        panda_add_arg("osi_linux", plugin_arg);
-        g_free(plugin_arg);
-
-        // print info and finish
         LOG_INFO("OSI grabbing Linux introspection backend.");
-        LOG_INFO("Linux OSI, using group %s from %s.", kconfgroup, kconffile);
-        g_free(kconffile);
-        g_free(kconfgroup);
-
         panda_require("osi_linux");
-    }
-    if (panda_os_familyno == OS_WINDOWS) {
+    }else if (panda_os_familyno == OS_WINDOWS) {
         LOG_INFO("OSI grabbing Windows introspection backend.");
         panda_require("wintrospection");
     }

--- a/panda/plugins/osi/osi_int_fns.h
+++ b/panda/plugins/osi/osi_int_fns.h
@@ -25,6 +25,8 @@ OsiProc *get_current_process(CPUState *cpu);
 
 OsiModule* get_one_module(GArray *osimodules, unsigned int idx);
 
+OsiProc* get_one_proc(GArray *osiprocs, unsigned int idx);
+
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 // gets the currently running process handle

--- a/panda/plugins/osi_linux/README.md
+++ b/panda/plugins/osi_linux/README.md
@@ -101,8 +101,9 @@ When taking a recording to be used with `osi_linux`, ASLR must be disabled in th
 Arguments
 ---------
 
-* `kconf_file`: string, defaults to "kernelinfo.conf". The location of the configuration file that gives the required offsets for different versions of Linux.
+* `kconf_file`: string, by default searches build directory then install directory for "kernelinfo.conf". The location of the configuration file that gives the required offsets for different versions of Linux.
 * `kconf_group`: string, defaults to "debian-3.2.65-i686". The specific configuration desired from the kernelinfo file (multiple configurations can be stored in a single `kernelinfo.conf`).
+* `load_now`: bool, defaults to false. When set, we will raise a fatal error if OSI cannot be initialized immediately. Otherwise, the plugin will attempt to provide introspection immediately, but if that fails, it will wait until the first syscall. If OSI is still unavailable at the first syscall, a fatal error will always be raised.
 
 Dependencies
 ------------

--- a/panda/plugins/osi_linux/default_profile.h
+++ b/panda/plugins/osi_linux/default_profile.h
@@ -6,6 +6,8 @@ target_ptr_t default_get_current_task_struct(CPUState *cpu);
 target_ptr_t default_get_task_struct_next(CPUState *cpu, target_ptr_t ts);
 target_ptr_t default_get_group_leader(CPUState *cpu, target_ptr_t ts);
 target_ptr_t default_get_file_fds(CPUState *cpu, target_ptr_t files);
+bool can_read_current(CPUState *env);
+void on_first_syscall(CPUState *cpu, target_ulong pc, target_ulong callno);
 
 const KernelProfile DEFAULT_PROFILE = {
     .get_current_task_struct = &default_get_current_task_struct,

--- a/panda/plugins/osi_linux/kernelinfo_downloader.cpp
+++ b/panda/plugins/osi_linux/kernelinfo_downloader.cpp
@@ -17,13 +17,12 @@ int download_kernelinfo(const char *file, const char *group){
 	// we'll create a file, but we won't make one without a filename
 	if  (file == NULL)
 		return -1;
-	std::cout << "Attempting to download from panda-re.mit.edu" << std::endl;
+	std::cout << "Attempting to download kernelinfo.conf from panda-re.mit.edu... ";
 	CURL *curl;
 	CURLcode res;
 	std::string url = "https://panda-re.mit.edu/kernelinfos/";
 	url.append(group);
 	url.append(".conf");
-	std::cout << "Downloading uri " << url << " to file "<< file << std::endl;
 	std::string readBuffer;
 
 	curl = curl_easy_init();
@@ -32,7 +31,6 @@ int download_kernelinfo(const char *file, const char *group){
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 		curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
-		std::cout << readBuffer << std::endl;
 		res = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 		if (readBuffer.length() > 0 && res == CURLE_OK){
@@ -40,11 +38,12 @@ int download_kernelinfo(const char *file, const char *group){
 	  		kernelinfo_file.open (file, std::ifstream::app);
 	  		kernelinfo_file << "\n" << readBuffer << std::endl;
 	  		kernelinfo_file.close();
+        std::cout << " OK" << std::endl;
 	  		return 0;
 		}else if(res == CURLE_HTTP_RETURNED_ERROR) {
-			std::cout << "config not found on server" << std::endl;
+			std::cout << " FAIL: config not found on server" << std::endl;
     }else{
-			std::cout << "didn't take" << std::endl;
+			std::cout << " FAIL: error" << std::endl;
 		}
 	}
 	return -1;

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -18,6 +18,7 @@
 #include "osi/os_intro.h"
 #include "utils/kernelinfo/kernelinfo.h"
 #include "osi_linux.h"
+#include "syscalls2/syscalls_ext_typedefs.h"
 
 #include "default_profile.h"
 #include "kernel_2_4_x_profile.h"
@@ -32,6 +33,7 @@ bool init_plugin(void *);
 void uninit_plugin(void *);
 #include "osi_linux_int_fns.h"
 }
+void on_first_syscall(CPUState *cpu, target_ulong pc, target_ulong callno);
 
 void on_get_processes(CPUState *env, GArray **out);
 void on_get_process_handles(CPUState *env, GArray **out);
@@ -43,6 +45,10 @@ void on_get_current_thread(CPUState *env, OsiThread *t);
 
 struct kernelinfo ki;
 struct KernelProfile const *kernel_profile;
+
+extern const char *qemu_file;
+static bool osi_initialized;
+static bool first_osi_check = true;
 
 /* ******************************************************************
  Helpers
@@ -143,7 +149,7 @@ void fill_osiproc(CPUState *cpu, OsiProc *p, target_ptr_t task_addr) {
                      {ki.task.real_parent_offset, ki.task.pid_offset});
 
     // Convert asid to physical to be able to compare it with the pgd register.
-    p->asid = panda_virt_to_phys(cpu, p->asid);
+    p->asid = p->asid ? panda_virt_to_phys(cpu, p->asid) : (target_ulong) NULL;
     p->taskd = kernel_profile->get_group_leader(cpu, task_addr);
     p->name = get_name(cpu, task_addr, p->name);
     p->pid = get_tgid(cpu, task_addr);
@@ -203,6 +209,70 @@ void fill_osithread(CPUState *env, OsiThread *t,
 }
 
 /* ******************************************************************
+ Initialization logic
+****************************************************************** */
+/**
+ * @brief When necessary, after the first syscall ensure we can read current task
+ * and then enable OSI
+ * TODO: Unregister this PPP-fn after it runs the first time (Issue #644)
+ */
+
+void on_first_syscall(CPUState *cpu, target_ulong pc, target_ulong callno) {
+    // Make sure we can now read current. Note this isn't like all the other on_...
+    // functions that are registered as OSI callbacks
+    assert(can_read_current(cpu) && "Couldn't find current task struct at first syscall");
+    if (!osi_initialized)
+      LOG_INFO(PLUGIN_NAME " initialization complete.");
+    osi_initialized=true;
+}
+
+/**
+ * @brief Test to see if we can read the current task struct
+ */
+inline bool can_read_current(CPUState *cpu) {
+    target_ptr_t ts = kernel_profile->get_current_task_struct(cpu);
+    return 0x0 != ts;
+}
+
+/**
+ * @brief Check if we've successfully initialized OSI for the guest.
+ * Returns true if introspection is available.
+ *
+ * If introspection is unavailable at the first check, this will register a PPP-style
+ * callback with syscalls2 to try reinitializing at the first syscall.
+ *
+ * If that fails, then we raise an assertion because OSI has really failed.
+ */
+bool osi_guest_is_ready(CPUState *cpu, void** ret) {
+
+    if (osi_initialized) // If osi_initialized is set, the guest must be ready
+      return true;      // or, if it isn't, the user wants an assertion error
+
+
+    // If it's the very first time, try reading current, if we can't
+    // wait until first sycall and try again
+    if (first_osi_check) {
+        first_osi_check = false;
+
+        // Try to load current, if it works, return true
+        if (can_read_current(cpu)) {
+            // TODO: disable on_first_syscall PPP callback because we're all set. Needs Issue #644 to be fixed
+            LOG_INFO(PLUGIN_NAME " initialization complete.");
+            osi_initialized=true;
+            return true;
+        }
+
+        // We can't read the current task right now. This isn't a surprise,
+        // it could be happening because we're in boot.
+        // Wait until on_first_syscall runs, everything should work then
+        LOG_INFO(PLUGIN_NAME " cannot find current task struct. Deferring OSI initialization until first syscall.");
+    }
+    // Not yet initialized, just set the caller's result buffer to NULL
+    ret = NULL;
+    return false;
+}
+
+/* ******************************************************************
  PPP Callbacks
 ****************************************************************** */
 
@@ -211,6 +281,7 @@ void fill_osithread(CPUState *env, OsiThread *t,
  *
  */
 void on_get_processes(CPUState *env, GArray **out) {
+    if (!osi_guest_is_ready(env, (void**)out)) return;
     // instantiate and call function from get_process_info template
     get_process_info<>(env, out, fill_osiproc, free_osiproc_contents);
 }
@@ -219,6 +290,8 @@ void on_get_processes(CPUState *env, GArray **out) {
  * @brief PPP callback to retrieve process handles from the running OS.
  */
 void on_get_process_handles(CPUState *env, GArray **out) {
+    if (!osi_guest_is_ready(env, (void**)out)) return;
+
     // instantiate and call function from get_process_info template
     get_process_info<>(env, out, fill_osiprochandle, free_osiprochandle_contents);
 }
@@ -227,6 +300,8 @@ void on_get_process_handles(CPUState *env, GArray **out) {
  * @brief PPP callback to retrieve info about the currently running process.
  */
 void on_get_current_process(CPUState *env, OsiProc **out) {
+    if (!osi_guest_is_ready(env, (void**)out)) return;
+
     static target_ptr_t last_ts = 0x0;
     static target_ptr_t cached_taskd = 0x0;
     static target_ptr_t cached_asid = 0x0;
@@ -271,6 +346,8 @@ void on_get_current_process(CPUState *env, OsiProc **out) {
  * @brief PPP callback to the handle of the currently running process.
  */
 void on_get_current_process_handle(CPUState *env, OsiProcHandle **out) {
+    if (!osi_guest_is_ready(env, (void**)out)) return;
+
     OsiProcHandle *p = NULL;
     target_ptr_t ts = kernel_profile->get_current_task_struct(env);
     if (ts) {
@@ -285,6 +362,8 @@ void on_get_current_process_handle(CPUState *env, OsiProcHandle **out) {
  * handle.
  */
 void on_get_process(CPUState *env, const OsiProcHandle *h, OsiProc **out) {
+    if (!osi_guest_is_ready(env, (void**)out)) return;
+
     OsiProc *p = NULL;
     if (h != NULL && h->taskd != (target_ptr_t)NULL) {
         p = (OsiProc *)g_malloc(sizeof(OsiProc));
@@ -303,6 +382,8 @@ void on_get_process(CPUState *env, const OsiProcHandle *h, OsiProc **out) {
  * @todo Remove duplicates from results.
  */
 void on_get_mappings(CPUState *env, OsiProc *p, GArray **out) {
+    if (!osi_guest_is_ready(env, (void**)out)) return;
+
     OsiModule m;
     target_ptr_t vma_first, vma_current;
 
@@ -341,6 +422,8 @@ void on_get_current_thread(CPUState *env, OsiThread **out) {
     static target_pid_t cached_tid = 0;
     static target_pid_t cached_pid = 0;
 
+    if (!osi_guest_is_ready(env, (void**)out)) return;
+
     OsiThread *t = NULL;
     target_ptr_t ts = kernel_profile->get_current_task_struct(env);
     if (0x0 != ts) {
@@ -362,6 +445,8 @@ void on_get_current_thread(CPUState *env, OsiThread **out) {
  * @brief PPP callback to retrieve the process pid from a handle.
  */
 void on_get_process_pid(CPUState *env, const OsiProcHandle *h, target_pid_t *pid) {
+    if (!osi_guest_is_ready(env, (void**)pid)) return;
+
     if (h->taskd == NULL || h->taskd == (target_ptr_t)-1) {
         *pid = (target_pid_t)-1;
     } else {
@@ -374,6 +459,7 @@ void on_get_process_pid(CPUState *env, const OsiProcHandle *h, target_pid_t *pid
  */
 void on_get_process_ppid(CPUState *cpu, const OsiProcHandle *h, target_pid_t *ppid) {
     struct_get_ret_t UNUSED(err);
+    if (!osi_guest_is_ready(cpu, (void**)ppid)) return;
 
     if (h->taskd == (target_ptr_t)-1) {
         *ppid = (target_pid_t)-1;
@@ -553,23 +639,53 @@ bool init_plugin(void *self) {
 
     // Read the name of the kernel configuration to use.
     panda_arg_list *plugin_args = panda_get_args(PLUGIN_NAME);
-    char *kconf_file = g_strdup(panda_parse_string_req(plugin_args, "kconf_file", "file containing kernel configuration information"));
-    char *kconf_group = g_strdup(panda_parse_string_req(plugin_args, "kconf_group", "kernel profile to use"));
-    bool load_now = panda_parse_bool_opt(plugin_args, "load_now", "Immediately initialize OSI instead of waiting for first syscall");
+    char *kconf_file = g_strdup(panda_parse_string_opt(plugin_args, "kconf_file", NULL, "file containing kernel configuration information"));
+    char *kconf_group = g_strdup(panda_parse_string_opt(plugin_args, "kconf_group", NULL, "kernel profile to use"));
+    osi_initialized = panda_parse_bool_opt(plugin_args, "load_now", "Raise a fatal error if OSI cannot be initialized immediately");
     panda_free_args(plugin_args);
+
+    if (!kconf_file) {
+        // Search build dir and installed location for kernelinfo.conf
+        gchar *progname = realpath(qemu_file, NULL);
+        gchar *progdir = g_path_get_dirname(progname);
+        gchar *kconffile_canon = NULL;
+        uint8_t UNUSED(kconffile_try) = 1;
+
+        if (kconffile_canon == NULL) {  // from build dir
+            if (kconf_file != NULL) g_free(kconf_file);
+            kconf_file = g_build_filename(progdir, "panda", "plugins", "osi_linux", "kernelinfo.conf", NULL);
+            LOG_INFO("Looking for kconf_file attempt %u: %s", kconf_file_try++, kconf_file);
+            kconffile_canon = realpath(kconf_file, NULL);
+        }
+        if (kconffile_canon == NULL) {  // from etc dir (installed location)
+            if (kconf_file != NULL) g_free(kconf_file);
+            kconf_file = g_build_filename(CONFIG_QEMU_CONFDIR, "osi_linux", "kernelinfo.conf", NULL);
+            LOG_INFO("Looking for kconf_file attempt %u: %s", kconf_file_try++, kconf_file);
+            kconffile_canon = realpath(kconf_file, NULL);
+        }
+
+        g_free(progdir);
+        free(progname);
+        assert(kconffile_canon != NULL && "Could not find default kernelinfo.conf file");
+        free(kconffile_canon);
+    }
+
+    if (!kconf_group) {
+        kconf_group = g_strdup_printf("%s:%d", panda_os_variant, panda_os_bits);
+    }
+
 
     // Load kernel offsets.
     if (read_kernelinfo(kconf_file, kconf_group, &ki) != 0) {
         LOG_ERROR("Failed to read group %s from %s.", kconf_group, kconf_file);
-        LOG_INFO("Attempting to download file from panda-re.mit.edu");
         if (download_kernelinfo(kconf_file, kconf_group) == 0) {
-            LOG_ERROR("Downloaded file from panda-re.mit.edu");
+            LOG_INFO("Downloaded file from panda-re.mit.edu");
             if (read_kernelinfo(kconf_file, kconf_group, &ki) != 0) {
-              LOG_ERROR("Downloaded file didn't contain correct group");
-              goto error;
+                LOG_ERROR("Downloaded file didn't contain correct group");
+                goto error;
             }
         }else{
-          LOG_ERROR("Download failed. No such file.");
+            LOG_ERROR("Download failed. No such file.");
             // Log all valid groups in your kconf file - user might've just specified the argument wrong
             printf("Valid kconf_groups in %s:\n", kconf_file);
             list_kernelinfo_groups(kconf_file);
@@ -596,10 +712,17 @@ bool init_plugin(void *self) {
     PPP_REG_CB("osi", on_get_current_thread, on_get_current_thread);
     PPP_REG_CB("osi", on_get_process_pid, on_get_process_pid);
     PPP_REG_CB("osi", on_get_process_ppid, on_get_process_ppid);
-    LOG_INFO(PLUGIN_NAME " initialization complete.");
+
+    // By default, we'll request syscalls2 to load on first syscall
+    if (!osi_initialized) {
+      panda_require("syscalls2");
+      PPP_REG_CB("syscalls2", on_all_sys_enter, on_first_syscall);
+    }
+
+
     return true;
 #else
-    fprintf(stderr, "[osi_linux]: Unsupported guest architecture\n");
+    fprintf(stderr, PLUGIN_NAME "Unsupported guest architecture\n");
     goto error;
 #endif
 

--- a/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo.h
+++ b/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo.h
@@ -189,6 +189,7 @@ extern "C" {
 #endif
 
 int read_kernelinfo(gchar const *file, gchar const *group, struct kernelinfo *ki);
+void list_kernelinfo_groups(gchar const *file);
 #ifdef __cplusplus
 }
 #endif

--- a/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
+++ b/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
@@ -230,4 +230,27 @@ end:
 		return rval;
 }
 
+/*!
+ * @brief Print a list of valid groupnames in a kernelinfo file
+ */
+void list_kernelinfo_groups(gchar const *file) {
+    GKeyFile *keyfile;
+	gchar ** groups;
+	GError *gerr = NULL;
+	int idx = 0;
+	const char* fname = (file != NULL ? file : DEFAULT_KERNELINFO_FILE);
+
+	keyfile = g_key_file_new();
+	g_key_file_load_from_file (keyfile, fname, G_KEY_FILE_NONE, &gerr);
+	if (gerr != NULL) {
+		printf("error parsing %s\n", fname);
+		return;
+	}
+
+	groups = g_key_file_get_groups(keyfile, NULL);
+	while (groups[idx] != NULL) {
+		printf("\t%s\n", groups[idx]);
+		idx++;
+	}
+}
 /* vim:set tabstop=4 softtabstop=4 noexpandtab: */

--- a/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
+++ b/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
@@ -243,7 +243,7 @@ void list_kernelinfo_groups(gchar const *file) {
 	keyfile = g_key_file_new();
 	g_key_file_load_from_file (keyfile, fname, G_KEY_FILE_NONE, &gerr);
 	if (gerr != NULL) {
-		printf("error parsing %s\n", fname);
+		printf("\tError parsing %s\n", fname);
 		return;
 	}
 

--- a/panda/plugins/syscalls2/syscalls2_info.h
+++ b/panda/plugins/syscalls2/syscalls2_info.h
@@ -9,6 +9,11 @@
 #include <cstdint>
 #endif
 
+// BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
+// api autogen needs it.  And don't put any compiler directives
+// between this and END_PYPANDA_NEEDS_THIS except includes of other
+// files in this directory that contain subsections like this one.
+
 /**
  * @brief Meta-information about system calls.
  */
@@ -43,6 +48,7 @@ typedef struct {
     uint8_t *argsz;
     bool noreturn;
 } syscall_info_t;
+// END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 #if defined(__cplusplus)
 extern "C" {

--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -244,7 +244,11 @@ define_clean_header(ffi, "{inc}/callstack_instr.h")
 
 #define_clean_header(ffi, "{inc}/panda_qemu_support.h")
 define_clean_header(ffi, "{inc}/panda_datatypes.h")
-""".format(inc=INCLUDE_DIR_PYP))
+define_clean_header(ffi, "{inc}/breakpoints.h")
+""".format(inc=INCLUDE_DIR_PYP,
+        GLOBAL_MAX_SYSCALL_ARG_SIZE=64, # It's sizeof(uint64_t) so that's always 64
+        GLOBAL_MAX_SYSCALL_ARGS=17 # Constant from syscalls2/generated/syscalls_ext_typedefs.h
+        ))
 
         for pypanda_header in pypanda_headers:
             pdty.write('define_clean_header(ffi, "%s")\n' % pypanda_header)
@@ -381,6 +385,7 @@ pcb.init : pandacbtype("init", -1),
         #      here without redefining things. Necessary for something? cb-defs?
         pdth.write("#define MAX_PANDA_PLUGINS 16\n")
         pdth.write("#define MAX_PANDA_PLUGIN_ARGS 32\n")
+
 
         for filename in ["callbacks/cb-defs.h",
                         f"{PLUGINS_DIR}/osi_linux/utils/kernelinfo/kernelinfo.h",

--- a/panda/python/core/panda/callback_mixins.py
+++ b/panda/python/core/panda/callback_mixins.py
@@ -51,6 +51,8 @@ class callback_mixins():
                 except Exception as e:
                     self.end_analysis()
                     print("\n" + "--"*30 + f"\n\nException in callback `{fun.__name__}`: {e}\n")
+                    import traceback
+                    traceback.print_exc()
                     self.exception = e # XXX: We can't raise here or exn won't fully be printed. Instead, we print it in check_crashed()
                     return # XXX: Some callbacks don't expect returns, but most do. If we don't return we might trigger a separate exn and lose ours (occasionally)
                     # If we return the wrong type, we lose the original exn (TODO)

--- a/panda/python/core/panda/extras/file_faker.py
+++ b/panda/python/core/panda/extras/file_faker.py
@@ -1,4 +1,5 @@
 from panda.extras.file_hook import FileHook
+from panda.ffi_importer import ffi
 import logging
 
 '''
@@ -22,7 +23,7 @@ class FakeFile:
     Note: a single FileFaker might be opened and in use by multiple FDs in the guest
 
     '''
-    def __init__(self, fake_contents=""):
+    def __init__(self, fake_contents="", filename=None):
         self.logger = logging.getLogger('panda.hooking')
 
         if isinstance(fake_contents, str):
@@ -31,6 +32,7 @@ class FakeFile:
         self.contents = fake_contents
         self.initial_contents = fake_contents
         self.refcount = 0 # Reference count
+        self.filename = filename # Just for debug printing
 
     def read(self, size, offset):
         '''
@@ -101,6 +103,8 @@ class HyperFD:
         Returns (data read, count)
         '''
         assert(self.file)
+        if not self.file.filename: # Store filename into FakeFile object, just for debug printing
+            self.file.filename = self.filename
         data = self.file.read(size, self.offset)
         self.offset+=len(data)
         return (data, len(data))
@@ -246,6 +250,21 @@ class FileFaker(FileHook):
         fd = args[2+fd_pos]
         asid = self._panda.current_asid(cpu)
 
+        if fd == 0xffffffff:
+            self.logger.debug(f"Got -1 for fd in enter of {syscall_name}")
+            return
+
+        assert(fd < 0xffffffff), "FD overflow?"
+
+        # Looks like this file isn't hooked. Let's use OSI and confirm
+        if (fd, asid) not in self.hooked_fds:
+            # Let's use OSI to figure out the backing filename here
+            fname = self._get_fname(cpu, fd)
+            if fname in self.faked_files:
+                self.logger.warning("Entering {syscall_name} with fd {fd} backed by {fname} but we missed it earlier - adding it now")
+                hfd = HyperFD(fname, self.faked_files[fname]) # Create HFD
+                self.hooked_fds[(fd, asid)] =  hfd
+
         # If this file descriptor is already hooked, update currently_hooked
         # so we know to mutate it when it returns
         if (fd, asid) in self.hooked_fds:
@@ -294,7 +313,8 @@ class FileFaker(FileHook):
         elif syscall_name == "close":
             # We want the guest to close the real FD. Delete it from our map of hooked fds
             hfd.close()
-            del self.hooked_fds[(fd, asid)]
+            if (fd, asid) in self.hooked_fds:
+                del self.hooked_fds[(fd, asid)]
 
         elif syscall_name == "write":
             # read count bytes from buf, add to our hyper-fd

--- a/panda/python/core/panda/extras/file_hook.py
+++ b/panda/python/core/panda/extras/file_hook.py
@@ -1,4 +1,5 @@
 import logging
+from panda.ffi_importer import ffi
 from os import path
 
 # If coloredlogs is installed, use it
@@ -47,7 +48,6 @@ class FileHook:
         self.logger = logging.getLogger('panda.hooking')
         self.logger.setLevel(logging.DEBUG)
 
-        self.eagain = {} # cb_name: num_retries
         self.pending_virt_read = None
 
         panda.load_plugin("syscalls2")
@@ -126,6 +126,15 @@ class FileHook:
 
         self._renamed_files[old_name] = new_name
 
+    def _get_fname(self, cpu, fd):
+        fname_s = None
+        proc = self._panda.plugins['osi'].get_current_process(cpu)
+        if proc != ffi.NULL:
+            fname = self._panda.plugins['osi_linux'].osi_linux_fd_to_filename(cpu, proc, fd)
+            if fname != ffi.NULL:
+                fname_s = ffi.string(fname).decode('utf8', 'ignore')
+        return fname_s
+
     def _gen_cb(self, name, fname_ptr_pos):
         '''
         Register syscalls2 PPP callback on enter and return for the given name
@@ -154,12 +163,17 @@ class FileHook:
         try:
             fname = self._panda.read_str(cpu, fname_ptr)
         except:
-            self.logger.debug(f"missed filename at 0x{fname_ptr:x} in call to {syscall_name}. Waiting for it")
-            self.pending_virt_read = cpu.env_ptr.regs[0]
-            self.pending_syscall = syscall_name
-            self._panda.enable_callback('before_virt_read')
-            #self._panda_enable_memcb()
-            return
+            fname = self._get_fname(cpu, args[2+fname_ptr_pos])
+
+            if fname:
+                self.logger.info(f"OSI found fname after simple logic missed it in call to {syscall_name}")
+            else:
+                self.logger.debug(f"missed filename at 0x{fname_ptr:x} in call to {syscall_name} - trying to find")
+                self.pending_virt_read = cpu.env_ptr.regs[0]
+                self.pending_syscall = syscall_name
+                self._panda.enable_callback('before_virt_read')
+                #self._panda_enable_memcb()
+                return
 
         fname = path.normpath(fname) # Normalize it
         self.logger.debug(f"Entering {syscall_name} with file={fname}")
@@ -200,24 +214,12 @@ class FileHook:
         if self.pending_virt_read:
             (cpu, pc) = args[0:2]
             fname_ptr = args[2+fname_ptr_pos] # offset to after (cpu, pc) in callback args
-            self.logger.warning(f"missed filename in call to {syscall_name} with fname at 0x{fname_ptr:x}. Ignore it")
+
+            self.logger.warning(f"missed filename in call to {syscall_name} with fname at 0x{fname_ptr:x}. Ignoring it")
 
             self._panda.disable_callback('before_virt_read') # No point in continuing this
             self.pending_virt_read = None # Virtual address that we're waiting to read as soon as possible
             return
-
-        # Do we need to make the guest reissue the syscall? # XXX there are side effects here... like open FDs
-        if syscall_name in self.eagain:
-            if self.eagain[syscall_name] >= 3:
-                self.logger.warning("GIVING UP")
-                return # Just give up
-            elif self.eagain[syscall_name] > 0: # Need to retry
-                self.logger.warning("IGNORING")
-                assert(args)
-                (cpu, pc) = args[0:2]
-                #cpu.env_ptr.regs[0] = self._panda.to_unsigned_guest(-11) # 11 for old debian?
-                #cpu.env_ptr.regs[0] = self._panda.to_unsigned_guest(-35) #  35 for modern linux. UGH
-                return
 
         if syscall_name in self._changed_strs:
             assert(args)

--- a/panda/python/core/panda/gdb_mixins.py
+++ b/panda/python/core/panda/gdb_mixins.py
@@ -1,0 +1,17 @@
+from .ffi_importer import ffi
+
+class gdb_mixins():
+    def set_breakpoint(self, cpu, pc):
+        '''
+        Set a GDB breakpoint such that when the guest hits PC, execution is paused and an attached
+        GDB instance can introspect on guest memory. Requires starting panda with -s, at least for now
+        '''
+        BP_GDB = 0x10
+        self.libpanda.cpu_breakpoint_insert(cpu, pc, BP_GDB, ffi.NULL)
+
+    def clear_breakpoint(self, cpu, pc):
+        '''
+        Remove a breakpoint
+        '''
+        BP_GDB = 0x10
+        self.libpanda.cpu_breakpoint_remove(cpu, pc, BP_GDB)

--- a/panda/python/core/panda/include/.gitignore
+++ b/panda/python/core/panda/include/.gitignore
@@ -16,3 +16,5 @@ query_res.h
 rr_api.h
 syscalls_ext_typedefs*.h
 callstack_instr.h
+osi_types.h
+syscalls2_info.h

--- a/panda/python/core/panda/include/breakpoints.h
+++ b/panda/python/core/panda/include/breakpoints.h
@@ -1,0 +1,17 @@
+// Manully created. Sorry. Didn't know how to deal with the QTAILQ stuff with cffi
+
+typedef struct {
+    struct CPUBreakpoint *tqe_next;       /* next element */
+    struct CPUBreakpoint **tqe_prev;      /* address of previous next element */
+} CPUBreakpoint_qtailq;
+
+typedef struct CPUBreakpoint {
+    vaddr pc;
+    uint64_t rr_instr_count;
+    int flags; /* BP_* */
+    CPUBreakpoint_qtailq entry; // Was a QTAILQ(CPUBreakpoint)
+} CPUBreakpoint;
+
+int cpu_breakpoint_insert(CPUState *cpu, vaddr pc, int flags, CPUBreakpoint **breakpoint);
+
+int cpu_breakpoint_remove(CPUState *cpu, vaddr pc, int flags);

--- a/panda/python/core/panda/include/panda_datatypes.h
+++ b/panda/python/core/panda/include/panda_datatypes.h
@@ -960,6 +960,7 @@ typedef union panda_cb {
        member could be used instead.
        However, cbaddr provides neutral semantics for the comparisson.
     */
+
     void (*cbaddr)(void);
 } panda_cb;
 

--- a/panda/python/core/panda/include/panda_datatypes.h
+++ b/panda/python/core/panda/include/panda_datatypes.h
@@ -80,6 +80,9 @@ typedef enum panda_cb_type {
 
     PANDA_CB_BEFORE_HANDLE_EXCEPTION, // Allows you to monitor, modify,
                                       // or squash exceptions
+
+    PANDA_CB_BEFORE_HANDLE_INTERRUPT, // ditto, for interrupts
+
     PANDA_CB_LAST
 } panda_cb_type;
 
@@ -960,6 +963,9 @@ typedef union panda_cb {
        member could be used instead.
        However, cbaddr provides neutral semantics for the comparisson.
     */
+
+
+    int32_t (*before_handle_interrupt)(CPUState *cpu, int32_t interrupt_request);
 
     void (*cbaddr)(void);
 } panda_cb;

--- a/panda/python/core/panda/main.py
+++ b/panda/python/core/panda/main.py
@@ -34,10 +34,11 @@ from .callback_mixins   import callback_mixins
 from .taint_mixins      import taint_mixins
 from .volatility_mixins import volatility_mixins
 from .pyperiph_mixins   import pyperipheral_mixins
+from .gdb_mixins        import gdb_mixins
 
 import pdb
 
-class Panda(libpanda_mixins, blocking_mixins, osi_mixins, hooking_mixins, callback_mixins, taint_mixins, volatility_mixins, pyperipheral_mixins):
+class Panda(libpanda_mixins, blocking_mixins, osi_mixins, hooking_mixins, callback_mixins, taint_mixins, volatility_mixins, pyperipheral_mixins, gdb_mixins):
     def __init__(self, arch="i386", mem="128M",
             expect_prompt=None, # Regular expression describing the prompt exposed by the guest on a serial console. Used so we know when a running command has finished with its output
             os_version=None,
@@ -480,8 +481,12 @@ class Panda(libpanda_mixins, blocking_mixins, osi_mixins, hooking_mixins, callba
 
     def current_sp(self, cpustate): # under construction
         if self.arch == "i386":
-            from x86.helper import R_ESP
+            # XXX see far more complex logic in panda/include/panda/common.h
+            from panda.x86.helper import R_ESP
             return cpustate.env_ptr.regs[R_ESP]
+        elif self.arch == "arm":
+            from panda.arm.helper import R_SP
+            return cpustate.env_ptr.regs[R_SP]
         else:
             raise NotImplemented("current_sp doesn't yet support arch {}".format(self.arch))
 

--- a/panda/python/core/panda/osi_mixins.py
+++ b/panda/python/core/panda/osi_mixins.py
@@ -37,3 +37,13 @@ class osi_mixins():
         processes = self.plugins['osi'].get_processes(cpu)
         processes_len = self.garray_len(processes)
         return GArrayIterator(self.plugins['osi'].get_one_proc, processes, processes_len)
+
+    def get_processes_dict(self, cpu):
+        procs = {} #pid: {name: X, pid: Y, parent_pid: Z})
+
+        for proc in self.get_processes(cpu):
+            assert(proc != ffi.NULL)
+            assert(proc.pid not in procs)
+            procs[proc.pid] = {"name": ffi.string(proc.name).decode('utf8', 'ignore'), 'pid': proc.pid, 'parent_pid': proc.ppid}
+            assert(not (proc.pid != 0 and proc.pid == proc.ppid)) # No cycles allowed other than at 0
+        return procs

--- a/panda/python/core/panda/osi_mixins.py
+++ b/panda/python/core/panda/osi_mixins.py
@@ -32,3 +32,8 @@ class osi_mixins():
         maps = self.plugins['osi'].get_mappings(cpu, current)
         map_len = self.garray_len(maps)
         return GArrayIterator(self.plugins['osi'].get_one_module, maps, map_len)
+
+    def get_processes(self, cpu):
+        processes = self.plugins['osi'].get_processes(cpu)
+        processes_len = self.garray_len(processes)
+        return GArrayIterator(self.plugins['osi'].get_one_proc, processes, processes_len)

--- a/panda/python/examples/simple_breakpoint.py
+++ b/panda/python/examples/simple_breakpoint.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+'''
+TODO: We don't currently have a way to unset the breakpoint so you get stuck there :(
+'''
+
+from sys import argv
+from panda import Panda, blocking, ffi
+
+panda = Panda(generic="i386", extra_args=["-s", "-S"])
+
+@blocking
+def run_cmd():
+    panda.revert_sync("root")
+    print(panda.run_serial_cmd("uname -a"))
+    panda.end_analysis()
+
+@panda.cb_asid_changed()
+def asidchange(env, old_asid, new_asid):
+    '''
+    On ASID change, print and enable next_bb_break fn
+    '''
+    if old_asid != new_asid:
+        print("Asid changed from %d to %d. Triggering breakpoint..." % (old_asid, new_asid))
+        panda.enable_callback("next_bb_break")
+    return 0
+
+
+@panda.cb_before_block_exec_invalidate_opt(enabled=False)
+def next_bb_break(cpu, tb):
+    '''
+    When enabled, add a breakpoint to the start of the next block we exec
+    Then disable this callbac
+    '''
+    print("SET breakpoint")
+    panda.set_breakpoint(cpu, panda.current_pc(cpu))
+
+    panda.disable_callback("next_bb_break")
+    return True
+
+panda.queue_async(run_cmd)
+
+panda.run()

--- a/panda/src/common.c
+++ b/panda/src/common.c
@@ -223,4 +223,57 @@ MemoryRegion* panda_find_ram(void) {
 
     return ram;
 }
+
+#ifdef TARGET_ARM
+#define CPSR_M (0x1fU)
+#define ARM_CPU_MODE_SVC 0x13
+static int saved_cpsr = -1;
+static int saved_r13 = -1;
+static bool in_fake_priv = false;
+
+// Force the guest into supervisor mode by directly modifying its cpsr and r13
+// See https://developer.arm.com/docs/ddi0595/b/aarch32-system-registers/cpsr
+bool enter_priv(CPUState* cpu) {
+    CPUARMState* env = ((CPUARMState*)cpu->env_ptr);
+
+    saved_cpsr = env->uncached_cpsr;
+    env->uncached_cpsr = (env->uncached_cpsr) | (ARM_CPU_MODE_SVC & CPSR_M);
+    if (env->uncached_cpsr == saved_cpsr) {
+        // No change was made
+        return false;
+    }
+
+    assert(!in_fake_priv && "enter_priv called when already entered");
+
+    // Should we also restore other banked regs like r_14? Seems unnecessary?
+    saved_r13 = env->regs[13];
+    // If we're not already in SVC mode, load the saved SVC r13 from the SVC mode's banked_r13
+    if ((((CPUARMState*)cpu->env_ptr)->uncached_cpsr & CPSR_M) != ARM_CPU_MODE_SVC) {
+        env->regs[13] = env->banked_r13[ /*SVC_MODE=>*/ 1 ];
+    }
+    in_fake_priv = true;
+    return true;
+}
+
+// return to whatever mode we were in previously (might be a NO-OP if we were in svc)
+// Assumes you've called enter_svc first
+void exit_priv(CPUState* cpu) {
+    //printf("RESTORING CSPR TO 0x%x\n", saved_cpsr);
+    assert(in_fake_priv && "exit called when not faked");
+
+    assert(saved_cpsr != -1 && "Must call enter_svc before reverting with exit_svc");
+    CPUARMState* env = ((CPUARMState*)cpu->env_ptr);
+
+    env->uncached_cpsr = saved_cpsr;
+    env->regs[13] = saved_r13;
+    in_fake_priv = false;
+}
+
+
+#else
+// Non-ARM architectures don't require special permissions for PANDA's memory access fns
+bool enter_priv(CPUState* cpu) {return false;};
+void exit_priv(CPUState* cpu)  {};
+#endif
+
 /* vim:set shiftwidth=4 ts=4 sts=4 et: */


### PR DESCRIPTION
This PR has a number of fixes that enable OSI on ARM.

Most significantly, this includes a bugfix for panda_virtual_memory_rw which was failing on ARM when trying to read kernel memory. The underlying qemu functions have comments that make them sound like they'll be able to access any guest memory, but on ARM (at least), that wasn't the case and the permission bits in the CPSR register were affecting if data could be read or not. I suspect other architectures may have the same problem so I tried to design a generic interface for switching into privileged mode as necessary.

Other various OSI updates include:
* The ability to load osi_linux with non-default arguments #638
* Changing OSI to initialize after the first syscall which ensures the kernel is setup and we're not trying to introspect on a system during early-boot. This can be disabled via an optional argument.
* When OSI_linux can't find the kgroup you specify, it will now list the available groups in your configuration. I'm still not a fan of these names, but it's slightly better now.
* A few pypanda enhancements for working with OSI and updates to python plugins to use OSI.

Other updates: 
* Add a missing makefile dependency
* Pypanda: Change error handling slightly, but it's still pretty bad (See #652)
* Pypanda: Add an interface to trigger a breakpoint in the guest. It's not as clean as I'd like but it's a start. Future work to connect to a gdbstub immediately from python (without waiting for any new guest code to run) would be really nice.

Edit: this isn't quite ready to merge, seeing some weird behavior with asidstory on arm