### PR TITLE
Fix process selection bug in ida_taint2.py

### DIFF
--- a/panda/plugins/ida_taint2/ida_taint2.py
+++ b/panda/plugins/ida_taint2/ida_taint2.py
@@ -104,7 +104,8 @@ def main():
     input_file.close()
 
     selected_pid = ProcessSelectDialog.selectProcess(processes)
-    if not selected_pid:
+    # N.B.:  0 is a valid process ID
+    if (None == selected_pid):
         return
 
     semantic_labels = read_semantic_labels(filename + ".semantic_labels")


### PR DESCRIPTION
Properly distinguish between selecting no process and selecting a process with ID 0.
Otherwise, ida_taint2.py will never colorize kernel processes, which have PID 0 in the ida_taint2 plugin output.