### PR TITLE
Minor bugfixes

### DIFF
--- a/chardev/char-stdio.c
+++ b/chardev/char-stdio.c
@@ -49,9 +49,15 @@ static void term_exit(void)
     fcntl(0, F_SETFL, old_fd0_flags);
 }
 
+extern bool panda_library_mode;
+
 static void qemu_chr_set_echo_stdio(Chardev *chr, bool echo)
 {
     struct termios tty;
+
+    if (panda_library_mode) {
+      return;
+    }
 
     stdio_echo_state = echo;
     tty = oldtty;

--- a/disas/i386.c
+++ b/disas/i386.c
@@ -3682,7 +3682,7 @@ static char scale_char;
 int
 print_insn_i386 (bfd_vma pc, disassemble_info *info)
 {
-  intel_syntax = -1;
+  intel_syntax = 1;
 
   return print_insn (pc, info);
 }

--- a/panda/plugins/osi_linux/Makefile
+++ b/panda/plugins/osi_linux/Makefile
@@ -38,13 +38,10 @@ $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
 	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o \
 	$(PLUGIN_OBJ_FILES)
 
-$(PLUGIN_OBJ_DIR)/kernelinfo.zip:
+$(PLUGIN_OBJ_DIR)/kernelinfo.zip: $(addprefix $(PLUGIN_SRC_DIR)/utils/kernelinfo/,Makefile kernel.conf kernelinfo.c kernelinfo.h kernelinfo_read.c kernelinfo_size.c kernelinfo_cmp.py kernelinfo_parse.py)
 	$(call quiet-command,zip -qr $@ $(PLUGIN_SRC_DIR)/utils/kernelinfo,"ZIP      $(TARGET_DIR)$@")
 
-$(PLUGIN_OBJ_DIR)/kernelinfo24.zip:
+$(PLUGIN_OBJ_DIR)/kernelinfo24.zip: $(addprefix $(PLUGIN_SRC_DIR)/utils/kernelinfo24/,Makefile kernelinfo24.c kernelinfo24.sh)
 	$(call quiet-command,zip -qr $@ $(PLUGIN_SRC_DIR)/utils/kernelinfo24,"ZIP      $(TARGET_DIR)$@")
 
-.PHONY: $(PLUGIN_OBJ_DIR)/kernelinfo.zip $(PLUGIN_OBJ_DIR)/kernelinfo24.zip
-
 all: $(PLUGIN_OBJ_DIR)/kernelinfo.conf $(PLUGIN_OBJ_DIR)/kernelinfo.zip $(PLUGIN_OBJ_DIR)/kernelinfo24.zip
-

--- a/panda/plugins/replaymovie/Makefile
+++ b/panda/plugins/replaymovie/Makefile
@@ -4,11 +4,9 @@
 # CFLAGS+=
 # LIBS+=
 
-.PHONY: $(PLUGIN_OBJ_DIR)/moviecounter.sh
 $(PLUGIN_OBJ_DIR)/moviecounter.sh: $(PLUGIN_SRC_DIR)/moviecounter.sh
 	$(call quiet-command,cp $< $@,"CP      $(TARGET_DIR)$@")
 
-.PHONY: $(PLUGIN_OBJ_DIR)/movie.sh
 $(PLUGIN_OBJ_DIR)/movie.sh: $(PLUGIN_SRC_DIR)/movie.sh
 	$(call quiet-command,cp $< $@,"CP      $(TARGET_DIR)$@")
 

--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -3067,7 +3067,7 @@ static void x86_cpu_reset(CPUState *s)
     target_ulong cs_base = 0xffff0000;
     if (x86_configurable_machine) {
       // Unicorn sets these two properties. Not sure if we should?
-      //env->hflags = 0;
+      //env->hflags = 0; // Note we set this below!
       //env->cr[0] = 0;
 
       // For x86 configurable machine, we don't want to start in real mode
@@ -3099,6 +3099,10 @@ static void x86_cpu_reset(CPUState *s)
       // setting up initial state. These registers
       // values should all be 0 or undefined at the start
       // of a unicorn-style execution
+
+      // But do set hflags so we're in 32-bit mode (else we end up in 16-bit)
+      // Not exposed to users as an option (yet)
+      env->hflags |= HF_CS32_MASK;
       return;
     }
 


### PR DESCRIPTION
* Don't rebuild osi_linux artifacts unless they've changed (introduced in #660)
* Update the i386 configurable machine to be in 32-bit mode instead of 16-bit mode. Eventually we could allow 16-bit as an option, but 32-bit is a better default. Fixes #687 
* Don't change terminal settings to disable echo when running in library mode. Now when you kill a pypanda script, the terminal should be more usable.
* Change our x86 disassembly to intel mode because everyone everyone I've talked to about it prefers it. This is subjective and we can revert it if there are objections.