### PR TITLE
coverage: add hook filter capability

### DIFF
--- a/panda/plugins/coverage/AsidBlockGenerator.cpp
+++ b/panda/plugins/coverage/AsidBlockGenerator.cpp
@@ -5,7 +5,7 @@ namespace coverage
 
 AsidBlockGenerator::AsidBlockGenerator(
     CPUState *c,
-    std::unique_ptr<RecordProcessor<AsidBlock>> d)
+    std::shared_ptr<RecordProcessor<AsidBlock>> d)
         : cpu(c), delegate(std::move(d))
 {
 }

--- a/panda/plugins/coverage/AsidBlockGenerator.h
+++ b/panda/plugins/coverage/AsidBlockGenerator.h
@@ -17,11 +17,11 @@ class AsidBlockGenerator : public RecordProcessor<Block>
 {
 public:
     AsidBlockGenerator(CPUState *c,
-                       std::unique_ptr<RecordProcessor<AsidBlock>> d);
+                       std::shared_ptr<RecordProcessor<AsidBlock>> d);
     void handle(Block record) override;
 private:
     CPUState *cpu;
-    std::unique_ptr<RecordProcessor<AsidBlock>> delegate;
+    std::shared_ptr<RecordProcessor<AsidBlock>> delegate;
 };
 
 }

--- a/panda/plugins/coverage/BlockInstrumentationDelegate.cpp
+++ b/panda/plugins/coverage/BlockInstrumentationDelegate.cpp
@@ -21,7 +21,7 @@ static void block_callback(RecordProcessor<Block> *bp, TranslationBlock *tb)
     }
 }
 
-BlockInstrumentationDelegate::BlockInstrumentationDelegate(std::unique_ptr<RecordProcessor<Block>> bp)
+BlockInstrumentationDelegate::BlockInstrumentationDelegate(std::shared_ptr<RecordProcessor<Block>> bp)
     : block_processor(std::move(bp))
 {
 }

--- a/panda/plugins/coverage/BlockInstrumentationDelegate.h
+++ b/panda/plugins/coverage/BlockInstrumentationDelegate.h
@@ -13,12 +13,12 @@ namespace coverage
 class BlockInstrumentationDelegate : public InstrumentationDelegate
 {
 public:
-    BlockInstrumentationDelegate(std::unique_ptr<RecordProcessor<Block>> bp);
+    BlockInstrumentationDelegate(std::shared_ptr<RecordProcessor<Block>> bp);
 
     void instrument(CPUState *cpu, TranslationBlock *tb) override;
 
 private:
-    std::unique_ptr<RecordProcessor<Block>> block_processor;
+    std::shared_ptr<RecordProcessor<Block>> block_processor;
 };
 
 }

--- a/panda/plugins/coverage/EdgeInstrumentationDelegate.cpp
+++ b/panda/plugins/coverage/EdgeInstrumentationDelegate.cpp
@@ -474,9 +474,9 @@ const static std::unordered_map<unsigned int,
 };
 
 EdgeInstrumentationDelegate::EdgeInstrumentationDelegate(
-    std::unique_ptr<RecordProcessor<Edge>> ep) : edge_processor(std::move(ep))
-                                               , capstone_initialized(false)
-                                               , edge_state(new EdgeState())
+    std::shared_ptr<RecordProcessor<Edge>> ep) : edge_processor(ep)
+                                                , capstone_initialized(false)
+                                                , edge_state(new EdgeState())
 {
 }
 

--- a/panda/plugins/coverage/EdgeInstrumentationDelegate.h
+++ b/panda/plugins/coverage/EdgeInstrumentationDelegate.h
@@ -21,7 +21,7 @@ class EdgeInstrumentationDelegate : public InstrumentationDelegate,
                                     public OsiObserver
 {
 public:
-    EdgeInstrumentationDelegate(std::unique_ptr<RecordProcessor<Edge>> ep);
+    EdgeInstrumentationDelegate(std::shared_ptr<RecordProcessor<Edge>> ep);
     ~EdgeInstrumentationDelegate();
 
     void instrument(CPUState *cpu, TranslationBlock *tb) override;
@@ -32,7 +32,7 @@ public:
     void task_changed(const std::string& process_name, target_pid_t pid, target_pid_t tid) override;
 
 private:
-    std::unique_ptr<RecordProcessor<Edge>> edge_processor;
+    std::shared_ptr<RecordProcessor<Edge>> edge_processor;
     bool capstone_initialized;
     csh handle;
     std::unique_ptr<EdgeState> edge_state;

--- a/panda/plugins/coverage/HookFilter.h
+++ b/panda/plugins/coverage/HookFilter.h
@@ -1,0 +1,93 @@
+#ifndef COVERAGE_HOOKFILTER_H
+#define COVERAGE_HOOKFILTER_H
+
+#include <memory>
+
+#include "panda/tcg-utils.h"
+
+#include "InstrumentationDelegate.h"
+#include "OsiObserver.h"
+#include "RecordProcessor.h"
+
+namespace coverage
+{
+
+static void pass_hook_cb(bool *pass_ptr, target_pid_t *current_tid_ptr,
+                         target_pid_t *target_tid_ptr)
+{
+    *pass_ptr = true;
+    *target_tid_ptr = *current_tid_ptr;
+}
+
+static void block_hook_cb(bool *pass_ptr)
+{
+    *pass_ptr = false;
+}
+
+/**
+ * HookFilter acts as a gate in the coverage processing pipline, passing or
+ * rejecting the records depending on whether or not the filter is on or off.
+ * The filter is turned on or off by hooking two user provided addresses. The
+ * "pass" hook disables the filter and allows records to pass to the delegate.
+ * The "block" hook turns on the filter and stops the records from passing to
+ * the delegate. An internal variable that keeps track of which thread is
+ * currently active is also used so that only the coverage from the thread at
+ * the time the pass hook is executed is reported.
+ */
+template<typename RecordType>
+class HookFilter : public RecordProcessor<RecordType>,
+                   public InstrumentationDelegate,
+                   public OsiObserver
+{
+public:
+    HookFilter(target_ulong ph, target_ulong bh,
+               std::shared_ptr<RecordProcessor<RecordType>> d)
+        : pass_hook(ph), block_hook(bh), pass(false), delegate(std::move(d))
+    {
+    }
+
+    ~HookFilter() override { }
+
+    void instrument(CPUState *cpu, TranslationBlock *tb) override
+    {
+        // Check if we need to instrument the "pass" instruction.
+        if (tb->pc <= pass_hook && pass_hook < tb->pc + tb->size) {
+            TCGOp *op = find_guest_insn_by_addr(pass_hook);
+            assert(op);
+            insert_call(&op, &pass_hook_cb, &pass, &current_tid, &target_tid);
+        }
+        // Check if we need to instrument the "block" instruction.
+        if (tb->pc <= block_hook && block_hook < tb->pc + tb->size) {
+            TCGOp *op = find_guest_insn_by_addr(block_hook);
+            assert(op);
+            insert_call(&op, &block_hook_cb, &pass);
+        }
+    }
+
+    void handle(RecordType record) override
+    {
+        // Check if the internal variable is set or not. If set, pass the
+        // record to the delegate.
+        if ((pass) && (current_tid == target_tid)) {
+            delegate->handle(record);
+        }
+    }
+
+    void task_changed(const std::string& process_name, target_pid_t pid,
+                      target_pid_t tid) override
+    {
+        current_tid = tid;
+    }
+
+private:
+    target_ulong pass_hook;
+    target_ulong block_hook;
+    bool pass;
+    target_pid_t current_tid;
+    target_pid_t target_tid;
+    std::shared_ptr<RecordProcessor<RecordType>> delegate;
+};
+
+}
+
+#endif

--- a/panda/plugins/coverage/ModeBuilder.h
+++ b/panda/plugins/coverage/ModeBuilder.h
@@ -21,8 +21,9 @@ public:
     ModeBuilder& with_filename(const std::string& filename);
     ModeBuilder& with_unique_filter();
     ModeBuilder& with_start_disabled();
+    ModeBuilder& with_hook_filter(target_ulong pass_hook, target_ulong block_hook);
 
-    std::unique_ptr<InstrumentationDelegate> build();
+    std::vector<std::shared_ptr<InstrumentationDelegate>> build();
 
 private:
     std::vector<CoverageMonitorDelegate *>& monitor_delegates;
@@ -32,6 +33,8 @@ private:
     std::string filename;
     bool unique;
     bool start_disabled;
+    target_ulong pass_hook; 
+    target_ulong block_hook;
 };
 
 }

--- a/panda/plugins/coverage/OsiBlockGenerator.cpp
+++ b/panda/plugins/coverage/OsiBlockGenerator.cpp
@@ -7,8 +7,8 @@
 namespace coverage
 {
 
-OsiBlockGenerator::OsiBlockGenerator(std::unique_ptr<RecordProcessor<OsiBlock>> d)
-        : pname("(unknown)"), pid(0), tid(0), delegate(std::move(d))
+OsiBlockGenerator::OsiBlockGenerator(std::shared_ptr<RecordProcessor<OsiBlock>> d)
+        : pname("(unknown)"), pid(0), tid(0), delegate(d)
 {
 }
 

--- a/panda/plugins/coverage/OsiBlockGenerator.h
+++ b/panda/plugins/coverage/OsiBlockGenerator.h
@@ -17,7 +17,7 @@ class OsiBlockGenerator : public RecordProcessor<Block>,
                           public OsiObserver
 {
 public:
-    OsiBlockGenerator(std::unique_ptr<RecordProcessor<OsiBlock>> d);
+    OsiBlockGenerator(std::shared_ptr<RecordProcessor<OsiBlock>> d);
     void handle(Block record) override;
 
     void task_changed(const std::string& process_name, target_pid_t pid, target_pid_t tid) override;
@@ -25,7 +25,7 @@ private:
     std::string pname;
     target_pid_t pid;
     target_pid_t tid;
-    std::unique_ptr<RecordProcessor<OsiBlock>> delegate;
+    std::shared_ptr<RecordProcessor<OsiBlock>> delegate;
 };
 
 }

--- a/panda/plugins/coverage/ProcessNameFilter.h
+++ b/panda/plugins/coverage/ProcessNameFilter.h
@@ -21,7 +21,7 @@ class ProcessNameFilter : public RecordProcessor<RecordType>,
 {
 public:
     ProcessNameFilter(const std::string& pname,
-                      std::unique_ptr<RecordProcessor<RecordType>> del)
+                      std::shared_ptr<RecordProcessor<RecordType>> del)
         : delegate(std::move(del)), target_process_name(pname), pass(false)
     {
     }
@@ -41,7 +41,7 @@ public:
     }
 
 private:
-    std::unique_ptr<RecordProcessor<RecordType>> delegate;
+    std::shared_ptr<RecordProcessor<RecordType>> delegate;
 
     std::string target_process_name;
     bool pass;

--- a/panda/plugins/coverage/README.md
+++ b/panda/plugins/coverage/README.md
@@ -42,7 +42,9 @@ the filter options can also improve performance because the options are used
 to determine whether or not a block should be instrumented. See the arguments
 section for a list of filter options.
 
-Regardless of mode used, the output CSV file contains metadata at the top of the header consisting of the PANDA build date and the execution time.  Note that the header is written out each time coverage collection is enabled.
+Regardless of mode used, the output CSV file contains metadata at the top of
+the header consisting of the PANDA build date and the execution time.  Note
+that the header is written out each time coverage collection is enabled.
 
 This plugin can be used with the included `coverage.py` script in IDAPython.
 `coverage.py` colorizes the dissasembly in IDA Pro using the CSV file produced
@@ -81,6 +83,13 @@ instrumentation time.
 <Start PC in Hex or Decimal>-<End PC in Hex or Decimal>.
 * `privilege` - Filter option, only instrument blocks executed with the
 specified privileges. Either: `user` or `kernel`.
+* `hook_filter` - Filter option that is controlled by two user provided hooks.
+When the instruction specified by Pass Hook is executed, the filter is disabled
+allowing records to be passed. The instruction specified by the Block Hook
+turns on the filter which stops records from being logged.  Note that this option
+implicitly filters coverage entries to those produced by the thread ID at the
+time the pass hook is executed and as such, requires OSI. Format:
+<Pass Hook Address>-<Block Hook Address>.
 
 Monitor Commands
 ------------

--- a/panda/plugins/coverage/UniqueFilter.h
+++ b/panda/plugins/coverage/UniqueFilter.h
@@ -22,8 +22,8 @@ public:
     /**
      * Constructs a new UniqueFilter and takes ownership of the delegate.
      */
-    UniqueFilter(std::unique_ptr<RecordProcessor<RecordType>> d)
-        : delegate(std::move(d))
+    UniqueFilter(std::shared_ptr<RecordProcessor<RecordType>> d)
+        : delegate(d)
     {
     }
 
@@ -48,7 +48,7 @@ public:
     }
 
 private:
-    std::unique_ptr<RecordProcessor<RecordType>> delegate;
+    std::shared_ptr<RecordProcessor<RecordType>> delegate;
     std::unordered_set<RecordType> seen;
 };
 


### PR DESCRIPTION
Adds the ability to filter coverage data based on user provided hooks. The user provided hooks are meant to turn the filter on or off. This is useful if you need to collect coverage data from a specific event in a program and can spend some cycles investigating the best place to hook.

This includes a small amount of refactoring to allow more than one instrumentation delegate object to be used.