### PR TITLE
Add tainted_mmio back to build

### DIFF
--- a/panda/plugins/config.llvm.panda
+++ b/panda/plugins/config.llvm.panda
@@ -6,5 +6,6 @@ serial_taint
 taint2
 tainted_branch
 tainted_instr
+tainted_mmio
 tainted_net
 tstringsearch

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -63,6 +63,12 @@ PPP_CB_BOILERPLATE(on_ptr_load);
 PPP_PROT_REG_CB(on_ptr_store);
 PPP_CB_BOILERPLATE(on_ptr_store);
 
+PPP_PROT_REG_CB(on_after_load);
+PPP_CB_BOILERPLATE(on_after_load);
+
+PPP_PROT_REG_CB(on_after_store);
+PPP_CB_BOILERPLATE(on_after_store);
+
 }
 
 extern const char *qemu_file;
@@ -120,6 +126,12 @@ void taint_pointer_run(uint64_t src, uint64_t ptr, uint64_t dest, bool is_store,
         PPP_RUN_CB(on_ptr_load, ptr_addr, src, size);
     }
 }
+
+void taint_after_ld_run(uint64_t rega, uint64_t addr, uint64_t size) {
+    Addr reg = make_laddr(rega / MAXREGSIZE, 0);
+    PPP_RUN_CB(on_after_load, reg, addr, size);    
+}
+
 
 static void taint_copyRegToPc_run(Shad *shad, uint64_t src, uint64_t size)
 {
@@ -189,6 +201,8 @@ bool PandaTaintFunctionPass::doInitialization(Module &M) {
     PTV.resetFrameF = M.getFunction("taint_reset_frame");
     PTV.breadcrumbF = M.getFunction("taint_breadcrumb");
 
+    PTV.afterLdF = M.getFunction("taint_after_ld");
+
     llvm::Type *shadT = M.getTypeByName("class.Shad");
     assert(shadT);
     llvm::Type *shadP = PointerType::getUnqual(shadT);
@@ -257,6 +271,8 @@ bool PandaTaintFunctionPass::doInitialization(Module &M) {
     ADD_MAPPING(taint_breadcrumb);
 
     ADD_MAPPING(taint_memlog_pop);
+
+    ADD_MAPPING(taint_after_ld);
 
     //ADD_MAPPING(label_set_union);
     //ADD_MAPPING(label_set_singleton);
@@ -509,6 +525,19 @@ void PandaTaintVisitor::insertTaintCopy(Instruction &I,
 
     insertTaintBulk(I, shad_dest, dest, shad_src, src, size, copyF);
 }
+
+
+// load llreg from addr
+// or store llreg to addr 
+// both logically after taint transfer has occurred
+// NB: val is llvm register that is dest of store or that is source of load
+void PandaTaintVisitor::insertAfterTaintLd(Instruction &I,
+       Value *val, Value *ptr, uint64_t size) {
+    LLVMContext &ctx = I.getContext();
+    vector<Value *> args {constSlot(val), constSlot(ptr), const_uint64(ctx, size)};
+    inlineCallAfter(I, afterLdF, args);    
+}
+
 
 void PandaTaintVisitor::insertTaintBulk(Instruction &I,
         Constant *shad_dest, Value *dest, Constant *shad_src, Value *src,
@@ -1342,6 +1371,11 @@ void PandaTaintVisitor::visitCallInst(CallInst &I) {
             return;
         } else if (ldFuncs.count(calledName) > 0) {
             Value *ptr = I.getArgOperand(1);
+            // insertAfterTaintLd mainly used for tainted_mmio
+            //   where we could expect ptr to be non-constant 
+            if (!isa<Constant>(ptr)) {
+                insertAfterTaintLd(I, &I, ptr, getValueSize(&I));
+            }
             if (tainted_pointer && !isa<Constant>(ptr)) {
                 insertTaintPointer(I, ptr, &I, false);
             } else {

--- a/panda/plugins/taint2/llvm_taint_lib.h
+++ b/panda/plugins/taint2/llvm_taint_lib.h
@@ -110,6 +110,7 @@ private:
     void insertTaintBulk(Instruction &I,
             Constant *shad_dest, Value *dest, Constant *shad_src, Value *src,
             uint64_t size, Function *func);
+    void insertAfterTaintLd(Instruction &I, Value *val, Value *addr, uint64_t size);
     void insertTaintCopyOrDelete(Instruction &I,
             Constant *shad_dest, Value *dest, Constant *shad_src, Value *src,
             uint64_t size);
@@ -155,6 +156,7 @@ public:
     Function *breadcrumbF;
     Function *branchF;
     Function *copyRegToPcF;
+    Function *afterLdF;
 
     Constant *memlogConst;
     Function *memlogPopF;

--- a/panda/plugins/taint2/taint2.cpp
+++ b/panda/plugins/taint2/taint2.cpp
@@ -131,9 +131,6 @@ llvm::PandaTaintFunctionPass *PTFP = nullptr;
 // becomes disabled when a query operation subsequently occurs
 bool taintEnabled = false;
 
-// Lets us know right when taint was disabled
-bool taintJustDisabled = false;
-
 // Taint memlog
 static taint2_memlog taint_memlog;
 

--- a/panda/plugins/taint2/taint2.h
+++ b/panda/plugins/taint2/taint2.h
@@ -36,6 +36,9 @@ typedef void (*on_indirect_jump_t) (Addr, uint64_t);
 typedef void (*on_taint_change_t) (Addr, uint64_t);
 typedef void (*on_ptr_load_t) (Addr, uint64_t, uint64_t);
 typedef void (*on_ptr_store_t) (Addr, uint64_t, uint64_t);
+typedef void (*on_after_load_t) (Addr, uint64_t, uint64_t);
+typedef void (*on_after_store_t) (Addr, uint64_t, uint64_t);
+ 
 
 
 struct ShadowState {

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -369,6 +369,15 @@ void taint_pointer(Shad *shad_dest, uint64_t dest, Shad *shad_ptr, uint64_t ptr,
     }
 }
 
+void taint_after_ld_run(uint64_t reg, uint64_t addr, uint64_t size);
+
+// logically after taint transfer has happened for ld *or* st
+void taint_after_ld(uint64_t reg, uint64_t memaddr, uint64_t size) {
+    taint_after_ld_run(reg, memaddr, size);
+}
+
+
+
 void taint_sext(Shad *shad, uint64_t dest, uint64_t dest_size, uint64_t src,
                 uint64_t src_size)
 {

--- a/panda/plugins/taint2/taint_ops.h
+++ b/panda/plugins/taint2/taint_ops.h
@@ -88,6 +88,9 @@ void taint_delete(Shad *shad, uint64_t dest, uint64_t size);
 void taint_set(Shad *shad_dest, uint64_t dest, uint64_t dest_size,
                Shad *shad_src, uint64_t src);
 
+// reg is the register number into which the load went or out of which the store happened
+void taint_after_ld(uint64_t reg, uint64_t memaddr, uint64_t size);
+
 // Union all labels within here: [1,2,3] -> [123,123,123]
 // A mixed compute becomes two mixes followed by a parallel.
 void taint_mix(Shad *shad, uint64_t dest, uint64_t dest_size, uint64_t src,

--- a/panda/plugins/tainted_mmio/tainted_mmio.cpp
+++ b/panda/plugins/tainted_mmio/tainted_mmio.cpp
@@ -122,7 +122,7 @@ void uninit_plugin(void *);
 
 #ifdef CONFIG_SOFTMMU
 
-bool only_label_uninitialized_reads = false;
+bool only_label_uninitialized_reads = true;
 
 // a taint label
 typedef uint32_t Tlabel;
@@ -133,6 +133,7 @@ map<uint64_t,Tlabel> ioaddr2label;
 
 bool taint_on = false;
 bool is_unassigned_io;
+bool is_mmio;
 target_ulong virt_addr;
 
 uint64_t first_instruction;
@@ -154,35 +155,47 @@ target_ulong bvr_pc;
 void before_virt_read(CPUState *env, target_ptr_t pc, target_ptr_t addr,
                      size_t size) {
     // clear this before every read
-    is_unassigned_io = false;    
+    is_unassigned_io = false;
+    is_mmio = false;
     virt_addr = addr;
     bvr_pc = panda_current_pc(first_cpu);
     return;
 }
 
 
-hwaddr unassigned_read_addr;
+hwaddr read_addr;
 target_ulong suior_pc;
 
-void saw_unassigned_io_read(CPUState *env, target_ulong pc, hwaddr addr, 
-                            size_t size, uint8_t *val) {
+bool saw_unassigned_io_read(CPUState *env, target_ulong pc, hwaddr addr, 
+                            size_t size, uint64_t *val) {
     cerr << "tainted_mmio: pc=" << hex << panda_current_pc(first_cpu) 
          << ": Saw unassigned io read virt_addr=" 
          << virt_addr << " addr=" << addr << dec << "\n";
     is_unassigned_io = true;
-    unassigned_read_addr = addr;
+    read_addr = addr;
     suior_pc = panda_current_pc(first_cpu);
 
 /*
-	if (virt_addr == unassigned_read_addr || bvr_pc == suior_pc) {
+	if (virt_addr == read_addr || bvr_pc == suior_pc) {
 		cerr << "virt_addr =            " << hex << virt_addr << "\n";
-		cerr << "unassigned_read_addr = " << unassigned_read_addr << "\n";
+		cerr << "read_addr = " << read_addr << "\n";
 		cerr << "bvr_pc               = " << bvr_pc << "\n";
 		cerr << "suior_pc             = " << suior_pc << "\n";
 	}
 */
-//	assert (virt_addr == unassigned_read_addr);
+//	assert (virt_addr == read_addr);
 	assert (bvr_pc = suior_pc);
+    return false;
+}
+
+void saw_mmio_read(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, 
+                            size_t size, uint64_t *val) {
+    cerr << "tainted_mmio: pc=" << hex << panda_current_pc(first_cpu) 
+         << ": Saw mmio read virt_addr=" 
+         << vaddr << " addr=" << physaddr << dec << "\n";
+    is_mmio = true;
+    read_addr = physaddr;
+    suior_pc = panda_current_pc(first_cpu);
 }
 
 
@@ -198,50 +211,51 @@ void label_io_read(Addr reg, uint64_t paddr, uint64_t size) {
     cerr << "pc = " << hex << pc << "\n";
     cerr << "bvr_pc = " << hex << bvr_pc << "\n";
     cerr << "suior_pc = " << hex << suior_pc << "\n";
+    cerr << "paddr = " << hex << paddr << "\n";
     
 //    if (pc != unassigned_io_read_pc) return;
 
-    if (!is_unassigned_io) return;
+    if (!is_unassigned_io && !is_mmio) return;
 
 
     cerr << "label_io_read: pc=" << hex << panda_current_pc(first_cpu)
          << " instr=" << rr_get_guest_instr_count() 
-         << " : addr=" << unassigned_read_addr << dec << "\n";
+         << " : addr=" << read_addr << dec << "\n";
 
     if (!taint_on) return;
 
     bool label_it = false;
     if (only_label_uninitialized_reads) {
-        cerr << "Unassigned mmio read of " << hex << unassigned_read_addr << dec << " \n";
+        cerr << "Unassigned mmio read of " << hex << read_addr << dec << " \n";
         label_it = true;
     }
     if (!only_label_uninitialized_reads) {
-        cerr << "mmio read of " << hex << unassigned_read_addr << dec << " \n";
+        cerr << "mmio read of " << hex << read_addr << dec << " \n";
         label_it = true;
     }
     if (label_it) {
         cerr << "... tainting register destination\n";
         Tlabel label;
-        if (ioaddr2label.count(unassigned_read_addr) > 0) 
+        if (ioaddr2label.count(read_addr) > 0) 
             // existing label
-            label = ioaddr2label[unassigned_read_addr];
+            label = ioaddr2label[read_addr];
         else {
             // new label
             label = label2ioaddr.size() + 1;
-            label2ioaddr[label] = unassigned_read_addr;
-            ioaddr2label[unassigned_read_addr] = label;
+            label2ioaddr[label] = read_addr;
+            ioaddr2label[read_addr] = label;
             Panda__TaintedMmioLabel *tml = (Panda__TaintedMmioLabel*) malloc(sizeof(Panda__TaintedMmioLabel));
             *tml = PANDA__TAINTED_MMIO_LABEL__INIT;
             tml->pc = panda_current_pc(first_cpu);;
             tml->label = label;
-            tml->addr = unassigned_read_addr;
+            tml->addr = read_addr;
             Panda__LogEntry ple = PANDA__LOG_ENTRY__INIT;
             ple.tainted_mmio_label = tml;
             pandalog_write_entry(&ple);
             free(tml);
         }
         cerr << "Taint label=" << label << " for io addr=" 
-             << hex << unassigned_read_addr << " size=" << dec << size << "\n";
+             << hex << read_addr << " size=" << dec << size << "\n";
         reg.off = 0;
 
         assert (reg.typ == LADDR);
@@ -287,8 +301,11 @@ bool init_plugin(void *self) {
         pcb.unassigned_io_read = saw_unassigned_io_read;
         panda_register_callback(self, PANDA_CB_UNASSIGNED_IO_READ, pcb);
     }
-    else
+    else {
         cerr << "tainted_mmio: labeling all mmio reads\n";
+        pcb.mmio_after_read = saw_mmio_read;
+        panda_register_callback(self, PANDA_CB_MMIO_AFTER_READ, pcb);
+    }
 
     PPP_REG_CB("taint2", on_after_load, label_io_read);
     return true;

--- a/panda/plugins/tainted_mmio/tainted_mmio.proto
+++ b/panda/plugins/tainted_mmio/tainted_mmio.proto
@@ -5,7 +5,7 @@ message TaintedMmioLabel {
     required uint64 addr = 3;
 }
 
-optional TaintedMmioLabel tainted_mmio_label = 41;
+optional TaintedMmioLabel tainted_mmio_label = 73;
 
  
 


### PR DESCRIPTION
This PR add tainted_mmio plugin back to build.

Revert "Revert "adding stuff to be able to taint mmio reads""
This reverts commit d8f4718430d6ca150351329b75759231e78f04f3.