### PR TITLE
Fix panda_in_kernel for ARM

### DIFF
--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -286,7 +286,7 @@ static inline bool panda_in_kernel(CPUState *cpu) {
 #if defined(TARGET_I386)
     return ((env->hflags & HF_CPL_MASK) == 0);
 #elif defined(TARGET_ARM)
-    return ((env->uncached_cpsr & CPSR_M) == ARM_CPU_MODE_SVC);
+    return ((env->uncached_cpsr & CPSR_M) > ARM_CPU_MODE_USR);
 #elif defined(TARGET_PPC)
     return msr_pr;
 #else


### PR DESCRIPTION
Currently PANDA only considers the kernel to be executing when in `ARM_CPU_MODE_SVC`.

This misses many other modes that should reasonably be considered kernel. In particular, `ARM_CPU_MODE_IRQ` and `ARM_CPU_MODE_FRQ`.

This PR fixes this by defining `panda_in_kernel()` as the complement to `ARM_CPU_MODE_USR`.