### PR TITLE
Add missing line feed to print statement in osi_linux

### DIFF
--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -693,7 +693,8 @@ bool init_plugin(void *self) {
             goto error;
         }
     }
-    printf ("Read kernel info from group \"%s\" of file \"%s\".", kconf_group, kconf_file);
+    // LOG_INFO puts \n at end of message; printf has to do so explicitly
+    printf ("Read kernel info from group \"%s\" of file \"%s\".\n", kconf_group, kconf_file);
     LOG_INFO("Read kernel info from group \"%s\" of file \"%s\".", kconf_group, kconf_file);
     g_free(kconf_file);
     g_free(kconf_group);


### PR DESCRIPTION
Yes, I know this is a little thing, but it was causing one of our regression tests to fail.  A message we were expecting to be on a line by itself was instead concatenated onto the end of the message from osi_linux.