### PR TITLE
Allow overwriting of already existing plugin args

### DIFF
--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -146,7 +146,7 @@ const char *panda_parse_string_opt(panda_arg_list *args, const char *argname, co
 
 char** str_split(char *a_str, const char a_delim);
 
-extern const gchar *panda_argv[MAX_PANDA_PLUGIN_ARGS];
+extern gchar *panda_argv[MAX_PANDA_PLUGIN_ARGS];
 extern int panda_argc;
 
 char *panda_plugin_path(const char *name);

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -49,7 +49,7 @@ WARNING: This is all gloriously thread-unsafe!!!
 panda_cb_list *panda_cbs[PANDA_CB_LAST];
 
 // Storage for command line options
-const gchar *panda_argv[MAX_PANDA_PLUGIN_ARGS];
+gchar *panda_argv[MAX_PANDA_PLUGIN_ARGS];
 int panda_argc;
 
 int nb_panda_plugins = 0;
@@ -76,8 +76,22 @@ bool panda_exit_loop = false;
 bool panda_add_arg(const char *plugin_name, const char *plugin_arg) {
     if (plugin_name == NULL)    // PANDA argument
         panda_argv[panda_argc++] = g_strdup(plugin_arg);
-    else                        // PANDA plugin argument
+    else {                       // PANDA plugin argument
+        /*  Check if plugin argument is already present and overwrite, if so */
+        for (int i = 0; i < panda_argc; i++) {
+            if (0 == strncmp(panda_argv[i], plugin_name, strlen(plugin_name))){
+                char * p;
+                p = strchr(plugin_arg, '=');
+                if (0 != p && 0 == strncmp(panda_argv[i]+strlen(plugin_name)+1, plugin_arg, p - plugin_arg)) {
+                    g_free(panda_argv[i]);
+                    panda_argv[i] = g_strdup_printf("%s:%s", plugin_name, plugin_arg);
+                    return true;
+                }
+            }
+        }
+        /* We see this argument for the first time, let's add it */
         panda_argv[panda_argc++] = g_strdup_printf("%s:%s", plugin_name, plugin_arg);
+    }
     return true;
 }
 


### PR DESCRIPTION
Currently, a plugin can be unloaded and loaded again later. This commit
ensures that in these cases, panda_argv only holds the most recent
arguments passed during the latest load of the plugin.

Note: This is not equal to removing all previously passed arguments.
Hence, when optional arguments are not overwritten, they will still hold
the values passed during the prior load of the plugins.

So, while this is far from ideal, it's at least an improvement and okay for my usecase.
A cleaner solution would be to clean-up the arguments for a plugin during `do_unload_plugin`, but this would require pointers to be moved around in the panda_argv array, which I wanted to avoid.