### PR TITLE
Change PyPANDA model to support multiple replays in a row and add simple memory hooks plugin

### DIFF
--- a/panda/include/panda/panda_api.h
+++ b/panda/include/panda/panda_api.h
@@ -62,6 +62,7 @@ char* panda_monitor_run(char* buf);// Redefinition from monitor.h
 CPUState* get_cpu(void);
 
 unsigned long garray_len(GArray *list);
+void panda_cleanup_record(void);
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 // don't expose to API  because we don't want to add siginfo_t understanding

--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -39,3 +39,4 @@ win7x86intro
 wintrospection
 winxpx86intro
 syscalls_logger
+mem_hooks

--- a/panda/plugins/hooks/hooks.cpp
+++ b/panda/plugins/hooks/hooks.cpp
@@ -3,6 +3,7 @@
  * Authors:
  *  Andrew Fasano               andrew.fasano@ll.mit.edu
  *  Nick Gregory                ngregory@nyu.edu
+ *  Luke Craig                  luke.craig@ll.mit.edu
  * 
  * This work is licensed under the terms of the GNU GPL, version 2. 
  * See the COPYING file in the top-level directory. 

--- a/panda/plugins/mem_hooks/Makefile
+++ b/panda/plugins/mem_hooks/Makefile
@@ -1,0 +1,9 @@
+# Don't forget to add your plugin to config.panda!
+
+# If you need custom CFLAGS or LIBS, set them up here
+# CFLAGS+=
+# LIBS+=
+
+# The main rule for your plugin. List all object-file dependencies.
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
+	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o

--- a/panda/plugins/mem_hooks/USAGE.md
+++ b/panda/plugins/mem_hooks/USAGE.md
@@ -1,0 +1,19 @@
+Plugin: mem_hooks
+===========
+
+Summary
+-------
+Plugin to call python functions (via pypanda) before executing code at a given address.
+
+Arguments
+---------
+
+Dependencies
+------------
+Must be used with pypanda
+
+APIs and Callbacks
+------------------
+
+Example
+-------

--- a/panda/plugins/mem_hooks/mem_hooks.cpp
+++ b/panda/plugins/mem_hooks/mem_hooks.cpp
@@ -1,0 +1,151 @@
+/* PANDABEGINCOMMENT
+ * 
+ * Authors:
+ *  Luke Craig                  luke.craig@ll.mit.edu
+ *  Andrew Fasano               andrew.fasano@ll.mit.edu
+ *  Nick Gregory                ngregory@nyu.edu
+ * 
+ * This work is licensed under the terms of the GNU GPL, version 2. 
+ * See the COPYING file in the top-level directory. 
+ * 
+PANDAENDCOMMENT */
+
+// This needs to be defined before anything is included in order to get
+// the PRIx64 macro
+#define __STDC_FORMAT_MACROS
+
+#include "panda/plugin.h"
+#include "mem_hooks_int_fns.h"
+#include <iostream>
+#include <unordered_map>
+#include <vector>
+#include <csignal>
+
+// These need to be extern "C" so that the ABI is compatible with
+// QEMU/PANDA, which is written in C
+extern "C" {
+bool init_plugin(void *);
+void uninit_plugin(void *);
+void enable_mem_hooking(void);
+void disable_mem_hooking(void);
+void phys_mem_before_write(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf);
+void phys_mem_before_read(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf);
+void phys_mem_after_write(CPUState *env, target_ulong pc, target_ulong addr, target_ulong size, void *buf);
+void phys_mem_after_read(CPUState *env, target_ulong pc, target_ulong addr, target_ulong size, void *buf);
+struct memory_hooks_region* add_mem_hook(struct memory_hooks_region* a);
+void cool_other_function(void);
+}
+
+
+std::vector<struct memory_hooks_region> hooks;
+
+// Callback objects
+panda_cb c_callback_before_read;
+panda_cb c_callback_before_write;
+panda_cb c_callback_after_read;
+panda_cb c_callback_after_write;
+
+// Handle to self
+void* self = NULL;
+
+// Enable and disable callbacks
+void enable_mem_hooking(void) {
+  assert(self != NULL);
+  panda_enable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_before_read);
+  panda_enable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_before_write);
+  panda_enable_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_after_read);
+  panda_enable_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_after_write);
+}
+void disable_mem_hooking(void) {
+  assert(self != NULL);
+  panda_disable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_before_read);
+  panda_disable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_before_write);
+  panda_disable_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_after_read);
+  panda_disable_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_after_write);
+}
+
+// nah
+//void update_hook(hook_func_t hook, target_ulong value){
+//  //Given hook function, move it to fire on a different address
+//  for (auto it = hooks.begin(); it != hooks.end(); ++it){
+//		if (it->first == value) continue;
+//        std::vector<hook_func_t> hook_pile = it->second;
+//        auto i = hook_pile.begin();
+//        while (i != hook_pile.end()){
+//            if (hook == *i){
+//                i = hook_pile.erase(i);
+//            }else{
+//                ++i;
+//            }
+//
+//        }
+//       it->second = hook_pile;
+//    }
+//	hooks[value].push_back(hook);
+//#if DEBUG
+//  printf("Updated hook to fire at %p\n", &hook);
+//#endif
+//}
+
+struct memory_hooks_region* add_mem_hook(struct memory_hooks_region* m) {
+  if (!panda_is_callback_enabled(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_before_read)) enable_mem_hooking(); // Ensure our panda callback is enabled when we add a hook
+	// check for existing hook
+  hooks.push_back(*m);
+  return &hooks[hooks.size() - 1];
+}
+
+void check_phys_mem_change(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf, bool is_write, bool is_before){
+  bool is_read = !is_write;
+  bool is_after = !is_before;
+  for (auto& it: hooks){
+    if (it.enabled){
+      if ((addr >= it.start_address && addr <= it.stop_address) ||
+          (addr + size >= it.start_address && addr + size <= it.stop_address) || (addr >= it.start_address && addr + size <= it.stop_address)){
+        // needs to be more complicated
+        if ((is_write && it.on_write && is_before && it.on_before) ||
+           (is_read && it.on_read && is_before && it.on_before) ||
+           (is_write && it.on_write && is_after && it.on_after) ||
+           (is_read && it.on_read && is_after && it.on_after)){
+             (*(it.cb))(cpu, pc, addr, size, buf, is_write, is_before);
+        }
+      }else{
+      }
+    }else{
+      printf("here but not enabled\n");
+    }
+  }
+}
+
+void phys_mem_before_write(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf){
+  check_phys_mem_change(cpu, pc, addr, size, buf, true, true);
+}
+void phys_mem_before_read(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size){
+  check_phys_mem_change(cpu, pc, addr, size, (uint8_t*) NULL, false, true);
+}
+
+void phys_mem_after_write(CPUState *cpu, target_ulong pc, target_ulong addr, size_t size, uint8_t *buf){
+  check_phys_mem_change(cpu, pc, addr, size, buf, true, false);
+}
+void phys_mem_after_read(CPUState *cpu, target_ulong pc, target_ulong addr, size_t size, uint8_t *buf){
+  check_phys_mem_change(cpu, pc, addr, size, buf, false, false);
+}
+
+bool init_plugin(void *_self) {
+    // On init, register a callback but don't enable it
+    self = _self;
+
+    c_callback_before_read.phys_mem_before_read = phys_mem_before_read;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_before_read);
+    c_callback_before_write.phys_mem_before_write = phys_mem_before_write;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_before_write);
+    c_callback_after_read.phys_mem_after_read = phys_mem_after_read;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_after_read);
+    c_callback_after_write.phys_mem_after_write = phys_mem_after_write;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_after_write);
+
+    panda_enable_memcb();
+
+    return true;
+}
+
+void uninit_plugin(void *self) {}

--- a/panda/plugins/mem_hooks/mem_hooks.cpp
+++ b/panda/plugins/mem_hooks/mem_hooks.cpp
@@ -33,17 +33,20 @@ void phys_mem_before_read(CPUState *cpu, target_ptr_t pc, target_ulong addr, siz
 void phys_mem_after_write(CPUState *env, target_ulong pc, target_ulong addr, target_ulong size, void *buf);
 void phys_mem_after_read(CPUState *env, target_ulong pc, target_ulong addr, target_ulong size, void *buf);
 struct memory_hooks_region* add_mem_hook(struct memory_hooks_region* a);
-void cool_other_function(void);
 }
 
 
 std::vector<struct memory_hooks_region> hooks;
 
 // Callback objects
-panda_cb c_callback_before_read;
-panda_cb c_callback_before_write;
-panda_cb c_callback_after_read;
-panda_cb c_callback_after_write;
+panda_cb c_callback_phys_before_read;
+panda_cb c_callback_phys_before_write;
+panda_cb c_callback_phys_after_read;
+panda_cb c_callback_phys_after_write;
+panda_cb c_callback_virt_before_read;
+panda_cb c_callback_virt_before_write;
+panda_cb c_callback_virt_after_read;
+panda_cb c_callback_virt_after_write;
 
 // Handle to self
 void* self = NULL;
@@ -51,17 +54,25 @@ void* self = NULL;
 // Enable and disable callbacks
 void enable_mem_hooking(void) {
   assert(self != NULL);
-  panda_enable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_before_read);
-  panda_enable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_before_write);
-  panda_enable_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_after_read);
-  panda_enable_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_after_write);
+  panda_enable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_phys_before_read);
+  panda_enable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_phys_before_write);
+  panda_enable_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_phys_after_read);
+  panda_enable_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_phys_after_write);
+  panda_enable_callback(self, PANDA_CB_VIRT_MEM_BEFORE_READ, c_callback_virt_before_read);
+  panda_enable_callback(self, PANDA_CB_VIRT_MEM_BEFORE_WRITE, c_callback_virt_before_write);
+  panda_enable_callback(self, PANDA_CB_VIRT_MEM_AFTER_READ, c_callback_virt_after_read);
+  panda_enable_callback(self, PANDA_CB_VIRT_MEM_AFTER_WRITE, c_callback_virt_after_write);
 }
 void disable_mem_hooking(void) {
   assert(self != NULL);
-  panda_disable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_before_read);
-  panda_disable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_before_write);
-  panda_disable_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_after_read);
-  panda_disable_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_after_write);
+  panda_disable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_phys_before_read);
+  panda_disable_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_phys_before_write);
+  panda_disable_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_phys_after_read);
+  panda_disable_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_phys_after_write);
+  panda_disable_callback(self, PANDA_CB_VIRT_MEM_BEFORE_READ, c_callback_virt_before_read);
+  panda_disable_callback(self, PANDA_CB_VIRT_MEM_BEFORE_WRITE, c_callback_virt_before_write);
+  panda_disable_callback(self, PANDA_CB_VIRT_MEM_AFTER_READ, c_callback_virt_after_read);
+  panda_disable_callback(self, PANDA_CB_VIRT_MEM_AFTER_WRITE, c_callback_virt_after_write);
 }
 
 // nah
@@ -88,64 +99,98 @@ void disable_mem_hooking(void) {
 //}
 
 struct memory_hooks_region* add_mem_hook(struct memory_hooks_region* m) {
-  if (!panda_is_callback_enabled(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_before_read)) enable_mem_hooking(); // Ensure our panda callback is enabled when we add a hook
+  if (!panda_is_callback_enabled(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_phys_before_read)) enable_mem_hooking(); // Ensure our panda callback is enabled when we add a hook
 	// check for existing hook
   hooks.push_back(*m);
   return &hooks[hooks.size() - 1];
 }
 
-void check_phys_mem_change(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf, bool is_write, bool is_before){
+void check_phys_mem_change(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf, bool is_write, bool is_before, bool is_physical){
   bool is_read = !is_write;
   bool is_after = !is_before;
+  bool is_virtual = !is_physical;
+  struct memory_access_desc mad = {.pc = pc, .addr = addr,
+                    .size = size,
+                    .buf = buf,
+                    .on_before = is_before,
+                    .on_after = is_after,
+                    .on_read = is_read,
+                    .on_write = is_write,
+                    .on_virtual = is_virtual,
+                    .on_physical = is_physical,
+                    .hook = NULL 
+                    };
   for (auto& it: hooks){
     if (it.enabled){
-      if ((addr >= it.start_address && addr <= it.stop_address) ||
-          (addr + size >= it.start_address && addr + size <= it.stop_address) || (addr >= it.start_address && addr + size <= it.stop_address)){
-        // needs to be more complicated
+      if ((addr >= it.start_address && addr < it.stop_address) ||
+          (addr + size > it.start_address && addr + size <= it.stop_address) ||
+          (addr >= it.start_address && addr + size <= it.stop_address)){
         if ((is_write && it.on_write && is_before && it.on_before) ||
            (is_read && it.on_read && is_before && it.on_before) ||
            (is_write && it.on_write && is_after && it.on_after) ||
            (is_read && it.on_read && is_after && it.on_after)){
-             (*(it.cb))(cpu, pc, addr, size, buf, is_write, is_before);
+             if ((is_virtual && it.on_virtual) ||
+                (is_physical && it.on_physical)){
+              mad.hook = &it;
+              (*(it.cb))(cpu, &mad);
+             }
         }
       }else{
       }
-    }else{
-      printf("here but not enabled\n");
     }
   }
 }
 
 void phys_mem_before_write(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf){
-  check_phys_mem_change(cpu, pc, addr, size, buf, true, true);
+  check_phys_mem_change(cpu, pc, addr, size, buf, true, true, true);
 }
 void phys_mem_before_read(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size){
-  check_phys_mem_change(cpu, pc, addr, size, (uint8_t*) NULL, false, true);
+  check_phys_mem_change(cpu, pc, addr, size, (uint8_t*) NULL, false, true, true);
 }
-
 void phys_mem_after_write(CPUState *cpu, target_ulong pc, target_ulong addr, size_t size, uint8_t *buf){
-  check_phys_mem_change(cpu, pc, addr, size, buf, true, false);
+  check_phys_mem_change(cpu, pc, addr, size, buf, true, false, true);
 }
 void phys_mem_after_read(CPUState *cpu, target_ulong pc, target_ulong addr, size_t size, uint8_t *buf){
-  check_phys_mem_change(cpu, pc, addr, size, buf, false, false);
+  check_phys_mem_change(cpu, pc, addr, size, buf, false, false, true);
+}
+void virt_mem_before_write(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf){
+  check_phys_mem_change(cpu, pc, addr, size, buf, true, true, false);
+}
+void virt_mem_before_read(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size){
+  check_phys_mem_change(cpu, pc, addr, size, (uint8_t*) NULL, false, true, false);
+}
+void virt_mem_after_write(CPUState *cpu, target_ulong pc, target_ulong addr, size_t size, uint8_t *buf){
+  check_phys_mem_change(cpu, pc, addr, size, buf, true, false, false);
+}
+void virt_mem_after_read(CPUState *cpu, target_ulong pc, target_ulong addr, size_t size, uint8_t *buf){
+  check_phys_mem_change(cpu, pc, addr, size, buf, false, false, false);
 }
 
 bool init_plugin(void *_self) {
     // On init, register a callback but don't enable it
     self = _self;
 
-    c_callback_before_read.phys_mem_before_read = phys_mem_before_read;
-    panda_register_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_before_read);
-    c_callback_before_write.phys_mem_before_write = phys_mem_before_write;
-    panda_register_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_before_write);
-    c_callback_after_read.phys_mem_after_read = phys_mem_after_read;
-    panda_register_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_after_read);
-    c_callback_after_write.phys_mem_after_write = phys_mem_after_write;
-    panda_register_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_after_write);
+    c_callback_phys_before_read.phys_mem_before_read = phys_mem_before_read;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_phys_before_read);
+    c_callback_phys_before_write.phys_mem_before_write = phys_mem_before_write;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_phys_before_write);
+    c_callback_phys_after_read.phys_mem_after_read = phys_mem_after_read;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_phys_after_read);
+    c_callback_phys_after_write.phys_mem_after_write = phys_mem_after_write;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_phys_after_write);
+    c_callback_virt_before_read.virt_mem_before_read = virt_mem_before_read;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_BEFORE_READ, c_callback_virt_before_read);
+    c_callback_virt_before_write.virt_mem_before_write = virt_mem_before_write;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_BEFORE_WRITE, c_callback_virt_before_write);
+    c_callback_virt_after_read.virt_mem_after_read = virt_mem_after_read;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_AFTER_READ, c_callback_virt_after_read);
+    c_callback_virt_after_write.virt_mem_after_write = virt_mem_after_write;
+    panda_register_callback(self, PANDA_CB_PHYS_MEM_AFTER_WRITE, c_callback_virt_after_write);
 
     panda_enable_memcb();
 
     return true;
 }
 
-void uninit_plugin(void *self) {}
+void uninit_plugin(void *self) {
+}

--- a/panda/plugins/mem_hooks/mem_hooks_int.h
+++ b/panda/plugins/mem_hooks/mem_hooks_int.h
@@ -1,0 +1,9 @@
+// XXX: pycparser is failing to parse hooks_int_fns.h with the
+// typedef'd function pointer.
+// However, this file is 's still provided for pypanda although the
+// typical panda plugin-to-plugin API isn't automatically created
+
+/*
+typedef void hook_func_t
+#include "hooks_int_fns.h"
+*/

--- a/panda/plugins/mem_hooks/mem_hooks_int_fns.h
+++ b/panda/plugins/mem_hooks/mem_hooks_int_fns.h
@@ -1,0 +1,28 @@
+extern "C" {
+
+// BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
+// api autogen needs it.  And don't put any compiler directives
+// between this and END_PYPANDA_NEEDS_THIS except includes of other
+// files in this directory that contain subsections like this one.
+
+// Hook functions must be of this type
+typedef void (*mem_hook_func_t)(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf, bool is_write, bool is_before);
+
+struct memory_hooks_region{
+    target_ulong start_address;
+    target_ulong stop_address;
+    bool enabled;
+    bool on_before;
+    bool on_after;
+    bool on_read;
+    bool on_write;
+    mem_hook_func_t cb;
+};
+
+struct memory_hooks_region* add_mem_hook(struct memory_hooks_region* a);
+void disable_mem_hooking(void);
+void enable_mem_hooking(void);
+
+// END_PYPANDA_NEEDS_THIS -- do not delete this comment!
+
+}

--- a/panda/plugins/mem_hooks/mem_hooks_int_fns.h
+++ b/panda/plugins/mem_hooks/mem_hooks_int_fns.h
@@ -5,9 +5,23 @@ extern "C" {
 // between this and END_PYPANDA_NEEDS_THIS except includes of other
 // files in this directory that contain subsections like this one.
 
-// Hook functions must be of this type
-typedef void (*mem_hook_func_t)(CPUState *cpu, target_ptr_t pc, target_ulong addr, size_t size, uint8_t *buf, bool is_write, bool is_before);
 
+struct memory_hooks_region;
+struct memory_access_desc {
+    target_ptr_t pc;
+    target_ulong addr;
+    size_t size;
+    uint8_t* buf;
+    bool on_before;
+    bool on_after;
+    bool on_read;
+    bool on_write;
+    bool on_virtual;
+    bool on_physical;
+    struct memory_hooks_region* hook;
+};
+// Hook functions must be of this type
+typedef void (*mem_hook_func_t)(CPUState *cpu, struct memory_access_desc* mad);
 struct memory_hooks_region{
     target_ulong start_address;
     target_ulong stop_address;
@@ -16,6 +30,8 @@ struct memory_hooks_region{
     bool on_after;
     bool on_read;
     bool on_write;
+    bool on_virtual;
+    bool on_physical;
     mem_hook_func_t cb;
 };
 

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -183,6 +183,7 @@ class Panda():
 
         # Shutdown stuff
         self.exception = None # When set to an exn, we'll raise and exit
+        self._in_replay = False
 
         # main_loop_wait functions and callbacks
         self.main_loop_wait_fnargs = [] # [(fn, args), ...]
@@ -420,7 +421,9 @@ class Panda():
         self.libpanda.panda_unload_plugins() # Unload c plugins - should be safe now since exec has stopped
         # Write PANDALOG, if any
         #self.libpanda.panda_cleanup_record()
-        self.reset()
+        if self._in_replay:
+            print("doing reset")
+            self.reset()
         if hasattr(self, "end_run_raise_signal"):
             raise self.end_run_raise_signal
         if hasattr(self, "callback_exit_exception"):
@@ -492,7 +495,9 @@ class Panda():
 
         charptr = ffi.new("char[]",bytes(replaypfx,"utf-8"))
         self.libpanda.panda_replay_begin(charptr)
+        self._in_replay = True
         self.run()
+        self._in_replay = False
 
     def require(self, name):
         '''

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -418,7 +418,9 @@ class Panda():
         self.libpanda.panda_run() # Give control to panda
         self.running.clear() # Back from panda's execution (due to shutdown or monitor quit)
         self.libpanda.panda_unload_plugins() # Unload c plugins - should be safe now since exec has stopped
-        self.panda_finish() # Write PANDALOG, if any
+        # Write PANDALOG, if any
+        #self.libpanda.panda_cleanup_record()
+        self.reset()
         if hasattr(self, "end_run_raise_signal"):
             raise self.end_run_raise_signal
         if hasattr(self, "callback_exit_exception"):

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -424,7 +424,6 @@ class Panda():
         # Write PANDALOG, if any
         #self.libpanda.panda_cleanup_record()
         if self._in_replay:
-            print("doing reset")
             self.reset()
         if hasattr(self, "end_run_raise_signal"):
             saved = self.end_run_raise_signal
@@ -595,8 +594,9 @@ class Panda():
             progress ("Disabling all python plugins, unloading all C plugins")
 
         # First unload python plugins, should be safe to do anytime
-        for name in self.registered_callbacks.keys():
-            self.delete_callback(name)
+        #for name in self.registered_callbacks.keys():
+        while len(list(self.registered_callbacks)) > 0:
+            self.delete_callback(list(self.registered_callbacks.keys())[0])
             #self.disable_callback(name)
 
         # Then unload C plugins. May be unsafe to do except from the top of the main loop (taint segfaults otherwise)
@@ -2240,7 +2240,6 @@ class Panda():
             raise ValueError("No callback has been registered with name '{}'".format(name))
 
         handle = self.registered_callbacks[name]['handle']
-        print(f"delete_callback {name} {handle}")
         self.libpanda.panda_unregister_callbacks(handle)
         del self.registered_callbacks[name]['handle']
         del self.registered_callbacks[name]

--- a/panda/python/examples/example_multiple_replay.py
+++ b/panda/python/examples/example_multiple_replay.py
@@ -1,0 +1,51 @@
+from pandare import Panda
+
+panda = Panda(generic="i386")
+
+from os.path import exists
+
+if not exists("cool_recording-rr-snp"):
+    @panda.queue_blocking
+    def do_stuff():
+        panda.revert_sync("root")
+        print(panda.run_serial_cmd("echo abcdefgh | tee cool_file"))
+        panda.run_monitor_cmd("begin_record cool_recording")
+        print(panda.run_serial_cmd("cat cool_file | nc 18.4.83.213 8888"))
+        panda.run_monitor_cmd("end_record")
+        panda.end_analysis()
+
+    panda.run()
+print("done with iniital section")
+## print out all the files we saw
+#@panda.ppp("syscalls2","on_sys_open_return")
+#def sys_open_return(cpu, pc, path, flags,mode):
+#    print(f"File opened {panda.read_str(cpu,path)}")
+#
+#@panda.cb_asid_changed
+#def asid_changed(cpu, old,new):
+#    print(f"new_asid {cpu.rr_guest_instr_count}")
+#    return 0
+#    
+#panda.run_replay("cool_recording")
+#
+## print out all the files we saw
+#@panda.ppp("syscalls2","on_sys_open_return")
+#def sys_open_return(cpu, pc, path, flags,mode):
+#    print(f"File opened second time {panda.read_str(cpu,path)}")
+#
+#@panda.cb_asid_changed
+#def asid_changed(cpu, old,new):
+#    print(f"new_asid {cpu.rr_guest_instr_count}")
+#    return 0
+#    
+#panda.run_replay("cool_recording")
+
+for i in range(10):
+
+    @panda.cb_asid_changed
+    def asid_changed(cpu, old,new):
+        print(f"new_asid {cpu.rr_guest_instr_count}")
+        return 0
+
+    panda.run_replay("cool_recording")
+

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -76,6 +76,12 @@ int panda_snap(char *snapshot_name) {
     return save_vmstate(NULL, snapshot_name);
 }
 
+void panda_cleanup_record(void){
+    if(rr_in_record()){
+        rr_do_end_record();
+    }
+}
+
 int panda_finish(void) {
     return main_aux(0, 0, 0, PANDA_FINISH);
 }


### PR DESCRIPTION
Working on getting the following functionality to work:

```
record()
replay()
...
replay()
```

and
```
replay()
replay()
...
replay()
```

This requires some rethinking of how plugins are going to be handled in PANDA as well as callbacks.

Also add support for `panda.hook_mem`.