### PR TITLE
Pypanda: Fix format string in FileFaker write()

### DIFF
--- a/panda/python/core/pandare/extras/file_faker.py
+++ b/panda/python/core/pandare/extras/file_faker.py
@@ -55,7 +55,7 @@ class FakeFile:
         Return how much HyperFD offset should be incremented by
         XXX what about writes past end of the file?
         '''
-        self.logger.info("FakeFD({self.filename}) writing {new_data} at offset {self.offset}")
+        self.logger.info(f"FakeFD({self.filename}) writing {new_data} at offset {self.offset}")
         new_data  = self.contents[:offset]
         new_data += write_data
         new_data += self.contents[offset+len(new_data):]


### PR DESCRIPTION
This PR is to fix the FileFaker write logging to use format strings.   Previously it was just printing the string without interpolation.