### PR TITLE
replaces git submodule protocol to support proxy (git->https)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,36 +1,36 @@
 [submodule "roms/vgabios"]
 	path = roms/vgabios
-	url = git://git.qemu-project.org/vgabios.git/
+	url = https://git.qemu.org/git/vgabios.git
 [submodule "roms/seabios"]
 	path = roms/seabios
-	url = git://git.qemu-project.org/seabios.git/
+	url = https://git.qemu.org/git/seabios.git
 [submodule "roms/SLOF"]
 	path = roms/SLOF
-	url = git://git.qemu-project.org/SLOF.git
+	url = https://git.qemu.org/git/SLOF.git
 [submodule "roms/ipxe"]
 	path = roms/ipxe
-	url = git://git.qemu-project.org/ipxe.git
+	url = https://git.qemu.org/git/ipxe.git
 [submodule "roms/openbios"]
 	path = roms/openbios
-	url = git://git.qemu-project.org/openbios.git
+	url = https://git.qemu.org/git/openbios.git
 [submodule "roms/openhackware"]
 	path = roms/openhackware
-	url = git://git.qemu-project.org/openhackware.git
+	url = https://git.qemu.org/git/openhackware.git
 [submodule "roms/qemu-palcode"]
 	path = roms/qemu-palcode
-	url = git://github.com/rth7680/qemu-palcode.git
+	url = https://github.com/rth7680/qemu-palcode.git
 [submodule "roms/sgabios"]
 	path = roms/sgabios
-	url = git://git.qemu-project.org/sgabios.git
+	url = https://git.qemu.org/git/sgabios.git
 [submodule "pixman"]
 	path = pixman
-	url = git://anongit.freedesktop.org/pixman
+	url = https://anongit.freedesktop.org/git/pixman
 [submodule "dtc"]
 	path = dtc
-	url = git://git.qemu-project.org/dtc.git
+	url = https://git.qemu.org/git/dtc.git
 [submodule "roms/u-boot"]
 	path = roms/u-boot
-	url = git://git.qemu-project.org/u-boot.git
+	url = https://git.qemu.org/git/u-boot.git
 [submodule "roms/skiboot"]
 	path = roms/skiboot
-	url = git://git.qemu.org/skiboot.git
+	url = https://git.qemu.org/git/skiboot.git


### PR DESCRIPTION
- reconfigures all git submodules to use https versus git so that
  installation and updating submodules works behind a https-proxy
  where ssh is blocked.