### PR TITLE
proper freeing of qemu_file in PANDA_MAIN_FINISH

### DIFF
--- a/vl.c
+++ b/vl.c
@@ -5059,7 +5059,7 @@ int main_aux(int argc, char **argv, char **envp, PandaMainMode pmm)
     if (pmm == PANDA_INIT) return 0;
 
 PANDA_MAIN_RUN:
-    
+
 
     panda_in_main_loop = 1;
     main_loop();
@@ -5094,7 +5094,11 @@ PANDA_MAIN_FINISH:
     }
 #endif
 
-    free((void*)qemu_file);
+    if (qemu_file != NULL){
+        free((void*)qemu_file);
+        qemu_file = NULL;
+    }
+
 
     return 0;
 }


### PR DESCRIPTION
qemu_file is also free'd in panda_set_qemu_path (https://github.com/panda-re/panda/blob/master/panda/src/panda_api.c#L97).
In corner cases, this can lead to a double-free as in PANDA_MAIN_FINISH qemu_file is neither checked against NULL, nor set to NULL after free'ing it.
This PR is a minimal fix for this.