### PR TITLE
Update dockerfile to pull in newer pycparser

### DIFF
--- a/panda/docker/Dockerfile_16_04
+++ b/panda/docker/Dockerfile_16_04
@@ -48,7 +48,8 @@ RUN add-apt-repository -y "$PANDA_PPA"
 #RUN mv -f "$panda_ppa_file" "$panda_ppa_file_fallback"
 
 RUN apt-get update
-RUN apt-get -y install libcapstone-dev libdwarf-dev python3-pycparser
+RUN apt-get -y install libcapstone-dev libdwarf-dev
+RUN pip3 install pycparser
 
 # Trying to install LLVM 3.3...
 RUN apt-get -y install llvm-3.3-dev clang-3.3

--- a/panda/docker/Dockerfile_18_04
+++ b/panda/docker/Dockerfile_18_04
@@ -47,10 +47,11 @@ RUN sed -i "s/$codename/$UBUNTU_FALLBACK/g" "$panda_ppa_file"
 RUN mv -f "$panda_ppa_file" "$panda_ppa_file_fallback"
 
 RUN apt-get update
-RUN apt-get -y install libcapstone-dev libdwarf-dev python3-pycparser
+RUN apt-get -y install libcapstone-dev libdwarf-dev
 
 # Upgrading protocol buffers python support
 RUN pip install --upgrade protobuf
+RUN pip install pycparser
 
 # Install LLVM 3.3...
 RUN apt-get -y install llvm-3.3-dev clang-3.3
@@ -89,17 +90,12 @@ RUN make -j4
 
 RUN make install
 
-# Make python mean python3
+# Make sure python meanss python3
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 # Install pypanda and dependencies
 WORKDIR "/panda/panda/python/core"
 RUN pip install colorama cffi protobuf
-RUN ls
 RUN python setup.py install
 
 WORKDIR "/panda"
-
-# Fetch all PRs in container so we can use this for testing
-RUN echo '[remote "origin"]' >> /panda/.git/config
-RUN echo 'fetch = +refs/pull/*/head:refs/remotes/origin/pr/*' >> /panda/.git/config


### PR DESCRIPTION
Fixes a bug introduced by ecb5fbf54546cb15da7dc34bd6f0b32acfc1f570 where
`apt install python3-pycparser` was pulling in an old version. Instead we now use pip
to get the latest version of the package.