### PR TITLE
Makefile: fix length calculation with recent 'make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -626,12 +626,17 @@ endif
 endif
 
 ifneq ($(CONFIG_LINUX),)
+
+# This hack is needed with `make` >=4.3
+# More details can be found in the changelog: https://lwn.net/Articles/810071/
+number_sign := \#
+
 # The install target won't succeed if the RPATH in the .so files is longer than
 # the value need to change it to for installation purposes.  It does not matter
 # which architecture is used for the comparison - it shows up once in both the
 # new and old RPATHs, so the differences cancel out.
 # Calculate length of new RPATH.
-newrplen=$(shell newrp="$(panda_plugindir)/$(ARCH)" ; eval echo $${\#newrp})
+newrplen=$(shell newrp="$(panda_plugindir)/$(ARCH)" ; eval echo $${$(number_sign)newrp})
 # Fetch current RPATH from an .so file - doesn't matter which plugin/arch it is for.
 archdir=$(lastword $(TARGET_DIRS))
 ifeq ($(archdir),)
@@ -643,7 +648,7 @@ cpout=$(shell chrpath -l "$(pathtoso)")
 # The old RPATH will include a "RPATH=" prefix - the size calculation will
 # adjust for that later.
 rppart=$(lastword $(cpout))
-newtoobig=$(shell oldrp="$(rppart)" ; oldrplen=`expr $${\#oldrp} - 6` ; if [ $$oldrplen -lt $(newrplen) ] ; then echo true ; else echo false ; fi)
+newtoobig=$(shell oldrp="$(rppart)" ; oldrplen=`expr $${$(number_sign)oldrp} - 6` ; if [ $$oldrplen -lt $(newrplen) ] ; then echo true ; else echo false ; fi)
 endif
 
 install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir


### PR DESCRIPTION
'make' >= 4.3 has a breaking change in the way it escapes the '#' character. A hack is needed to make it work with
multiple versions of 'make'.
More details can be found in the 'make' changelog (https://lwn.net/Articles/810071/).

This already affects Debian testing and the latest Ubuntu at least.