### PR TITLE
Pypanda: Don't _require_ a revert before taking a recording

### DIFF
--- a/panda/python/core/panda/blocking_mixins.py
+++ b/panda/python/core/panda/blocking_mixins.py
@@ -80,26 +80,38 @@ class blocking_mixins():
 
     @blocking
     def record_cmd(self, guest_command, copy_directory=None, iso_name=None, setup_command=None, recording_name="recording", snap_name="root", ignore_errors=False):
-        self.revert_sync(snap_name) # Can't use self.revert because that would would run async and we'd keep going before the revert happens
+        '''
+        Take a recording as follows:
+            0) Revert to the specified snapshot name if one is set. By default 'root'. Set to `None` if you have already set up the guest and are ready to record with no revert
+            1) Create an ISO of files that need to be copied into the guest if copy_directory is specified. Copy them in
+            2) Run the setup_command in the guest, if provided
+            3) Type the command you wish to record but do not press enter to begin execution. This avoids the recording capturing the command being typed
+            4) Begin the recording (name controlled by recording_name)
+            5) Press enter in the guest to begin the command. Wait until it finishes.
+            6) End the recording
+        '''
+        # 0) Revert to the specified snapshot
+        if snap_name is not None:
+            self.revert_sync(snap_name) # Can't use self.revert because that would would run async and we'd keep going before the revert happens
 
-	# 0) Make copy_directory into an iso and copy it into the guest - It will end up at the exact same path
+	# 1) Make copy_directory into an iso and copy it into the guest - It will end up at the exact same path
         if copy_directory: # If there's a directory, build an ISO and put it in the cddrive
             # Make iso
             self.copy_to_guest(copy_directory, iso_name)
 
-	# 1) Run setup_command, if provided before we start the recording (good place to CD or install, etc)
+	# 2) Run setup_command, if provided before we start the recording (good place to CD or install, etc)
         if setup_command:
             print(f"Running setup command {setup_command}")
             r = self.run_serial_cmd(setup_command)
             print(f"Setup command results: {r}")
 
-        # 2) type commmand (note we type command, start recording, finish command)
+        # 3) type commmand (note we type command, start recording, finish command)
         self.type_serial_cmd(guest_command)
 
-        # 3) start recording
+        # 4) start recording
         self.run_monitor_cmd("begin_record {}".format(recording_name))
 
-        # 4) finish command
+        # 5) finish command
         result = self.finish_serial_cmd()
 
         if debug:
@@ -114,7 +126,7 @@ class blocking_mixins():
             print("Bad output running command: {}".format(result))
             raise RuntimeError("Could not execute binary while taking recording")
 
-        # 5) End recording
+        # 6) End recording
         self.run_monitor_cmd("end_record")
 
         print("Finished recording")

--- a/panda/python/tests/enabled_tests.txt
+++ b/panda/python/tests/enabled_tests.txt
@@ -9,3 +9,4 @@ taint_reg.py
 record_then_replay.py i386
 record_then_replay.py x86_64
 record_then_replay.py arm
+record_no_snap.py

--- a/panda/python/tests/record_no_snap.py
+++ b/panda/python/tests/record_no_snap.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+from sys import argv
+from panda import Panda, blocking
+from panda.extras.proc_write_capture import ProcWriteCapture
+
+
+# Take a recording without first reverting to a snapshot
+
+# Single arg of arch, defaults to i386
+arch = "i386" if len(argv) <= 1 else argv[1]
+panda = Panda(generic=arch)
+
+rec_name = "test_ls"
+
+@blocking
+def record_no_revert():
+    # Normally record_cmd will do the revert, but we want to modify the guest
+    # after the snapshot and before the recording starts
+    panda.revert_sync("root")
+    panda.run_serial_cmd("mkdir /newdir")
+
+    panda.record_cmd("ls /", recording_name=rec_name, snap_name=None)
+
+    panda.end_analysis()
+
+
+print("Queue up recording...")
+panda.queue_async(record_no_revert)
+panda.run()
+
+print("Running replay")
+
+# Use PWC to capture ls output and then we'll check host filesystem for the newdir string
+pwc = ProcWriteCapture(panda, "ls", log_dir = "./pwc_log")
+panda.run_replay(rec_name)
+
+# Check pwc output for newdir
+with open("./pwc_log/ls/_dev_ttyS0.stdout") as f:
+    assert ("newdir" in f.read()), "Missing newdir in output"
+


### PR DESCRIPTION
This change to the `create_recording` python function makes it so that it no longer reverts to a snapshot before taking the recording if you set `snap_name=None`.

This is useful if you want to set up a guest and then take a recording as opposed to recording from a snapshot.

Also adds a test for this behavior: `recording_no_revert.py`