### PR TITLE
fix siginfo dependency

### DIFF
--- a/panda/include/panda/panda_api.h
+++ b/panda/include/panda/panda_api.h
@@ -43,11 +43,7 @@ target_ulong panda_current_sp_external(CPUState *cpu);
 target_ulong panda_current_sp_masked_pagesize_external(CPUState *cpu, target_ulong pagesize);
 target_ulong panda_virt_to_phys_external(CPUState *cpu, target_ulong virt_addr);
 
-
-// set to true if panda_setup_signal_handling is called
-void (*panda_external_signal_handler)(int, siginfo_t*,void*) = NULL;
-
-void panda_setup_signal_handling(void (*f) (int, siginfo_t*, void *));
+void panda_setup_signal_handling(void (*f) (int, void*, void *));
 
 void map_memory(char* name, uint64_t size, uint64_t address);
 
@@ -67,4 +63,9 @@ CPUState* get_cpu(void);
 
 unsigned long garray_len(GArray *list);
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
+
+// don't expose to API  because we don't want to add siginfo_t understanding
+// set to true if panda_setup_signal_handling is called
+void (*panda_external_signal_handler)(int, siginfo_t*,void*) = NULL;
+
 #endif

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -160,17 +160,17 @@ target_ulong panda_virt_to_phys_external(CPUState *cpu, target_ulong virt_addr) 
   return panda_virt_to_phys(cpu, virt_addr);
 }
 
-void panda_setup_signal_handling(void (*f) (int, siginfo_t*, void *))
+void panda_setup_signal_handling(void (*f) (int, void*, void *))
 {
     struct sigaction act;
 
     memset(&act, 0, sizeof(act));
-    act.sa_sigaction = f;
+    act.sa_sigaction = (void(*)(int,siginfo_t*,void*))f;
     act.sa_flags = SA_SIGINFO;
     sigaction(SIGINT,  &act, NULL);
     sigaction(SIGHUP,  &act, NULL);
     sigaction(SIGTERM, &act, NULL);
-    panda_external_signal_handler = f;
+    panda_external_signal_handler = (void(*)(int,siginfo_t*,void*)) f;
 }
 
 // we have this temporarily in callbacks.c -> to be moved here


### PR DESCRIPTION
This was a simple mistake I made when adding API support to python for the signal handler.

When the include file was compiled it required python to have an understanding of the siginfo_t struct. Doing so would be a pain and require us to either update it when it changes or have an old siginfo struct. We could do something like have a blank stand-in siginfo as well, but making it a void pointer is slightly more honest and easy to follow.