### PR TITLE
Updates for gcc8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,9 +68,13 @@ fi
 
 msg "Using python2 at: $PYTHON2PATH"
 
-### Check gcc/g++ versions: 7.1 is minimum supported. If you want to build with clang, you might need to disable this
+### Check gcc/g++ versions: 7.1-8.4 are supported. If you want to build with clang, you might need to disable this
 gcc --version | awk '/gcc/ && ($3+0)<7.1{print "Fatal error: GCC too old"; exit 1}' || exit 1
 g++ --version | awk '/g\+\+/ && ($3+0)<7.1{print "Fatal error: G++ too old"; exit 1}' || exit 1
+
+# Untested GCC - it's probably going to have some warnings - Just disable Werror and hope it works
+gcc --version | awk '/gcc/   && ($3+0)>8.4{print "WARNING: Your GCC is too new: disabling -Werror and hoping this builds"; exit 1}' || COMPILER_CONFIG="--extra-cflags=-Wno-error"
+g++ --version | awk '/g\+\+/ && ($3+0)>8.4{print "WARNING: Your G++ is too new: disabling -Werror and hoping this builds"; exit 1}' ||  COMPILER_CONFIG="--extra-cxxflags=-Wno-error"
 
 #COMPILER_CONFIG="--cc=gcc-$GCC_TOOLCHAIN_VERSION_MAX --cxx=g++-$GCC_TOOLCHAIN_VERSION_MAX"
 #COMPILER_CONFIG="--extra-cflags=-std=gnu11 --extra-cxxflags=-std=gnu++1z --cc=gcc --cxx=g++"

--- a/hw/char/exynos4210_uart.c
+++ b/hw/char/exynos4210_uart.c
@@ -589,7 +589,7 @@ DeviceState *exynos4210_uart_create(hwaddr addr,
     SysBusDevice *bus;
 
     const char chr_name[] = "serial";
-    char label[ARRAY_SIZE(chr_name) + 1];
+    char label[ARRAY_SIZE(chr_name) + 16];
 
     dev = qdev_create(NULL, TYPE_EXYNOS4210_UART);
 

--- a/hw/i386/kvm/pci-assign.c
+++ b/hw/i386/kvm/pci-assign.c
@@ -524,7 +524,7 @@ static void get_real_device_id(const char *devpath, uint16_t *val,
 
 static void get_real_device(AssignedDevice *pci_dev, Error **errp)
 {
-    char dir[128], name[128];
+    char dir[128-16], name[128];
     int fd, r = 0;
     FILE *f;
     uint64_t start, end, size, flags;
@@ -725,7 +725,7 @@ static void free_assigned_device(AssignedDevice *dev)
  */
 static char *assign_failed_examine(const AssignedDevice *dev)
 {
-    char name[PATH_MAX], dir[PATH_MAX], driver[PATH_MAX] = {}, *ns;
+    char name[PATH_MAX], dir[PATH_MAX-8], driver[PATH_MAX] = {}, *ns;
     uint16_t vendor_id, device_id;
     int r;
     Error *local_err = NULL;

--- a/hw/ppc/e500.c
+++ b/hw/ppc/e500.c
@@ -105,9 +105,9 @@ static void dt_serial_create(void *fdt, unsigned long long offset,
                              const char *soc, const char *mpic,
                              const char *alias, int idx, bool defcon)
 {
-    char ser[128];
+    char *ser;
 
-    snprintf(ser, sizeof(ser), "%s/serial@%llx", soc, offset);
+    ser = g_strdup_printf("%s/serial@%llx", soc, offset);
     qemu_fdt_add_subnode(fdt, ser);
     qemu_fdt_setprop_string(fdt, ser, "device_type", "serial");
     qemu_fdt_setprop_string(fdt, ser, "compatible", "ns16550");
@@ -121,6 +121,7 @@ static void dt_serial_create(void *fdt, unsigned long long offset,
     if (defcon) {
         qemu_fdt_setprop_string(fdt, "/chosen", "linux,stdout-path", ser);
     }
+    g_free(ser);
 }
 
 static void create_dt_mpc8xxx_gpio(void *fdt, const char *soc, const char *mpic)
@@ -276,13 +277,13 @@ static int ppce500_load_device_tree(MachineState *machine,
     uint32_t tb_freq = 400000000;
     int i;
     char compatible_sb[] = "fsl,mpc8544-immr\0simple-bus";
-    char soc[128];
-    char mpic[128];
+    char *soc;
+    char *mpic;
     uint32_t mpic_ph;
     uint32_t msi_ph;
-    char gutil[128];
-    char pci[128];
-    char msi[128];
+    char *gutil;
+    char *pci;
+    char *msi;
     uint32_t *pci_map = NULL;
     int len;
     uint32_t pci_ranges[14] =
@@ -383,7 +384,7 @@ static int ppce500_load_device_tree(MachineState *machine,
     for (i = smp_cpus - 1; i >= 0; i--) {
         CPUState *cpu;
         PowerPCCPU *pcpu;
-        char cpu_name[128];
+        char *cpu_name;
         uint64_t cpu_release_addr = params->spin_base + (i * 0x20);
 
         cpu = qemu_get_cpu(i);
@@ -393,8 +394,7 @@ static int ppce500_load_device_tree(MachineState *machine,
         env = cpu->env_ptr;
         pcpu = POWERPC_CPU(cpu);
 
-        snprintf(cpu_name, sizeof(cpu_name), "/cpus/PowerPC,8544@%x",
-                 ppc_get_vcpu_dt_id(pcpu));
+        cpu_name = g_strdup_printf("/cpus/PowerPC,8544@%x", i);
         qemu_fdt_add_subnode(fdt, cpu_name);
         qemu_fdt_setprop_cell(fdt, cpu_name, "clock-frequency", clock_freq);
         qemu_fdt_setprop_cell(fdt, cpu_name, "timebase-frequency", tb_freq);
@@ -417,11 +417,12 @@ static int ppce500_load_device_tree(MachineState *machine,
         } else {
             qemu_fdt_setprop_string(fdt, cpu_name, "status", "okay");
         }
+        g_free(cpu_name);
     }
 
     qemu_fdt_add_subnode(fdt, "/aliases");
     /* XXX These should go into their respective devices' code */
-    snprintf(soc, sizeof(soc), "/soc@%"PRIx64, params->ccsrbar_base);
+    soc = g_strdup_printf("/soc@%"PRIx64, params->ccsrbar_base);
     qemu_fdt_add_subnode(fdt, soc);
     qemu_fdt_setprop_string(fdt, soc, "device_type", "soc");
     qemu_fdt_setprop(fdt, soc, "compatible", compatible_sb,
@@ -434,7 +435,7 @@ static int ppce500_load_device_tree(MachineState *machine,
     /* XXX should contain a reasonable value */
     qemu_fdt_setprop_cell(fdt, soc, "bus-frequency", 0);
 
-    snprintf(mpic, sizeof(mpic), "%s/pic@%llx", soc, MPC8544_MPIC_REGS_OFFSET);
+    mpic = g_strdup_printf("%s/pic@%llx", soc, MPC8544_MPIC_REGS_OFFSET);
     qemu_fdt_add_subnode(fdt, mpic);
     qemu_fdt_setprop_string(fdt, mpic, "device_type", "open-pic");
     qemu_fdt_setprop_string(fdt, mpic, "compatible", "fsl,mpic");
@@ -462,14 +463,15 @@ static int ppce500_load_device_tree(MachineState *machine,
                          soc, mpic, "serial0", 0, true);
     }
 
-    snprintf(gutil, sizeof(gutil), "%s/global-utilities@%llx", soc,
-             MPC8544_UTIL_OFFSET);
+    gutil = g_strdup_printf("%s/global-utilities@%llx", soc,
+                            MPC8544_UTIL_OFFSET);
     qemu_fdt_add_subnode(fdt, gutil);
     qemu_fdt_setprop_string(fdt, gutil, "compatible", "fsl,mpc8544-guts");
     qemu_fdt_setprop_cells(fdt, gutil, "reg", MPC8544_UTIL_OFFSET, 0x1000);
     qemu_fdt_setprop(fdt, gutil, "fsl,has-rstcr", NULL, 0);
+    g_free(gutil);
 
-    snprintf(msi, sizeof(msi), "/%s/msi@%llx", soc, MPC8544_MSI_REGS_OFFSET);
+    msi = g_strdup_printf("/%s/msi@%llx", soc, MPC8544_MSI_REGS_OFFSET);
     qemu_fdt_add_subnode(fdt, msi);
     qemu_fdt_setprop_string(fdt, msi, "compatible", "fsl,mpic-msi");
     qemu_fdt_setprop_cells(fdt, msi, "reg", MPC8544_MSI_REGS_OFFSET, 0x200);
@@ -487,9 +489,10 @@ static int ppce500_load_device_tree(MachineState *machine,
         0xe7, 0x0);
     qemu_fdt_setprop_cell(fdt, msi, "phandle", msi_ph);
     qemu_fdt_setprop_cell(fdt, msi, "linux,phandle", msi_ph);
+    g_free(msi);
 
-    snprintf(pci, sizeof(pci), "/pci@%llx",
-             params->ccsrbar_base + MPC8544_PCI_REGS_OFFSET);
+    pci = g_strdup_printf("/pci@%llx",
+                          params->ccsrbar_base + MPC8544_PCI_REGS_OFFSET);
     qemu_fdt_add_subnode(fdt, pci);
     qemu_fdt_setprop_cell(fdt, pci, "cell-index", 0);
     qemu_fdt_setprop_string(fdt, pci, "compatible", "fsl,mpc8540-pci");
@@ -517,14 +520,17 @@ static int ppce500_load_device_tree(MachineState *machine,
     qemu_fdt_setprop_cell(fdt, pci, "#size-cells", 2);
     qemu_fdt_setprop_cell(fdt, pci, "#address-cells", 3);
     qemu_fdt_setprop_string(fdt, "/aliases", "pci0", pci);
+    g_free(pci);
 
     if (params->has_mpc8xxx_gpio) {
         create_dt_mpc8xxx_gpio(fdt, soc, mpic);
     }
+    g_free(soc);
 
     if (params->has_platform_bus) {
         platform_bus_create_devtree(params, fdt, mpic);
     }
+    g_free(mpic);
 
     params->fixup_devtree(params, fdt);
 

--- a/panda/plugins/replaymovie/Makefile
+++ b/panda/plugins/replaymovie/Makefile
@@ -4,15 +4,14 @@
 # CFLAGS+=
 # LIBS+=
 
-$(PLUGIN_OBJ_DIR)/moviecounter.sh: $(PLUGIN_SRC_DIR)/moviecounter.sh
-	$(call quiet-command,cp $< $@,"CP      $(TARGET_DIR)$@")
+$(PLUGIN_TARGET_DIR)/moviecounter.sh: $(PLUGIN_OBJ_DIR)/moviecounter.sh
+	$(call quiet-command,cp $< $@,"CP      $(PLUGIN_TARGET_DIR)$@")
 
-$(PLUGIN_OBJ_DIR)/movie.sh: $(PLUGIN_SRC_DIR)/movie.sh
-	$(call quiet-command,cp $< $@,"CP      $(TARGET_DIR)$@")
-
+$(PLUGIN_TARGET_DIR)/movie2.sh: $(PLUGIN_OBJ_DIR)/movie.sh
+	$(call quiet-command,cp $< $@,"CP      $(PLUGIN_TARGET_DIR)$@")
 
 # The main rule for your plugin. List all object-file dependencies.
 $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
 	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o
 
-all: $(PLUGIN_OBJ_DIR)/movie.sh $(PLUGIN_OBJ_DIR)/moviecounter.sh
+all: $(PLUGIN_TARGET_DIR)/movie2.sh $(PLUGIN_TARGET_DIR)/moviecounter.sh


### PR DESCRIPTION
Pulls some fixes in from upstream, others are done by hand because the code no longer exists in upstream.
 
Changes build.sh to print a warning when using newer compilers than what we've tested with (max is currently gcc 8.4) and to disable `-Werrror` for them