### PR TITLE
Add in_dll() to OSI

### DIFF
--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -1,15 +1,15 @@
 /* PANDABEGINCOMMENT
- * 
+ *
  * Authors:
  *  Tim Leek               tleek@ll.mit.edu
  *  Ryan Whelan            rwhelan@ll.mit.edu
  *  Joshua Hodosh          josh.hodosh@ll.mit.edu
  *  Michael Zhivich        mzhivich@ll.mit.edu
  *  Brendan Dolan-Gavitt   brendandg@gatech.edu
- * 
- * This work is licensed under the terms of the GNU GPL, version 2. 
- * See the COPYING file in the top-level directory. 
- * 
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
+ *
 PANDAENDCOMMENT */
 // This needs to be defined before anything is included in order to get
 // the PRIx64 macro
@@ -128,6 +128,25 @@ target_pid_t get_process_ppid(CPUState *cpu, const OsiProcHandle *h) {
 void notify_task_change(CPUState *cpu)
 {
     PPP_RUN_CB(on_task_change, cpu);
+}
+
+bool in_dll(CPUState *cpu, OsiProc *p) {
+    target_ulong pc = panda_current_pc(cpu);
+    GArray *mappings = get_mappings(cpu, p);
+    if (mappings != NULL) {
+        for (int i = 0; i < mappings->len; i++) {
+            OsiModule *m = &g_array_index(mappings, OsiModule, i);
+            if ((m->base <= pc) && (pc <= (m->base + m->size))) {
+                if (strcasestr(m->name, ".so") != NULL) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+    }
+
+    return false;
 }
 
 extern const char *qemu_file;

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -142,6 +142,8 @@ bool in_shared_object(CPUState *cpu, OsiProc *p) {
         for (int i = 0; i < mappings->len; i++) {
             OsiModule *m = &g_array_index(mappings, OsiModule, i);
             if ((m->base <= pc) && (pc <= (m->base + m->size))) {
+                // XXX: libc doesn't have a bounded string substring search? e.g. strnstr?
+                // XXX: this logic hasn't been tested on the Windows OS
                 if ((strcasestr(m->name, ".so") != NULL) || (strcasestr(m->name, ".dll") != NULL)) {
                     return true;
                 } else {

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -131,8 +131,13 @@ void notify_task_change(CPUState *cpu)
 }
 
 bool in_dll(CPUState *cpu, OsiProc *p) {
+    if (panda_in_kernel(cpu)) {
+        return false;
+    }
+
     target_ulong pc = panda_current_pc(cpu);
     GArray *mappings = get_mappings(cpu, p);
+
     if (mappings != NULL) {
         for (int i = 0; i < mappings->len; i++) {
             OsiModule *m = &g_array_index(mappings, OsiModule, i);

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -130,7 +130,7 @@ void notify_task_change(CPUState *cpu)
     PPP_RUN_CB(on_task_change, cpu);
 }
 
-bool in_dll(CPUState *cpu, OsiProc *p) {
+bool in_shared_object(CPUState *cpu, OsiProc *p) {
     if (panda_in_kernel(cpu)) {
         return false;
     }
@@ -142,7 +142,7 @@ bool in_dll(CPUState *cpu, OsiProc *p) {
         for (int i = 0; i < mappings->len; i++) {
             OsiModule *m = &g_array_index(mappings, OsiModule, i);
             if ((m->base <= pc) && (pc <= (m->base + m->size))) {
-                if (strcasestr(m->name, ".so") != NULL) {
+                if ((strcasestr(m->name, ".so") != NULL) || (strcasestr(m->name, ".dll") != NULL)) {
                     return true;
                 } else {
                     return false;

--- a/panda/plugins/osi/osi_int_fns.h
+++ b/panda/plugins/osi/osi_int_fns.h
@@ -31,8 +31,8 @@ OsiProc* get_one_proc(GArray *osiprocs, unsigned int idx);
 
 void cleanup_garray(GArray *g);
 
-// returns true if execution is currently within a DLL function, else false.
-bool in_dll(CPUState *cpu, OsiProc *p);
+// returns true if execution is currently within a dynamically-linked function, else false.
+bool in_shared_object(CPUState *cpu, OsiProc *p);
 
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 

--- a/panda/plugins/osi/osi_int_fns.h
+++ b/panda/plugins/osi/osi_int_fns.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdbool.h>
+
 // BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
 // api autogen needs it.  And don't put any compiler directives
 // between this and END_PYPANDA_NEEDS_THIS except includes of other

--- a/panda/plugins/osi/osi_int_fns.h
+++ b/panda/plugins/osi/osi_int_fns.h
@@ -29,6 +29,9 @@ OsiProc* get_one_proc(GArray *osiprocs, unsigned int idx);
 
 void cleanup_garray(GArray *g);
 
+// returns true if execution is currently within a DLL function, else false.
+bool in_dll(CPUState *cpu, OsiProc *p);
+
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 // gets the currently running process handle

--- a/panda/python/examples/osi_in_dll.py
+++ b/panda/python/examples/osi_in_dll.py
@@ -11,7 +11,7 @@ def bbe(cpu, tb, exit_code):
 
     global bb_ctr
 
-    if exit_code <= 1:
+    if (not panda.in_kernel(cpu)) and (exit_code <= 1):
         bb_ctr += 1
 
         if (bb_ctr % 1000) == 0:

--- a/panda/python/examples/osi_in_dll.py
+++ b/panda/python/examples/osi_in_dll.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+from pandare import Panda, blocking, ffi
+
+panda = Panda(generic="i386")
+panda.load_plugin("osi")
+bb_ctr = 0
+
+@panda.cb_after_block_exec
+def bbe(cpu, tb, exit_code):
+
+    global bb_ctr
+
+    if exit_code <= 1:
+        bb_ctr += 1
+
+        if (bb_ctr % 1000) == 0:
+            proc = panda.plugins['osi'].get_current_process(cpu)
+            if proc == ffi.NULL:
+                return
+
+            proc_name = ffi.string(proc.name).decode("utf-8")
+            pc = panda.current_pc(cpu)
+            in_dll = panda.plugins['osi'].in_dll(cpu, proc)
+            print(f"{proc_name}@{pc:016x}, in DLL? {in_dll}")
+
+@blocking
+def start():
+    panda.revert_sync("root")
+    print(panda.run_serial_cmd("cat /etc/passwd"))
+    panda.end_analysis()
+
+panda.queue_async(start)
+panda.run()

--- a/panda/python/examples/osi_in_shared_obj.py
+++ b/panda/python/examples/osi_in_shared_obj.py
@@ -21,8 +21,8 @@ def bbe(cpu, tb, exit_code):
 
             proc_name = ffi.string(proc.name).decode("utf-8")
             pc = panda.current_pc(cpu)
-            in_dll = panda.plugins['osi'].in_dll(cpu, proc)
-            print(f"{proc_name}@{pc:016x}, in DLL? {in_dll}")
+            in_dll = panda.plugins['osi'].in_shared_object(cpu, proc)
+            print(f"{proc_name}@{pc:016x}, in SO? {in_dll}")
 
 @blocking
 def start():


### PR DESCRIPTION
Using the algorithm @lacraig2 suggested.

Experimented with caching mappings (e.g. `unordered_map<std::tuple<proc_asid, proc_create_time>, get_mappings_result>`) to speed this up, but decided against it because:

- Added a lot of complexity, but this is already plenty fast (see `python/examples/osi_in_shared_obj.py`)
- Added potential sources of error (e.g. when to flush cache entries for dead processes to prevent unbounded growth? Is asid + create_time truly unique?)
- Short circuiting with `panda_in_kernel()` was much better bang for the runtime buck
