### PR TITLE
Minor pypanda update

### DIFF
--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -181,11 +181,7 @@ def main(install=False):
     # out pypanda bits to go in INCLUDE_DIR files
     plugin_dirs = os.listdir(PLUGINS_DIR)
 
-    if install: # DYNAMIC from file
-        INCLUDE_DIR_PYP_INSTALL = 'os.path.abspath(os.path.join(*[os.path.dirname(__file__), "..", "..", "pandare", "data", "pypanda", "include"]))'  # ... /python3.6/site-packages/panda/data/pypanda/include/
-    else:
-        # STATIC from current
-        INCLUDE_DIR_PYP_INSTALL = os.path.abspath(os.path.join(*[os.path.dirname(__file__), "..", "core", "panda", "include"]))          # panda-git/panda/python/core/panda/include
+    INCLUDE_DIR_PYP_INSTALL = 'os.path.abspath(os.path.join(*[os.path.dirname(__file__), "..", "..", "pandare", "data", "pypanda", "include"]))'  # ... /python3.6/site-packages/panda/data/pypanda/include/
 
     # Pull in osi/osi_types.h first - it's needed by other plugins too
     if os.path.exists("%s/%s" % (PLUGINS_DIR, 'osi')):

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -740,6 +740,37 @@ class Panda():
         else: # Else it's positive
             return x
 
+    def queue_blocking(self, func, queue=True):
+        """
+        Decorator to mark a function as `blocking`, and by default queue it to run asynchronously
+
+        ```
+        @panda.queue_blocking
+        def do_something():
+            panda.revert_sync('root')
+            print(panda.run_serial_cmd('whoami'))
+            panda.end_analysis()
+        ```
+
+        is equivalent to
+
+        ```
+        @blocking
+        def run_whoami():
+            panda.revert_sync('root')
+            print(panda.run_serial_cmd('whoami'))
+            panda.end_analysis()
+
+        panda.queue_async(run_whoami)
+        ```
+
+        """
+        f = blocking(func)
+        if queue:
+            self.queue_async(f)
+        return f
+
+
     ########################## LIBPANDA FUNCTIONS ########################
     # Methods that directly pass data to/from PANDA with no extra logic beyond argument reformatting.
     def set_pandalog(self, name):

--- a/panda/python/core/setup.py
+++ b/panda/python/core/setup.py
@@ -17,6 +17,8 @@ import shutil
 
 root_dir = os.path.join(*[os.path.dirname(__file__), "..", "..", ".."]) # panda-git/ root dir
 
+pypi_build = False # Set to true if trying to minimize size for pypi package upload. Note this disables some architectures
+
 lib_dir = os.path.join("pandare", "data")
 def copy_objs():
     '''
@@ -50,9 +52,12 @@ def copy_objs():
         llvm_enabled = True if 'CONFIG_LLVM=y' in cfg.read() else False
 
     # For each arch, copy library, plugins, plog_pb2.py and llvm-helpers
-    #for arch in ['arm', 'i386', 'x86_64', 'ppc', 'mips', 'mipsel']:
-    # XXX dropping mips and ppc to fit into pypi
-    for arch in ['arm', 'i386', 'x86_64', 'mipsel']:
+    arches = ['arm', 'i386', 'x86_64', 'ppc', 'mips', 'mipsel']
+    if pypi_build:
+        # XXX need to drop mips and ppc to fit into pypi
+        arches = ['arm', 'i386', 'x86_64', 'mipsel']
+
+    for arch in arches:
         libname = "libpanda-"+arch+".so"
         softmmu = arch+"-softmmu"
         path      = os.path.join(*[build_root, softmmu, libname])
@@ -77,8 +82,9 @@ def copy_objs():
 
         shutil.copytree(plugindir,  new_plugindir)
 
-    # Strip libpandas and plugins to save space (Need <100mb for pipy)
-    check_output(f"find {lib_dir} -type f -executable -exec strip {{}} \;", shell=True)
+    # Strip libpandas and plugins to save space (Need <100mb for pypi)
+    if pypi_build:
+        check_output(f"find {lib_dir} -type f -executable -exec strip {{}} \;", shell=True)
 
 
 #########################

--- a/panda/python/examples/asid.py
+++ b/panda/python/examples/asid.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from sys import argv
-from pandarere import Panda, blocking, ffi
+from pandare import Panda, blocking, ffi
 
 panda = Panda(generic="x86_64" if len(argv) < 2 else argv[1])
 

--- a/panda/python/examples/unicorn/mips.py
+++ b/panda/python/examples/unicorn/mips.py
@@ -28,7 +28,7 @@ stop_addr = ADDRESS + len(encoding)
 
 panda = Panda("mipsel",
         extra_args=["-M", "configurable", "-nographic"],
-        raw_monitor=True)
+        raw_monitor=True) # Allows for a user to ctrl-a + c then type quit if things go wrong
 
 @panda.cb_after_machine_init
 def setup(cpu):
@@ -42,7 +42,7 @@ def setup(cpu):
     panda.physical_memory_write(ADDRESS, bytes(encoding))
 
     # Set up registers
-    cpu.env_ptr.active_tc.gpr[8] = 0x10
+    cpu.env_ptr.active_tc.gpr[panda.arch.registers['t0']] = 0x10
 
     # Set starting_pc
     cpu.env_ptr.active_tc.PC = ADDRESS
@@ -59,8 +59,8 @@ def on_insn(cpu, pc):
     if pc >= stop_addr:
         print("Finished execution")
         #dump_regs(panda, cpu)
-        print("Register t0 contains:", hex(cpu.env_ptr.active_tc.gpr[8]))
-        print("Register t1 contains:", hex(cpu.env_ptr.active_tc.gpr[9]))
+        print("Register t0 contains:", hex(cpu.env_ptr.active_tc.gpr[panda.arch.registers['t0']]))
+        print("Register t1 contains:", hex(cpu.env_ptr.active_tc.gpr[panda.arch.registers['t1']]))
         os._exit(0) # TODO: we need a better way to stop here
 
     code = panda.virtual_memory_read(cpu, pc, 12)

--- a/panda/scripts/plog_reader.py
+++ b/panda/scripts/plog_reader.py
@@ -32,7 +32,7 @@ assert 'plog_pb2' in sys.modules, "Couldn't load module plog_pb2. Searched paths
 
 class PLogReader:
     def __init__(self, fn):
-        self.f = open(fn)
+        self.f = open(fn, 'rb')
         self.version, _, self.dir_pos, _, self.chunk_gsize = struct.unpack('<IIQII', self.f.read(24))
 
         self.f.seek(self.dir_pos)


### PR DESCRIPTION
Bugfixes:
* The generated `panda_datatypes.py` was invalid if was produced by `setup.py develop`.
* By default the pandare package now installs mips and ppc targets (had previously been disabled to support pypi uploads but that shouldn't be the default)
* Python3 fix for plog_reader
* Cleanup unicorn mode example for mips

Features:
Add a new decorator `@panda.queue_blocking` which marks a function as blocking and queues it to run.
