### PR TITLE
Don't ignore signals when in library mode

### DIFF
--- a/os-posix.c
+++ b/os-posix.c
@@ -51,11 +51,14 @@ static int daemon_pipe;
 void os_setup_early_signal_handling(void)
 {
     struct sigaction act;
-    sigfillset(&act.sa_mask);
-    act.sa_flags = 0;
-    if (panda_get_library_mode()) { // Don't ignore signals in library mode
+
+    if (panda_get_library_mode()) {
+       // Don't ignore signals in library mode
       return;
     }
+
+    sigfillset(&act.sa_mask);
+    act.sa_flags = 0;
     act.sa_handler = SIG_IGN;
     sigaction(SIGPIPE, &act, NULL);
 }
@@ -68,6 +71,11 @@ static void termsig_handler(int signal, siginfo_t *info, void *c)
 void os_setup_signal_handling(void)
 {
     struct sigaction act;
+
+    if (panda_get_library_mode()) {
+       // Don't ignore signals in library mode
+      return;
+    }
 
     memset(&act, 0, sizeof(act));
     act.sa_sigaction = termsig_handler;

--- a/os-posix.c
+++ b/os-posix.c
@@ -53,6 +53,9 @@ void os_setup_early_signal_handling(void)
     struct sigaction act;
     sigfillset(&act.sa_mask);
     act.sa_flags = 0;
+    if (panda_get_library_mode()) { // Don't ignore signals in library mode
+      return;
+    }
     act.sa_handler = SIG_IGN;
     sigaction(SIGPIPE, &act, NULL);
 }


### PR DESCRIPTION
When the python interpreter is blocking on a `panda.run()` call, if a user presses Ctrl+C we want to raise a `KeyboardInterrupt` exception and end the panda execution. Currently we just end the panda execution with no indication of interruption.

This PR is a work in progress - it disables the PANDA signal handlers when in library mode. But it looks like the exception is being caught and dropped by CFFI instead of passed to anything useful.

This is trying to fix #540 