### PR TITLE
fixed kernel version bug

### DIFF
--- a/panda/plugins/osi_linux/endian_helpers.h
+++ b/panda/plugins/osi_linux/endian_helpers.h
@@ -6,11 +6,16 @@
 // If guest and host endianness don't match:
 // fixupendian will flip a dword in place
 #define fixupendian(x)         {x=bswap32((target_ptr_t)x);}
+#define fixupendian64(x)       {x=bswap64((uint64_t)x);}
 // of flipbadendian will flip a dword
 #define flipbadendian(x)       bswap32((target_ptr_t)x)
+#define flipbadendian64(x)     bswap64((uint64_t)x)
+
 
 #else
 #define fixupendian(x)         {}
-#define flipbadendian(x)     x
+#define fixupendian64(x)       {}
+#define flipbadendian(x)       x
+#define flipbadendian64(x)     x
 #endif
 

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -165,7 +165,16 @@ void fill_osiproc(CPUState *cpu, OsiProc *p, target_ptr_t task_addr) {
     p->pid = get_tgid(cpu, task_addr);
     //p->ppid = get_real_parent_pid(cpu, task_addr);
     p->pages = NULL;  // OsiPage - TODO
-    p->create_time = get_start_time(cpu, task_addr);
+
+    //if kernel version is < 3.17
+    if(ki.version.a < 3 || (ki.version.a == 3 && ki.version.b < 17)) {
+
+        //convert the 32 least significant bits from seconds to nanoseconds, and add the value of the 32 most significant bits (already in nanoseconds)
+        uint64_t tmp = get_start_time(cpu, task_addr);
+        p->create_time = ((tmp & 0x00000000FFFFFFFF) * 1000000000) + ((tmp & 0xFFFFFFFF00000000) >> 32);
+    } else {
+        p->create_time = get_start_time(cpu, task_addr);
+    }
     fixupendian(p->create_time); // The struct_get call won't automatically fix endian
 }
 

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -168,14 +168,22 @@ void fill_osiproc(CPUState *cpu, OsiProc *p, target_ptr_t task_addr) {
 
     //if kernel version is < 3.17
     if(ki.version.a < 3 || (ki.version.a == 3 && ki.version.b < 17)) {
-
-        //convert the 32 least significant bits from seconds to nanoseconds, and add the value of the 32 most significant bits (already in nanoseconds)
         uint64_t tmp = get_start_time(cpu, task_addr);
-        p->create_time = ((tmp & 0x00000000FFFFFFFF) * 1000000000) + ((tmp & 0xFFFFFFFF00000000) >> 32);
+        fixupendian64(tmp);
+
+        //if there's an endianness mismatch
+        #if defined(TARGET_WORDS_BIGENDIAN) != defined(HOST_WORDS_BIGENDIAN)
+            //convert the most significant half into nanoseconds, then add the rest of the nanoseconds
+            p->create_time = (((tmp & 0xFFFFFFFF00000000) >> 32) * 1000000000) + (tmp & 0x00000000FFFFFFFF);
+        #else
+            //convert the least significant half into nanoseconds, then add the rest of the nanoseconds
+            p->create_time = ((tmp & 0x00000000FFFFFFFF) * 1000000000) + ((tmp & 0xFFFFFFFF00000000) >> 32);
+        #endif
+       
     } else {
         p->create_time = get_start_time(cpu, task_addr);
+        fixupendian64(p->create_time); // The struct_get call won't automatically fix endian
     }
-    fixupendian(p->create_time); // The struct_get call won't automatically fix endian
 }
 
 /**


### PR DESCRIPTION
Fixed an issue where OSI would return incorrect task_struct.start_time values on linux kernels older than version 3.17. 

Kernel versions >= 3.17 store the start_time field as an uint64, which contains the number of nanoseconds elapsed since boot.

In versions < 3.17, start_time is a struct which contains two uint32 fields, one which stores the number of seconds since boot, and one which stores the number of nanoseconds elapsed since the last increment of the seconds counter. When this struct is read as a uint64 by OSI, the result is a 64-bit number with the seconds value in the lower 32 bits and the nanoseconds value in the higher 32 bits, creating an unusable timestamp for the user.

This can be solved by converting the seconds counter into nanoseconds, and then adding the value of the nanoseconds counter. This creates a new timestamp value in nanoseconds, and can be used the same way as a timestamp from more recent versions.

---EDIT---

Fixed another start_time issue - using `fixupendian()` on start_time can result in the truncation of the start_time value, because arguments to `fixupendian()` are passed to `bswap32()`, which only operates on 32 bits. I added a new helper function `fixupendian64()` to correct it.