### PR TITLE
CI Fix for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 dist: bionic
 language: c
-compiler:
-  - gcc
+compiler: gcc-8
+addons:
+	apt:
+		sources:
+			- ubuntu-toolchain-r-test
+		packages:
+			- gcc-8
+env:
+	- CC=gcc-8
+	- AR=gcc-ar-8
+
+
 cache:
   # There is one cache per branch and compiler version.
   timeout: 1200


### PR DESCRIPTION
I'm not sure why we're even using Travis for testing anymore but it was failing due to an old GCC version.

Hopefully this PR will get gcc-8 in the Travis environment. Can't (easily) test without creating a PR so this might need some more work...