### PR TITLE
Pypanda: Support functions that return target_longs

### DIFF
--- a/panda/plugins/syscalls2/syscalls2_int_fns.h
+++ b/panda/plugins/syscalls2/syscalls2_int_fns.h
@@ -6,6 +6,12 @@ const syscall_info_t *get_syscall_info(uint32_t callno);
 // returns meta-information about the syscalls of the guest os
 const syscall_meta_t *get_syscall_meta(void);
 
+// BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
+// api autogen needs it.  And don't put any compiler directives
+// between this and END_PYPANDA_NEEDS_THIS except includes of other
+// files in this directory that contain subsections like this one.
+
 // returns the system call return value, hiding arch-specific details
 target_long get_syscall_retval(CPUState *cpu);
 
+// END_PYPANDA_NEEDS_THIS -- do not delete this comment!

--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -239,6 +239,7 @@ ffi.cdef("typedef void GArray;")
 ffi.cdef("typedef int target_pid_t;")
 
 ffi.cdef("typedef uint"+str(bits)+"_t target_ulong;")
+ffi.cdef("typedef int"+str(bits)+"_t target_long;")
 #define_clean_header(ffi, "{inc}/pthreadtypes.h")
 
 # PPP Headers

--- a/panda/python/examples/osi_syscalls.py
+++ b/panda/python/examples/osi_syscalls.py
@@ -12,7 +12,8 @@ def on_sys_read_return(cpu, pc, fd, buf, count):
     procname = ffi.string(proc.name) if proc != ffi.NULL else "error"
     fname_ptr = panda.plugins['osi_linux'].osi_linux_fd_to_filename(cpu, proc, fd)
     fname = ffi.string(fname_ptr) if fname_ptr != ffi.NULL else "error"
-    print(f"[PANDA] {procname} read from {fname}")
+    rc = panda.plugins['syscalls2'].get_syscall_retval(cpu)
+    print(f"[PANDA] {procname} read {rc} bytes from {fname}")
 
 @panda.ppp("syscalls2", "on_sys_execve_enter")
 def on_sys_execve_enter(cpu, pc, fname_ptr, argv_ptr, envp):


### PR DESCRIPTION
This was just a simple oversight. This PR allows us to get syscall return values from pypanda in an architecture-agnostic way:

```py
@panda.ppp("syscalls2", "on_sys_read_return")
def on_sys_read_return(cpu, pc, fd, buf, count):
    proc = panda.plugins['osi'].get_current_process(cpu)
    procname = ffi.string(proc.name) if proc != ffi.NULL else "error"
    fname_ptr = panda.plugins['osi_linux'].osi_linux_fd_to_filename(cpu, proc, fd)
    fname = ffi.string(fname_ptr) if fname_ptr != ffi.NULL else "error"
    rc = panda.plugins['syscalls2'].get_syscall_retval(cpu)   # <---- NEW!
    print(f"{procname} read {rc} bytes from {fname}")
```