### PR TITLE
fix segfault when taint not enabled via hypercall

### DIFF
--- a/panda/plugins/taint2/taint2_hypercalls.cpp
+++ b/panda/plugins/taint2/taint2_hypercalls.cpp
@@ -240,6 +240,7 @@ void lava_attack_point(PandaHypercallStruct phs) {
 }
 #endif // defined(TARGET_I386)
 
+#if defined(TARGET_I386) || defined(TARGET_X86_64) || defined(TARGET_ARM)
 static void write_taint_log(const std::string &msg)
 {
     if (NULL == taint2_log_file) {
@@ -248,6 +249,7 @@ static void write_taint_log(const std::string &msg)
 
     fprintf(taint2_log_file, "%s", msg.c_str());
 }
+#endif
 
 bool guest_hypercall_callback(CPUState *cpu) {
     bool ret = false;

--- a/panda/plugins/taint2/taint2_hypercalls.cpp
+++ b/panda/plugins/taint2/taint2_hypercalls.cpp
@@ -134,7 +134,8 @@ void taint_query_hypercall(PandaHypercallStruct phs) {
                 uint8_t c;
                 panda_virtual_memory_rw(cpu, pa, &c, 1, false);
                 // null terminator
-                if (c==0) break;
+                if (c == 0)
+                    break;
             }
             if ((int) pa != (hwaddr)-1) {
                 ram_addr_t RamOffset = RAM_ADDR_INVALID;
@@ -239,6 +240,15 @@ void lava_attack_point(PandaHypercallStruct phs) {
 }
 #endif // defined(TARGET_I386)
 
+static void write_taint_log(const std::string &msg)
+{
+    if (NULL == taint2_log_file) {
+        return;
+    }
+
+    fprintf(taint2_log_file, "%s", msg.c_str());
+}
+
 bool guest_hypercall_callback(CPUState *cpu) {
     bool ret = false;
 #if defined(TARGET_I386) || defined(TARGET_X86_64) || defined(TARGET_ARM)
@@ -294,7 +304,7 @@ bool guest_hypercall_callback(CPUState *cpu) {
                         label);
                 std::stringstream head;
                 head << PANDA_MSG << std::string(taint2_log_msg) << std::endl;
-                fprintf(taint2_log_file, "%s", head.str().c_str());
+                write_taint_log(head.str());
                 taint2_add_taint_ram_single_label(cpu, (uint64_t)buf_start,
                                                   (int)buf_len, label);
             }
@@ -310,7 +320,7 @@ bool guest_hypercall_callback(CPUState *cpu) {
                         label);
                 std::stringstream head;
                 head << PANDA_MSG << std::string(taint2_log_msg) << std::endl;
-                fprintf(taint2_log_file, "%s", head.str().c_str());
+                write_taint_log(head.str());
                 taint2_add_taint_ram_pos(cpu, (uint64_t)buf_start, (int)buf_len, label);
             }
             else if (REG_CMD == QUERY_BUFFER) {
@@ -373,7 +383,7 @@ bool guest_hypercall_callback(CPUState *cpu) {
                         }
                     }
                     head << PANDA_MSG << std::string(taint2_log_msg) << std::endl;
-                    fprintf(taint2_log_file, "%s", head.str().c_str());
+                    write_taint_log(head.str());
                 }
                 else {
                     // bad address
@@ -381,7 +391,7 @@ bool guest_hypercall_callback(CPUState *cpu) {
                             "fail: panda_virt_to_phys failed for addr 0x%" PRIXPTR "\n",
                             (uintptr_t)va);
                     head << PANDA_MSG << std::string(taint2_log_msg) << std::endl;
-                    fprintf(taint2_log_file, "%s", head.str().c_str());
+                    write_taint_log(head.str());
                 }
             }
             else if (REG_CMD == LABEL_REGISTER) {
@@ -395,8 +405,8 @@ bool guest_hypercall_callback(CPUState *cpu) {
                         label);
                 std::stringstream head;
                 head << PANDA_MSG << std::string(taint2_log_msg) << std::endl;
-                fprintf(taint2_log_file, "%s", head.str().c_str());
-		taint2_label_reg(reg_num, reg_off, label);
+                write_taint_log(head.str());
+                taint2_label_reg(reg_num, reg_off, label);
             }
             else if (REG_CMD == QUERY_REGISTER) {
                 // query taint for label on register
@@ -449,7 +459,7 @@ bool guest_hypercall_callback(CPUState *cpu) {
 
                 }
                 head << PANDA_MSG << std::string(taint2_log_msg) << std::endl;
-                fprintf(taint2_log_file, "%s", head.str().c_str());
+                write_taint_log(head.str());
             }
             else if (REG_CMD == LOG) {
                 // print a string located in guest memory to taint2 log
@@ -462,7 +472,7 @@ bool guest_hypercall_callback(CPUState *cpu) {
                 hypercall_msg[string_len-1] = 0;
                 std::stringstream head;
                 head << PANDA_MSG << std::string(hypercall_msg) << std::endl;
-                fprintf(taint2_log_file, "%s", head.str().c_str());
+                write_taint_log(head.str());
             }
             fflush(taint2_log_file);
             ret = true;


### PR DESCRIPTION
When the taint2 hypercalls are enabled, a segfault occurs if taint is not enabled via hypercall.

This patch should workaround the issue and allow tests to pass, although some refactoring might be needed to clean this up a bit.