### PR TITLE
Fix memory leak in OSI in_shared_object

### DIFF
--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -151,6 +151,7 @@ bool in_shared_object(CPUState *cpu, OsiProc *p) {
                 }
             }
         }
+        g_array_free(mappings, true);
     }
 
     return false;
@@ -175,7 +176,7 @@ bool init_plugin(void *self) {
     if (panda_os_familyno == OS_LINUX) {
         LOG_INFO("OSI grabbing Linux introspection backend.");
         panda_require("osi_linux");
-    }else if (panda_os_familyno == OS_WINDOWS) {
+    } else if (panda_os_familyno == OS_WINDOWS) {
         LOG_INFO("OSI grabbing Windows introspection backend.");
         panda_require("wintrospection");
     }


### PR DESCRIPTION
According to the tests in osi_linux, the `mappings` GArray is an owned GArray (link below), so this should be correct, however I do not have anything that uses this on hand to properly regression test against.

https://github.com/panda-re/panda/blob/c9b275ec2ffd8cb45f98dff5b4fc90e7ef6b3836/panda/plugins/osi_linux/osi_linux.cpp#L580-L586