### PR TITLE
Generic Linux console capture capabilty

### DIFF
--- a/panda/python/core/panda/extras/proc_write_capture.py
+++ b/panda/python/core/panda/extras/proc_write_capture.py
@@ -5,57 +5,107 @@ from panda import ffi
 class ProcWriteCapture():
 
     '''
-    For a named process, capture stdout/stderr and any file writes from the hypervisor, mirror results to log directory.
-    Requires Linux OSI.
+    Set console_capture = True to capture all console output to file, including boot messages.
+    Set proc_name = "name_of_proc" to, for a named process, capture stdout/stderr and any file writes from the hypervisor, mirror results to log directory.
+    Can be stacked with console capture.
     '''
 
-    def __init__(self, panda, proc_name, log_dir = None, rm_existing_logs = False):
+    def __init__(self, panda, console_capture = False, proc_name = None, log_dir = None, rm_existing_logs = False):
 
         self._panda = panda
         self._files_written = set()
-        self._proc_name = proc_name
         self._rm = rm_existing_logs
+        self._console_capture = console_capture
+        self._proc_name = proc_name
+        self._proc_printed_err = False
+        self._console_printed_err = False
 
         if log_dir == None:
-            self._log_dir = Path(__file__).parent.absolute().joinpath(self._proc_name)
+            self._console_log_dir = Path(__file__).parent.absolute()
+            if proc_name:
+                self._proc_log_dir = Path(__file__).parent.absolute().joinpath(self._proc_name)
         else:
-            self._log_dir = Path(log_dir).joinpath(self._proc_name)
+            self._console_log_dir = Path(log_dir)
+            if proc_name:
+                self._proc_log_dir = Path(log_dir).joinpath(self._proc_name)
 
         # Setup logging dir
-        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._console_log_dir.mkdir(parents=True, exist_ok=True)
+        self._proc_log_dir.mkdir(parents=True, exist_ok=True)
         if self._rm:
-            shutil.rmtree(self._log_dir)
+            shutil.rmtree(self._proc_log_dir)
+            shutil.rmtree(self._console_log_dir)
 
         # Mirror writes
         @self._panda.ppp("syscalls2", "on_sys_write_enter")
         def proc_write_capture_on_sys_write_enter(cpu, pc, fd, buf, cnt):
 
-            curr_proc = panda.plugins['osi'].get_current_process(cpu)
-            curr_proc_name = ffi.string(curr_proc.name).decode()
-            if self._proc_name == curr_proc_name:
+            # Capture console output
+            if self._console_capture:
 
-                try:
-                    data = panda.virtual_memory_read(cpu, buf, cnt)
-                except ValueError:
-                    raise RuntimeError("Failed to read buffer: proc \'{}\', addr 0x{:016x}".format(curr_proc_name, buf))
+                try_read = False
 
-                file_name_ptr = panda.plugins['osi_linux'].osi_linux_fd_to_filename(cpu, curr_proc, fd)
-                file_path = ffi.string(file_name_ptr).decode()
+                # Fun trick: lazy eval of OSI since only available post-boot
+                # Based on the idea that a non-POSIX FD will only be used after boot is finished an OSI is functional
+                if (fd == 1) or (fd == 2) or (fd == 3):
+                    try_read = True
+                else:
+                    curr_proc = panda.plugins['osi'].get_current_process(cpu)
+                    file_name_ptr = panda.plugins['osi_linux'].osi_linux_fd_to_filename(cpu, curr_proc, fd)
+                    file_path = ffi.string(file_name_ptr).decode()
+                    if ("tty" in file_path):
+                        try_read = True
 
-                # For informational purposes only, collection not reliant on this exact mapping
-                if fd == 1: # POSIX stdout
-                    file_path += ".stdout"
-                elif fd == 2: # POSIX stderr
-                    file_path += ".stderr"
+                if try_read:
 
-                log_file = self._log_dir.joinpath(file_path.replace("//", "_").replace("/", "_"))
-                with open(log_file, "ab") as f:
-                    f.write(data)
+                    try:
+                        data = panda.virtual_memory_read(cpu, buf, cnt)
+                    except ValueError:
+                        raise RuntimeError(f"Failed to read buffer: addr 0x{buf:016x}")
 
-                self._files_written.add(str(log_file))
+                    if fd == 2:
+                        self._console_printed_err = True
 
-    def printed_err(self):
-        return (self._stderr_log_file in self._files_written)
+                    log_file = self._console_log_dir.joinpath("console.out")
+                    with open(log_file, "ab") as f:
+                        f.write(data)
+
+                    self._files_written.add(str(log_file))
+
+            # Use OSI to capture logs for a named process
+            if self._proc_name:
+
+                curr_proc = panda.plugins['osi'].get_current_process(cpu)
+                curr_proc_name = ffi.string(curr_proc.name).decode()
+
+                if self._proc_name == curr_proc_name:
+
+                    try:
+                        data = panda.virtual_memory_read(cpu, buf, cnt)
+                    except ValueError:
+                        raise RuntimeError(f"Failed to read buffer: proc \'{curr_proc_name}\', addr 0x{buf:016x}")
+
+                    file_name_ptr = panda.plugins['osi_linux'].osi_linux_fd_to_filename(cpu, curr_proc, fd)
+                    file_path = ffi.string(file_name_ptr).decode()
+
+                    # For informational purposes only, collection not reliant on this exact mapping
+                    if fd == 1: # POSIX stdout
+                        file_path += ".stdout"
+                    elif fd == 2: # POSIX stderr
+                        file_path += ".stderr"
+                        self._proc_printed_err = True
+
+                    log_file = self._proc_log_dir.joinpath(file_path.replace("//", "_").replace("/", "_"))
+                    with open(log_file, "ab") as f:
+                        f.write(data)
+
+                    self._files_written.add(str(log_file))
+
+    def proc_printed_err(self):
+        return self._proc_printed_err
+
+    def console_printed_post_boot_err(self):
+        return self._console_printed_err
 
     def get_files_written(self):
         return self._files_written

--- a/panda/python/examples/proc_write_capture.py
+++ b/panda/python/examples/proc_write_capture.py
@@ -14,9 +14,10 @@ panda = Panda(generic=generic_type)
 @blocking
 def run_cmd():
 
-    pwc = ProcWriteCapture(panda, "dhclient", log_dir = "./pwc_log")
+    pwc = ProcWriteCapture(panda, console_capture = True, proc_name = "dhclient", log_dir = "./pwc_log")
 
     panda.revert_sync("root")
+    panda.run_serial_cmd("date")
     panda.run_serial_cmd("dhclient -v -4")
 
     print("Captured logs:")


### PR DESCRIPTION
- Update `ProcWriteCapture` primitive with an optional flag to also mirror all console output to a file on the host (still via hypervisor `write` syscall hook)
- Does lazy eval for OSI, only using it when needed. Tested on a MIPS FW from boot, captures _both_ all console logs after `init` and logs for a specific process (web server) at the same time without issue.
- Future work: also hook kernel `printk` to get boot messages (do not get printed via `write` syscall).