### PR TITLE
Fix file taint segfault

### DIFF
--- a/panda/plugins/taint2/shad.h
+++ b/panda/plugins/taint2/shad.h
@@ -295,6 +295,7 @@ class FastShad : public Shad
 
     TaintData query_full(uint64_t addr) override
     {
+        tassert(addr < size);
         return labels[addr];
     }
 

--- a/panda/plugins/taint2/taint2_int_fns.h
+++ b/panda/plugins/taint2/taint2_int_fns.h
@@ -24,9 +24,9 @@ int taint2_enabled(void);
 
 void taint2_label_addr(Addr a, int offset, uint32_t l);
 
-// label this phys addr in memory with label l, and only label l. any previous
-// labels applied to this address are removed.
-void taint2_label_ram(uint64_t pa, uint32_t l);
+// label this RAM offset in memory with label l, and only label l. any previous
+// labels applied to this RAM offset are removed.
+void taint2_label_ram(uint64_t RamOffset, uint32_t l);
 
 // label this reg with label l, and only label l. any previous labels applied 
 // to this address are removed.
@@ -36,9 +36,9 @@ void taint2_label_reg(int reg_num, int offset, uint32_t l);
 // labels applied to this address are removed.
 void taint2_label_io(uint64_t ia, uint32_t l);
 
-// add label l to this phys addr in memory. any previous labels applied to this
-// address are not removed.
-void taint2_label_ram_additive(uint64_t pa, uint32_t l);
+// add label l to this RAM offset in memory. any previous labels applied to this
+// RAM offset are not removed.
+void taint2_label_ram_additive(uint64_t RamOffset, uint32_t l);
 
 // add label l to this register. any previous labels applied to this register
 // are not removed.
@@ -50,7 +50,7 @@ void taint2_label_io_additive(uint64_t ia, uint32_t l);
 
 // query fns return 0 if untainted, else cardinality of taint set
 uint32_t taint2_query(Addr a);
-uint32_t taint2_query_ram(uint64_t pa);
+uint32_t taint2_query_ram(uint64_t RamOffset);
 uint32_t taint2_query_reg(int reg_num, int offset);
 uint32_t taint2_query_io(uint64_t ia);
 uint32_t taint2_query_laddr(uint64_t ia, uint64_t offset);
@@ -61,13 +61,13 @@ uint32_t taint2_query_set_a(Addr a, uint32_t **out, uint32_t *outsz);
 // query set fns writes taint set contents to the specified array. the size of
 // the array must be >= the cardianlity of the taint set.
 void taint2_query_set(Addr a, uint32_t *out);
-void taint2_query_set_ram(uint64_t pa, uint32_t *out);
+void taint2_query_set_ram(uint64_t RamOffset, uint32_t *out);
 void taint2_query_set_reg(int reg_num, int offset, uint32_t *out);
 void taint2_query_set_io(uint64_t ia, uint32_t *out);
 
 // returns taint compute number associated with addr
 uint32_t taint2_query_tcn(Addr a);
-uint32_t taint2_query_tcn_ram(uint64_t pa);
+uint32_t taint2_query_tcn_ram(uint64_t RamOffset);
 uint32_t taint2_query_tcn_reg(int reg_num, int offset);
 uint32_t taint2_query_tcn_io(uint64_t ia);
 
@@ -75,8 +75,8 @@ uint32_t taint2_query_tcn_io(uint64_t ia);
 // reversibly from input).
 uint64_t taint2_query_cb_mask(Addr a, uint8_t size);
 
-// delete taint from this phys addr
-void taint2_delete_ram(uint64_t pa);
+// delete taint from this RAM Offset
+void taint2_delete_ram(uint64_t RamOffset);
 
 // delete taint from this register
 void taint2_delete_reg(int reg_num, int offset);
@@ -87,9 +87,9 @@ void taint2_delete_io(uint64_t ia);
 // addr is an opaque.  it should be &a if a is known to be an Addr
 void taint2_labelset_addr_iter(Addr addr, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 
-// apply this fn to each of the labels associated with this pa
+// apply this fn to each of the labels associated with this RAM offset
 // fn should return 0 to continue iteration
-void taint2_labelset_ram_iter(uint64_t pa, int (*app)(uint32_t el, void *stuff1), void *stuff2);
+void taint2_labelset_ram_iter(uint64_t RamOffset, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 
 // ditto, but a machine register
 // you should be able to use R_EAX, etc as reg_num
@@ -123,11 +123,11 @@ uint32_t taint2_query_result_next(QueryResult *qr, bool *done);
 void taint2_query_reg_full(uint32_t reg_num, uint32_t offset, QueryResult *qr);
 
 
-// Places taint query results for this physical address in
+// Places taint query results for this RAM offset in
 // returned qr.  qr's label set iterator is pre initialized, so there
 // is no need to call taint2_query_results_iter unless you want to
 // iterate through labels more than once).
-void taint2_query_ram_full(uint64_t pa, QueryResult *qr);
+void taint2_query_ram_full(uint64_t RamOffset, QueryResult *qr);
 
 // Places taint query results for this laaddress in
 // returned qr.  qr's label set iterator is pre initialized, so there

--- a/panda/plugins/taint2/taint_api.cpp
+++ b/panda/plugins/taint2/taint_api.cpp
@@ -156,8 +156,8 @@ static void tp_ls_iter(LabelSetP ls, int (*app)(uint32_t, void *), void *opaque)
 }
 
 // label this phys addr in memory with this label
-void taint2_label_ram(uint64_t pa, uint32_t l) {
-    Addr a = make_maddr(pa);
+void taint2_label_ram(uint64_t RamOffset, uint32_t l) {
+    Addr a = make_maddr(RamOffset);
     tp_label(a, l);
 }
 
@@ -181,8 +181,8 @@ void taint2_label_reg(int reg_num, int offset, uint32_t l) {
     tp_label(a, l);
 }
 
-void taint2_label_ram_additive(uint64_t pa, uint32_t l) {
-    Addr a = make_maddr(pa);
+void taint2_label_ram_additive(uint64_t RamOffset, uint32_t l) {
+    Addr a = make_maddr(RamOffset);
     tp_label_additive(a, l);
 }
 
@@ -248,10 +248,10 @@ uint32_t taint2_query(Addr a) {
     return ls ? ls->size() : 0;
 }
 
-// if phys addr pa is untainted, return 0.
+// if RAM offset is untainted, return 0.
 // else returns label set cardinality
-uint32_t taint2_query_ram(uint64_t pa) {
-    LabelSetP ls = tp_labelset_get(make_maddr(pa));
+uint32_t taint2_query_ram(uint64_t RamOffset) {
+    LabelSetP ls = tp_labelset_get(make_maddr(RamOffset));
     return ls ? ls->size() : 0;
 }
 //
@@ -327,8 +327,8 @@ extern "C" void taint2_query_set(Addr a, uint32_t *out) {
 	}
 }
 
-extern "C" void taint2_query_set_ram(uint64_t pa, uint32_t *out) {
-	auto set = tp_labelset_get(make_maddr(pa));
+extern "C" void taint2_query_set_ram(uint64_t RamOffset, uint32_t *out) {
+	auto set = tp_labelset_get(make_maddr(RamOffset));
 	if (set == nullptr || set->empty()) return;
 
 	auto it = set->begin();
@@ -361,8 +361,8 @@ uint32_t taint2_query_tcn(Addr a) {
     return tp_query_full(a).tcn;
 }
 
-uint32_t taint2_query_tcn_ram(uint64_t pa) {
-    return taint2_query_tcn(make_maddr(pa));
+uint32_t taint2_query_tcn_ram(uint64_t RamOffset) {
+    return taint2_query_tcn(make_maddr(RamOffset));
 }
 
 uint32_t taint2_query_tcn_reg(int reg_num, int offset) {
@@ -385,8 +385,8 @@ uint32_t taint2_num_labels_applied(void) {
     return labels_applied.size();
 }
 
-void taint2_delete_ram(uint64_t pa) {
-    Addr a = make_maddr(pa);
+void taint2_delete_ram(uint64_t RamOffset) {
+    Addr a = make_maddr(RamOffset);
     tp_delete(a);
 }
 
@@ -404,8 +404,8 @@ void taint2_labelset_addr_iter(Addr a, int (*app)(uint32_t el, void *stuff1), vo
     tp_ls_iter(tp_labelset_get(a), app, stuff2);
 }
 
-void taint2_labelset_ram_iter(uint64_t pa, int (*app)(uint32_t el, void *stuff1), void *stuff2) {
-    tp_ls_iter(tp_labelset_get(make_maddr(pa)), app, stuff2);
+void taint2_labelset_ram_iter(uint64_t RamOffset, int (*app)(uint32_t el, void *stuff1), void *stuff2) {
+    tp_ls_iter(tp_labelset_get(make_maddr(RamOffset)), app, stuff2);
 }
 
 void taint2_labelset_reg_iter(int reg_num, int offset, int (*app)(uint32_t el, void *stuff1), void *stuff2) {
@@ -553,10 +553,10 @@ void taint2_query_reg_full(uint32_t reg_num, uint32_t offset, QueryResult *qr) {
 }
 //
 // pass in query result pre-allocated
-void taint2_query_ram_full(uint64_t pa, QueryResult *qr) {
+void taint2_query_ram_full(uint64_t RamOffset, QueryResult *qr) {
 	// Hmm.  Doesn't this allocate a LabeSetP?
 	// are we leaking (if so we leaking in a bunch of other places)
-	Addr a = make_maddr(pa);
+	Addr a = make_maddr(RamOffset);
 	TaintData td = tp_query_full(a);
 	qr->num_labels = td.ls->size();
 	qr->tcn = td.tcn;

--- a/panda/plugins/taint2/taint_api.h
+++ b/panda/plugins/taint2/taint_api.h
@@ -18,16 +18,16 @@ void taint2_enable_taint(void);
 void taint2_enable_tainted_pointer(void);
 int taint2_enabled(void);
 void taint2_label_addr(Addr a, int offset, uint32_t l) ;
-void taint2_label_ram(uint64_t pa, uint32_t l) ;
+void taint2_label_ram(uint64_t RamOffset, uint32_t l) ;
 void taint2_label_reg(int reg_num, int offset, uint32_t l) ;
 void taint2_label_io(uint64_t ia, uint32_t l);
-void taint2_label_ram_additive(uint64_t pa, uint32_t l);
+void taint2_label_ram_additive(uint64_t RamOffset, uint32_t l);
 void taint2_label_reg_additive(int reg_num, int offset, uint32_t l);
 void taint2_label_io_additive(uint64_t ia, uint32_t l);
 void taint2_add_taint_ram_pos(CPUState *cpu, uint64_t addr, uint32_t length, uint32_t start_label);
 void taint2_add_taint_ram_single_label(CPUState *cpu, uint64_t addr,
     uint32_t length, long label);
-void taint2_delete_ram(uint64_t pa);
+void taint2_delete_ram(uint64_t RamOffset);
 void taint2_delete_reg(int reg_num, int offset);
 void taint2_delete_io(uint64_t ia);
 
@@ -35,7 +35,7 @@ Panda__TaintQuery *taint2_query_pandalog (Addr addr, uint32_t offset);
 void pandalog_taint_query_free(Panda__TaintQuery *tq);
 
 uint32_t taint2_query(Addr a);
-uint32_t taint2_query_ram(uint64_t pa);
+uint32_t taint2_query_ram(uint64_t RamOffset);
 uint32_t taint2_query_laddr(uint64_t la, uint64_t off);
 uint32_t taint2_query_reg(int reg_num, int offset);
 uint32_t taint2_query_io(uint64_t ia);
@@ -44,12 +44,12 @@ uint32_t taint2_query_llvm(int reg_num, int offset);
 uint32_t taint2_query_set_a(Addr a, uint32_t **out, uint32_t *outsz);
 
 void taint2_query_set(Addr a, uint32_t *out);
-void taint2_query_set_ram(uint64_t pa, uint32_t *out);
+void taint2_query_set_ram(uint64_t RamOffset, uint32_t *out);
 void taint2_query_set_reg(int reg_num, int offset, uint32_t *out);
 void taint2_query_set_io(uint64_t ia, uint32_t *out);
 
 uint32_t taint2_query_tcn(Addr a);
-uint32_t taint2_query_tcn_ram(uint64_t pa);
+uint32_t taint2_query_tcn_ram(uint64_t RamOffset);
 uint32_t taint2_query_tcn_reg(int reg_num, int offset);
 uint32_t taint2_query_tcn_io(uint64_t ia);
 uint32_t taint2_query_tcn_llvm(int reg_num, int offset);
@@ -57,7 +57,7 @@ uint32_t taint2_query_tcn_llvm(int reg_num, int offset);
 uint64_t taint2_query_cb_mask(Addr a, uint8_t size);
 
 void taint2_labelset_addr_iter(Addr addr, int (*app)(uint32_t el, void *stuff1), void *stuff2);
-void taint2_labelset_ram_iter(uint64_t pa, int (*app)(uint32_t el, void *stuff1), void *stuff2);
+void taint2_labelset_ram_iter(uint64_t RamOffset, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 void taint2_labelset_reg_iter(int reg_num, int offset, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 void taint2_labelset_io_iter(uint64_t ia, int (*app)(uint32_t el, void *stuff1), void *stuff2);
 void taint2_labelset_llvm_iter(int reg_num, int offset, int (*app)(uint32_t el, void *stuff1), void *stuff2);
@@ -76,7 +76,7 @@ void taint2_query_laddr_full(uint64_t reg_num, uint64_t offset, QueryResult *qr)
 
 void taint2_query_reg_full(uint32_t reg_num, uint32_t offset, QueryResult *qr);
 
-void taint2_query_ram_full(uint64_t pa, QueryResult *qr);
+void taint2_query_ram_full(uint64_t RamOffset, QueryResult *qr);
 
 }
 


### PR DESCRIPTION
This should address Issue #607 

Adds `PandaPhysicalAddressToRamOffset` and `PandaVirtualAddressToRamOffset` in addition to patching the call sites I've identified to make use of it (this should include everyone that called `taint2_label_ram` and `make_maddr`.

The cat_test2 recording that reproduced the issue from the ticket no longer segfaults and appears to complete successfully.

The core issue that directly tainting an address past the size of the core system memory will result in a segfault is not addressed (although a missing assertion was added that should catch it in debug mode). As I understand it the checks are not performed at runtime for performance reasons.

Additionally, I didn't look into anything using the new python API to invoke these functions.

I've tried to honor what it appears the original plugins were doing in other error cases whenever they would have tainted an inappropriate address. A likely noteworthy case is that the panda log (which presumably some plugins/external programs read) should still have the original Virtual Address and Physical Address written to it (I didn't add a field for RAM Offset), so care should be taken if those addresses are re-queried somewhere.