### PR TITLE
Add hooks2 support to pypanda

### DIFF
--- a/panda/python/core/panda/main.py
+++ b/panda/python/core/panda/main.py
@@ -473,17 +473,6 @@ class Panda():
         self.libpanda.panda_require_from_library(charptr, plugin_args, len(argstrs_ffi))
         self._load_plugin_library(name)
 
-    def _procname_changed(self, cpu, name):
-        for cb_name, cb in self.registered_callbacks.items():
-            if not cb["procname"]:
-                continue
-            if name == cb["procname"] and not cb['enabled']:
-                self.enable_callback(cb_name)
-            if name != cb["procname"] and cb['enabled']:
-                self.disable_callback(cb_name)
-
-        self._update_hooks_new_procname(cpu, name)
-
     def unload_plugin(self, name):
         '''
         Unload plugin with given name.
@@ -2211,125 +2200,45 @@ class Panda():
     Provides the ability to interact with the hooks2 plugin and receive callbacks based on user-provided criteria.
     """
 
-    def update_hook(self,hook_name,addr):
-        '''
-        Update hook to point to a different addres.
-        '''
-        if hook_name in self.named_hooks:
-            hook = self.named_hooks[hook_name]
-            if addr != hook.target_addr:
-                hook.target_addr = addr
-                self.enable_hook(hook)
-
     def enable_hook(self,hook_name):
         '''
         Set hook status to active.        
         '''
-        if hook_name in self.named_hooks:
-            hook = self.named_hooks[hook_name]
-            if not hook.is_enabled:
-                hook.is_enabled = True
-                self.plugins['hooks'].enable_hook(hook.hook_cb, hook.target_addr)
+        if hook_name in self.hook_list:
+            self.plugins['hooks2'].enable_hooks2(self.hook_list[hook_name])
+        else:
+            print("ERROR: Your hook name was not in the hook list")
 
     def disable_hook(self,hook_name):
         '''
         Set hook status to inactive.
         '''
-        if hook_name in self.named_hooks:
-            hook = self.named_hooks[hook_name]
-            if hook.is_enabled:
-                hook.is_enabled = False
-                self.plugins['hooks'].disable_hook(hook.hook_cb)
+        if hook_name in self.hook_list:
+            self.plugins['hooks2'].disable_hooks2(self.hook_list[hook_name])
         else:
-            print(f"{hook_name} not in list of hooks")
+            print("ERROR: Your hook name was not in the hook list")
 
-    def _update_hooks_new_procname(self, cpu, name):
-        '''
-        Uses user-defined information to update the state of hooks based on things such as libraryname, procname and whether 
-        or not the hook points to kernel space.
-        '''
-        for h in self.hook_list:
-            if h.is_kernel:
-                continue
-
-            if h.program_name:
-                if (h.program_name != name):
-                    if h.is_enabled:
-                        self.disable_hook(h)
-                    continue
-
-                if h.library_name is None:
-                    if h.is_enabled:
-                        self.enable_hook(h)
-                    continue
-
-            if h.library_name:
-                asid = self.libpanda.panda_current_asid(cpu)
-                lowest_matching_addr = 0
-
-                if lowest_matching_addr == 0:
-                    libs = self.get_mappings(cpu)
-                    if libs == ffi.NULL:
-                        continue
-                    for lib in libs:
-                        if lib.file != ffi.NULL:
-                            filename = ffi.string(lib.file).decode("utf8", "ignore")
-                            if h.library_name in filename:
-                                if (lowest_matching_addr == 0) or (lib.base < lowest_matching_addr):
-                                    lowest_matching_addr = lib.base
-
-                if lowest_matching_addr:
-                    self.update_hook(h, lowest_matching_addr + h.target_library_offset)
-                else:
-                    self.disable_hook(h)
-
-    def _register_mmap_cb(self):
-        if self._registered_mmap_cb:
-            return
-
-        @self.ppp("syscalls2", "on_do_mmap2_return")
-        def on_do_mmap2_return(cpu, pc, addr, length, prot, flags, fd, pgoff):
-            self._update_hooks_new_procname(cpu, self.get_process_name(cpu))
-
-    def hook(self, addr, enabled=True, kernel=True, libraryname=None, procname=None, name=None):
+    def hook(self,name, kernel=True, procname=ffi.NULL, libname=ffi.NULL, trace_start=0, trace_stop=0, range_begin=0, range_end=0):
+        if procname != ffi.NULL:
+            procname = ffi.new("char[]",bytes(procname,"utf-8"))
+        if libname != ffi.NULL:
+            libname = ffi.new("char[]",bytes(libname,"utf-8"))
         '''
         Decorate a function to setup a hook: when a guest goes to execute a basic block beginning with addr,
         the function will be called with args (CPUState, TranslationBlock)
         '''
-        if procname:
-            self._register_internal_asid_changed_cb()
-
-        if libraryname:
-            self._register_mmap_cb()
-
         def decorator(fun):
             # Ultimately, our hook resolves as a before_block_exec_invalidate_opt callback so we must match its args
-            hook_cb_type = self.callback.before_block_exec_invalidate_opt # (CPUState, TranslationBlock)
-
-            if 'hooks' not in self.plugins:
-                # Enable hooks plugin on first request
-                self.load_plugin("hooks")
-
-            if debug:
-                print("Registering breakpoint at 0x{:x} -> {} == {}".format(addr, fun, 'cdata_cb'))
-
+            hook_cb_type = ffi.callback("bool (CPUState*, TranslationBlock*, void*)")
             # Inform the plugin that it has a new breakpoint at addr
+            
             hook_cb_passed = hook_cb_type(fun)
-            self.plugins['hooks'].add_hook(addr, hook_cb_passed)
-            hook_to_add = Hook(is_enabled=enabled,is_kernel=kernel,target_addr=addr,library_name=libraryname,program_name=procname,hook_cb=None, target_library_offset=None)
-            if libraryname: 
-                hook_to_add.target_library_offset = addr
-                hook_to_add.target_addr = 0
-                hook_to_add.hook_cb = hook_cb_passed
-            else:
-                hook_to_add.hook_cb = hook_cb_passed
-            self.hook_list.append(hook_to_add)
-            if name:
-                if not hasattr(self, "named_hooks"):
-                    self.named_hooks = {}
-                self.named_hooks[name] = hook_to_add
-            if libraryname or procname:
-                self.disable_hook(hook_to_add)
+            # I don't know what this is/does
+            cb_data = ffi.NULL
+            hook_number = self.plugins['hooks2'].add_hooks2(hook_cb_passed, cb_data, kernel, \
+                procname, libname, trace_start, trace_stop, range_begin,range_end)
+            
+            self.hook_list[name] = hook_number
 
             @hook_cb_type # Make CFFI know it's a callback. Different from _generated_callback for some reason?
             def wrapper(*args, **kw):
@@ -2337,5 +2246,10 @@ class Panda():
 
             return wrapper
         return decorator
+    
+    def hook_single_insn(self, name, pc, kernel=False, procname=None, libname=None):
+        return self.hook(name, kernel=kernel, procname=procname,libname=libname,range_begin=pc, range_end=pc)
+    
+
 
 # vim: expandtab:tabstop=4:

--- a/panda/python/core/panda/main.py
+++ b/panda/python/core/panda/main.py
@@ -166,7 +166,7 @@ class Panda():
         self._initialized_panda = False
         self.disabled_tb_chaining = False
         self.taint_enabled = False
-        self.hook_list = []
+        self.hook_list = {}
 
         # Asid stuff
         self.current_asid_name = None
@@ -2233,6 +2233,11 @@ class Panda():
             # Inform the plugin that it has a new breakpoint at addr
             
             hook_cb_passed = hook_cb_type(fun)
+            if not hasattr(self, "hook_gc_list"):
+                self.hook_gc_list = [hook_cb_passed]
+            else:
+                self.hook_gc_list.append(hook_cb_passed)
+
             # I don't know what this is/does
             cb_data = ffi.NULL
             hook_number = self.plugins['hooks2'].add_hooks2(hook_cb_passed, cb_data, kernel, \
@@ -2247,7 +2252,7 @@ class Panda():
             return wrapper
         return decorator
     
-    def hook_single_insn(self, name, pc, kernel=False, procname=None, libname=None):
+    def hook_single_insn(self, name, pc, kernel=False, procname=ffi.NULL, libname=ffi.NULL):
         return self.hook(name, kernel=kernel, procname=procname,libname=libname,range_begin=pc, range_end=pc)
     
 

--- a/panda/python/core/panda/utils.py
+++ b/panda/python/core/panda/utils.py
@@ -85,19 +85,6 @@ def blocking(func):
     wrapper.__name__ = func.__name__ + " (with async thread)"
     return wrapper
 
-class Hook(object):
-    '''
-    Maintains the state of a hook as defined by a user.
-    '''
-    def __init__(self,is_enabled=True,is_kernel=True,hook_cb=True,target_addr=0,target_library_offset=0,library_name=None,program_name=None):
-        self.is_enabled = is_enabled
-        self.is_kernel = is_kernel
-        self.hook_cb = hook_cb
-        self.target_addr = target_addr
-        self.target_library_offset = target_library_offset
-        self.library_name = library_name
-        self.program_name = program_name
-
 class GArrayIterator():
     '''
     Iterator which will run a function on each iteration incrementing

--- a/panda/python/examples/experimental/example_fwrite.py
+++ b/panda/python/examples/experimental/example_fwrite.py
@@ -15,7 +15,7 @@ with open("libc_syms.pickle", "rb") as f:
     libc = pickle.load(f)
 
 f = open("fwrite.out","wb")
-@panda.hook(libc["fwrite"],libraryname="libc",kernel=False)
+@panda.hook_single_insn("fwrite_hook", libc["fwrite"],libraryname="libc",kernel=False)
 def fwrite_hook(cpustate, tb):
 	# grab arguments ESP, arg1, arg2, arg3...
 	ret = ffi.new("uint32_t[]", 5)

--- a/panda/python/tests/hooking.py
+++ b/panda/python/tests/hooking.py
@@ -53,7 +53,7 @@ sysaccess_ran_ctr = 0
 # something went wrong
 need_sysaccess = False
 
-@panda.hook(kallsyms["system_call"])
+@panda.hook_single_insn("call_hook", kallsyms["system_call"], kernel=True)
 def call_hook(env, tb):
     pc = panda.current_pc(env)
     syscall_num = env.env_ptr.regs[0]
@@ -68,7 +68,7 @@ def call_hook(env, tb):
 
     return False
 
-@panda.hook(kallsyms["sys_access"])
+@panda.hook("call_hook2", kallsyms["sys_access"], kernel=True, kernel=True)
 def call_hook2(env, tb):
     pc = panda.current_pc(env)
     global sysaccess_ran_ctr, need_sysaccess


### PR DESCRIPTION
This adds support for adding hooks via the hooks2 plugin to pypanda. It also gets rid of any explicit support for the (now deprecated) hooks plugin.