### PR TITLE
Add PANDA_DIR to kernelinfo.conf search path

### DIFF
--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -25,6 +25,8 @@
 #include "kernelinfo_downloader.h"
 #include "endian_helpers.h"
 
+#define KERNEL_CONF "/" TARGET_NAME "-softmmu/panda/plugins/osi_linux/kernelinfo.conf"
+
 /*
  * Functions interfacing with QEMU/PANDA should be linked as C.
  * C++ function name mangling breaks linkage.
@@ -697,6 +699,12 @@ bool init_plugin(void *self) {
             if (kconf_file != NULL) g_free(kconf_file);
             kconf_file = g_build_filename(CONFIG_QEMU_CONFDIR, "osi_linux", "kernelinfo.conf", NULL);
             LOG_INFO("Looking for kconf_file attempt %u: %s", 2, kconf_file);
+            kconffile_canon = realpath(kconf_file, NULL);
+        }
+        if (kconffile_canon == NULL) { // from PANDA_DIR
+            if (kconf_file != NULL) g_free(kconf_file);
+            const char* panda_dir = g_getenv("PANDA_DIR");
+            kconf_file = g_strdup_printf("%s%s", panda_dir, KERNEL_CONF);
             kconffile_canon = realpath(kconf_file, NULL);
         }
 

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -184,8 +184,10 @@ bool _panda_load_plugin(const char *filename, const char *plugin_name, bool libr
 
       if (!libpanda) {
         fprintf(stderr, "Failed to load libpanda: %s from %s\n", dlerror(), library_path);
+        g_free(library_path);
         return false;
       }
+      g_free(library_path);
     }
 
     void *plugin = dlopen(filename, RTLD_NOW);


### PR DESCRIPTION
This improves the ability to use osi_linux from libpanda due to not being constrained to operating within the PANDA tree.