### PR TITLE
Pypanda: Update FileFaker & IoctlFaker

### DIFF
--- a/panda/python/core/pandare/extras/file_faker.py
+++ b/panda/python/core/pandare/extras/file_faker.py
@@ -217,7 +217,7 @@ class FileFaker(FileHook):
             for name in names:
                 self._gen_fd_cb(name, arg_offset)
 
-    def replace_file(self, filename, faker, disk_file="etc/passwd"):
+    def replace_file(self, filename, faker, disk_file="/etc/passwd"):
         '''
         Replace all accesses to filename with accesses to the fake file instead
         which optionally may be specified by disk_file.

--- a/panda/python/core/pandare/extras/file_faker.py
+++ b/panda/python/core/pandare/extras/file_faker.py
@@ -55,7 +55,7 @@ class FakeFile:
         Return how much HyperFD offset should be incremented by
         XXX what about writes past end of the file?
         '''
-        self.logger.info("FakeFD({self.filename}) writing {new_data} at offset {self.offset}")
+        self.logger.info(f"FakeFD({self.filename}) writing {new_data} at offset {self.offset}")
         new_data  = self.contents[:offset]
         new_data += write_data
         new_data += self.contents[offset+len(new_data):]

--- a/panda/python/core/pandare/extras/file_faker.py
+++ b/panda/python/core/pandare/extras/file_faker.py
@@ -55,10 +55,11 @@ class FakeFile:
         Return how much HyperFD offset should be incremented by
         XXX what about writes past end of the file?
         '''
-        self.logger.info(f"FakeFD({self.filename}) writing {new_data} at offset {self.offset}")
         new_data  = self.contents[:offset]
         new_data += write_data
         new_data += self.contents[offset+len(new_data):]
+        
+        self.logger.info(f"FakeFD({self.filename}) writing {new_data} at offset {offset}")
 
         self.contents = new_data
         return len(write_data)
@@ -216,15 +217,16 @@ class FileFaker(FileHook):
             for name in names:
                 self._gen_fd_cb(name, arg_offset)
 
-    def replace_file(self, filename, faker):
+    def replace_file(self, filename, faker, disk_file="etc/passwd"):
         '''
         Replace all accesses to filename with accesses to the fake file instead
+        which optionally may be specified by disk_file.
         '''
         self.faked_files[filename] = faker
 
         # XXX: We rename the files to real files to the guest kernel can manage FDs for us.
         #      this may need to use different real files depending on permissions requested
-        self.rename_file(filename, "/etc/passwd")
+        self.rename_file(filename, disk_file)
 
     def _gen_fd_cb(self, name, fd_offset):
         '''

--- a/panda/python/core/pandare/extras/ioctl_faker.py
+++ b/panda/python/core/pandare/extras/ioctl_faker.py
@@ -72,7 +72,8 @@ class Ioctl():
                 self.guest_ptr = guest_ptr
                 self.guest_buf = panda.virtual_memory_read(cpu, self.guest_ptr, self.cmd.bits.arg_size)
             except ValueError:
-                raise RuntimeError("Failed to read guest buffer: ioctl({})".format(str(self.cmd)))
+                self.guest_buf = None
+                #raise RuntimeError("Failed to read guest buffer: ioctl({})".format(str(self.cmd)))
         else:
             self.has_buf = False
             self.guest_ptr = None
@@ -83,8 +84,8 @@ class Ioctl():
             proc = panda.plugins['osi'].get_current_process(cpu)
             proc_name_ptr = proc.name
             file_name_ptr = panda.plugins['osi_linux'].osi_linux_fd_to_filename(cpu, proc, panda.ffi.cast("int", fd))
-            self.proc_name = ffi.string(proc_name_ptr).decode() if proc_name_ptr != ffi.NULL else "unknown"
-            self.file_name = ffi.string(file_name_ptr).decode() if file_name_ptr != ffi.NULL else "unknown"
+            self.proc_name = ffi.string(proc_name_ptr).decode(errors="ignore") if proc_name_ptr != ffi.NULL else "unknown"
+            self.file_name = ffi.string(file_name_ptr).decode(errors="ignore") if file_name_ptr != ffi.NULL else "unknown"
         else:
             self.proc_name = None
             self.file_name = None

--- a/panda/python/tests/file_fake.py
+++ b/panda/python/tests/file_fake.py
@@ -13,11 +13,20 @@ fake_str = "Hello world. This is data generated from python!"
 faker = FileFaker(panda)
 faker.replace_file("/foo", FakeFile(fake_str))
 
+new_str = "This is some new data"
+
 @blocking
 def read_it():
+    global new_str
+
     panda.revert_sync('root')
     data = panda.run_serial_cmd("cat /foo")
     assert(fake_str in data), f"Failed to read fake file /foo: {data}"
+
+    panda.run_serial_cmd(f'echo {new_str} > /foo')
+    data = panda.run_serial_cmd("cat /foo")
+    assert(new_str in data), f"Failed to update fake file /foo: {data}. Expected: {new_str}"
+
     panda.end_analysis()
 
 panda.queue_async(read_it)


### PR DESCRIPTION
This PR is to fix and add the following items:
- Ignore string decode errors in IoctlFaker to prevent crashing during run
- Set the buffer to None instead of an exception if the IoctlFaker is unable to read a memory region
- Allow the user to specify a custom file on disk for `replace_file` instead of being hard coded to `/etc/passwd`
- Move the log statement down for `file_faker.write` since it requires `new_data`.  Removed the `self.` for `offset` since it is a local variable, not a class variable.
- Update `file_fake` test to include a test for writing data to the faked file in the emulated OS.