### PR TITLE
get rid of heptapod zip requirement

### DIFF
--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -497,12 +497,7 @@ PandaCB.__doc__ = '''custom named tuple to handle callbacks. Each element is a c
         ]
 
         for arch in arches:
-            try:
-                compile(arch[0], arch[1], pypanda_headers, install, INCLUDE_DIR_PYP)
-            except Exception as e:
-                print("You need a newer version of cffi to run pypanda. Install from source with \
-                    pip3 install https://foss.heptapod.net/pypy/cffi/-/archive/branch/default/cffi-branch-default.tar.gz")
-                raise e
+            compile(arch[0], arch[1], pypanda_headers, install, INCLUDE_DIR_PYP)
 
 if __name__ == '__main__':
     main()

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -87,7 +87,7 @@ else
 fi
 
 # PyPanda dependencies
-python3 -m pip install pycparser "protobuf==3.0.0" "https://foss.heptapod.net/pypy/cffi/-/archive/branch/default/cffi-branch-default.zip" colorama
+python3 -m pip install pycparser "protobuf==3.0.0" cffi colorama
 
 progress "Trying to update DTC submodule"
 git submodule update --init dtc || true

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -87,7 +87,7 @@ else
 fi
 
 # PyPanda dependencies
-python3 -m pip install pycparser "protobuf==3.0.0" cffi colorama
+python3 -m pip install pycparser "protobuf==3.0.0" "cffi>=1.14.3" colorama
 
 progress "Trying to update DTC submodule"
 git submodule update --init dtc || true


### PR DESCRIPTION
At one point we had a dependency on a *very* new version of cffi. That version of cffi is now in pip so we don't so we're getting rid of that requirement.