### PR TITLE
Capture named process's stdout, stderr, file writes (rehosting extras)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ trace-dtrace-root.h
 trace-dtrace-root.dtrace
 trace-ust-all.h
 trace-ust-all.c
+
+# Pypanda Examples
+pwc_log

--- a/panda/python/core/panda/extras/ioctl_faker.py
+++ b/panda/python/core/panda/extras/ioctl_faker.py
@@ -19,7 +19,7 @@ def do_ioctl_init(arch):
 	CMD_BITS = 8
 	SIZE_BITS = 14 if arch != "ppc" else 13
 	DIR_BITS = 2 if arch != "ppc" else 3
-	
+
 	ffi.cdef("""
 	struct IoctlCmdBits {
 		uint8_t type_num:%d;
@@ -27,12 +27,12 @@ def do_ioctl_init(arch):
 		uint16_t arg_size:%d;
 		uint8_t direction:%d;
 	};
-	
+
 	union IoctlCmdUnion {
 		struct IoctlCmdBits bits;
 		uint32_t asUnsigned32;
 	};
-	
+
 	enum ioctl_direction {
 		IO = 0,
 		IOW = 1,
@@ -121,24 +121,26 @@ class IoctlFaker():
     Bin all returns into failures (needed forcing) and successes, store for later retrival/analysis.
     '''
 
-    def __init__(self, panda, use_osi_linux = False):
+    def __init__(self, panda, use_osi_linux = False, log = False):
 
         self.osi = use_osi_linux
         self._panda = panda
         self._panda.load_plugin("syscalls2")
+        self._log = log
 
         if self.osi:
             self._panda.load_plugin("osi")
             self._panda.load_plugin("osi_linux")
 
-        self._logger = logging.getLogger('panda.hooking')
-        self._logger.setLevel(logging.DEBUG)
+        if self._log:
+            self._logger = logging.getLogger('panda.hooking')
+            self._logger.setLevel(logging.DEBUG)
 
         # Save runtime memory with sets instead of lists (no duplicates)
         self._fail_returns = set()
         self._success_returns = set()
 
-		
+
         # PPC (other arches use the default config)
         if self._panda.arch == "ppc":
             SIZE_BITS = 13
@@ -154,9 +156,9 @@ class IoctlFaker():
             if (ioctl.original_ret_code != 0):
                 self._fail_returns.add(ioctl)
                 cpu.env_ptr.regs[0] = 0
-                if ioctl.has_buf:
+                if ioctl.has_buf and self._log:
                     self._logger.warning("Forcing success return for data-containing {}".format(ioctl))
-                else:
+                elif self._log:
                     self._logger.info("Forcing success return for data-less {}".format(ioctl))
             else:
                 self._success_returns.add(ioctl)

--- a/panda/python/core/panda/extras/proc_write_capture.py
+++ b/panda/python/core/panda/extras/proc_write_capture.py
@@ -1,0 +1,62 @@
+import shutil
+from pathlib import Path
+from panda import ffi
+
+class ProcWriteCapture():
+
+    '''
+    For a named process, capture stdout and any file writes from the hypervisor, mirror results to log directory.
+    Requires Linux OSI.
+    '''
+
+    def __init__(self, panda, proc_name, log_dir = None, rm_existing_logs = False):
+
+        self._panda = panda
+        self._files_written = set()
+        self._proc_name = proc_name
+        self._rm = rm_existing_logs
+
+        if log_dir == None:
+            self._log_dir = Path(__file__).parent.absolute().joinpath(self._proc_name)
+        else:
+            self._log_dir = Path(log_dir).joinpath(self._proc_name)
+
+        # Setup logging dir
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._stdout_log_file = self._log_dir.joinpath(proc_name + "_stdout.txt")
+        self._stderr_log_file = self._log_dir.joinpath(proc_name + "_stderr.txt")
+        if self._rm:
+            shutil.rmtree(self._log_dir)
+
+        # Mirror writes
+        @self._panda.ppp("syscalls2", "on_sys_write_enter")
+        def on_sys_write_enter(cpu, pc, fd, buf, cnt):
+
+            curr_proc = panda.plugins['osi'].get_current_process(cpu)
+            curr_proc_name = ffi.string(curr_proc.name).decode()
+            if self._proc_name == curr_proc_name:
+
+                try:
+                    data = panda.virtual_memory_read(cpu, buf, cnt)
+                except ValueError:
+                    raise RuntimeError("Failed to read buffer: proc \'{}\', addr 0x{:016x}".format(curr_proc_name, buf))
+
+                if fd == 1:
+                    log_file = self._stdout_log_file
+                elif fd == 2:
+                    log_file = self._stderr_log_file
+                else:
+                    file_name_ptr = panda.plugins['osi_linux'].osi_linux_fd_to_filename(cpu, curr_proc, fd)
+                    file_path = ffi.string(file_name_ptr).decode()
+                    log_file = self._log_dir.joinpath(file_path.replace("//", "_").replace("/", "_"))
+
+                with open(log_file, "ab") as f:
+                    f.write(data)
+
+                self._files_written.add(str(log_file))
+
+    def printed_err(self):
+        return (self._stderr_log_file in self._files_written)
+
+    def get_files_written(self):
+        return self._files_written

--- a/panda/python/core/panda/extras/proc_write_capture.py
+++ b/panda/python/core/panda/extras/proc_write_capture.py
@@ -5,7 +5,7 @@ from panda import ffi
 class ProcWriteCapture():
 
     '''
-    For a named process, capture stdout and any file writes from the hypervisor, mirror results to log directory.
+    For a named process, capture stdout/stderr and any file writes from the hypervisor, mirror results to log directory.
     Requires Linux OSI.
     '''
 

--- a/panda/python/examples/proc_write_capture.py
+++ b/panda/python/examples/proc_write_capture.py
@@ -1,6 +1,5 @@
 '''
-Capture stdout of "whoami" from the hypervisor, write to a log file on the host
-Also works for stderr and any file written by the target process
+Capture output of "dhclient" process from the hypervisor, mirror to log files on the host
 '''
 
 import sys
@@ -15,7 +14,7 @@ panda = Panda(generic=generic_type)
 @blocking
 def run_cmd():
 
-    pwc = ProcWriteCapture(panda, "dhclient", log_dir = "./poc_log")
+    pwc = ProcWriteCapture(panda, "dhclient", log_dir = "./pwc_log")
 
     panda.revert_sync("root")
     panda.run_serial_cmd("dhclient -v -4")

--- a/panda/python/examples/proc_write_capture.py
+++ b/panda/python/examples/proc_write_capture.py
@@ -1,0 +1,35 @@
+'''
+Capture stdout of "whoami" from the hypervisor, write to a log file on the host
+Also works for stderr and any file written by the target process
+'''
+
+import sys
+
+from panda import blocking, Panda
+from panda.extras.proc_write_capture import ProcWriteCapture
+
+# No arguments, i386. Otherwise argument should be guest arch
+generic_type = sys.argv[1] if len(sys.argv) > 1 else "i386"
+panda = Panda(generic=generic_type)
+
+def print_list_elems(l):
+    if not l:
+        print("None")
+    else:
+        for e in l:
+            print(e)
+
+@blocking
+def run_cmd():
+
+    pwc = ProcWriteCapture(panda, "whoami", log_dir = "./poc_log")
+
+    panda.revert_sync("root")
+    panda.run_serial_cmd("whoami")
+
+    print("Captured logs:")
+    for fw in pwc.get_files_written():
+        print(fw)
+
+panda.queue_async(run_cmd)
+panda.run()

--- a/panda/python/examples/proc_write_capture.py
+++ b/panda/python/examples/proc_write_capture.py
@@ -12,20 +12,13 @@ from panda.extras.proc_write_capture import ProcWriteCapture
 generic_type = sys.argv[1] if len(sys.argv) > 1 else "i386"
 panda = Panda(generic=generic_type)
 
-def print_list_elems(l):
-    if not l:
-        print("None")
-    else:
-        for e in l:
-            print(e)
-
 @blocking
 def run_cmd():
 
-    pwc = ProcWriteCapture(panda, "whoami", log_dir = "./poc_log")
+    pwc = ProcWriteCapture(panda, "dhclient", log_dir = "./poc_log")
 
     panda.revert_sync("root")
-    panda.run_serial_cmd("whoami")
+    panda.run_serial_cmd("dhclient -v -4")
 
     print("Captured logs:")
     for fw in pwc.get_files_written():


### PR DESCRIPTION
PyPanda rehosting extras:

- New: for a named process, capture stdout/stderr and any file writes from the hypervisor, mirror results to log directory. See example: `panda/python/examples/proc_write_capture.py `
- Update: optionally suppress logs for `ioctl_faker`