### PR TITLE
Bugfix: Enable capstone-style disassembly for PPC

### DIFF
--- a/disas.c
+++ b/disas.c
@@ -451,6 +451,10 @@ void disas(FILE *out, void *code, unsigned long size)
 #elif defined(_ARCH_PPC)
     s.info.disassembler_options = (char *)"any";
     print_insn = print_insn_ppc;
+    s.info.cap_arch = CS_ARCH_PPC;
+# ifdef _ARCH_PPC64
+    s.info.cap_mode = CS_MODE_64;
+# endif
 #elif defined(__aarch64__) && defined(CONFIG_ARM_A64_DIS)
     print_insn = print_insn_arm_a64;
 #elif defined(__alpha__)


### PR DESCRIPTION
Pulls in code from upstream commits ac226899db15c5751f5b1f4f42ea4b31a3d360e0 and 0eea8cdd6d680e74f9f994bbb024d0c486b5cc3c

Fixes #691 