### PR TITLE
Small pypanda bugfixes

### DIFF
--- a/panda/python/core/panda/callback_mixins.py
+++ b/panda/python/core/panda/callback_mixins.py
@@ -237,6 +237,9 @@ class callback_mixins():
             if local_name is None:
                 local_name = func.__name__
             f = ffi.callback(attr+"_t")(func)  # Wrap the python fn in a c-callback.
+            if local_name == "<lambda>":
+                local_name = f"<lambda_{self.lambda_cnt}>"
+                self.lambda_cnt += 1
             assert (local_name not in self.ppp_registered_cbs), f"Two callbacks with conflicting name: {local_name}"
 
             # Ensure function isn't garbage collected, and keep the name->(fn, plugin_name, attr) map for disabling

--- a/panda/python/core/panda/extras/file_faker.py
+++ b/panda/python/core/panda/extras/file_faker.py
@@ -256,7 +256,7 @@ class FileFaker(FileHook):
         if (fd, asid) not in self.hooked_fds:
             # Let's use OSI to figure out the backing filename here
             fname = self._get_fname(cpu, fd)
-            if fname in self.faked_files:
+            if fname and fname in self.faked_files:
                 self.logger.warning("Entering {syscall_name} with fd {fd} backed by {fname} but we missed it earlier - adding it now")
                 hfd = HyperFD(fname, self.faked_files[fname]) # Create HFD
                 self.hooked_fds[(fd, asid)] =  hfd

--- a/panda/python/core/panda/main.py
+++ b/panda/python/core/panda/main.py
@@ -80,6 +80,7 @@ class Panda(libpanda_mixins, libqemu_mixins, blocking_mixins, osi_mixins, hookin
         self.qcow = qcow
         self.plugins = plugin_list(self)
         self.expect_prompt = expect_prompt
+        self.lambda_cnt = 0
 
         if isinstance(extra_args, str): # Extra args can be a string or array
             extra_args = extra_args.split()


### PR DESCRIPTION
Don't raise an error for colliding function names for lambda functions (but users can't enable/disable lambda functions by name)

Change the pypanda.extras.file_faker/file_hook to not always require OSI. These `extras` should really be moved into a separate repo...