### PR TITLE
Bugfixs in panda expect

### DIFF
--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -145,7 +145,7 @@ class Panda():
         if self.expect_prompt:
             self.serial_file = NamedTemporaryFile(prefix="pypanda_s").name
             self.serial_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.serial_console = Expect('serial', expectation=self.expect_prompt, quiet=True, consume_first=False)
+            self.serial_console = Expect('serial', expectation=self.expect_prompt, consume_first=False)
             self.panda_args.extend(['-serial', 'unix:{},server,nowait'.format(self.serial_file)])
         else:
             self.serial_file = None
@@ -158,7 +158,7 @@ class Panda():
         self.raw_monitor = raw_monitor
         if not self.raw_monitor:
             # XXX don't forget to escape expectation regex parens!
-            self.monitor_console = Expect('monitor', expectation=rb"\(qemu\) ", quiet=True, consume_first=True)
+            self.monitor_console = Expect('monitor', expectation=rb"\(qemu\) ", consume_first=True)
             self.panda_args.extend(['-monitor', 'unix:{},server,nowait'.format(self.monitor_file)])
 
         self.running = threading.Event()

--- a/panda/python/core/pandare/panda_expect.py
+++ b/panda/python/core/pandare/panda_expect.py
@@ -310,8 +310,12 @@ class Expect(object):
                 elif typ == 'u':
                     (cur_line, line_pos) = store_ptr
 
+                elif typ == 'm':
+                    # alter character attributes - just ignore
+                    pass
+
                 else:
-                    raise ValueError(f"Unsupporte ANSI command {typ}")
+                    raise ValueError(f"Unsupported ANSI command {typ}")
             #_dump(lines_out, cur_line, line_pos)
 
         # Done processing - update variables

--- a/panda/python/core/pandare/panda_expect.py
+++ b/panda/python/core/pandare/panda_expect.py
@@ -415,8 +415,8 @@ class Expect(object):
         if not self.quiet:
             sys.stdout.flush()
 
-        self.current_line = current_line.decode('utf8')
-        raise TimeoutExpired(f"{self.name} Read message \n{self.current_line}\n")
+        full_buffer = self.prior_lines + [self.current_line]
+        raise TimeoutExpired(f"{self.name} Read message \n{full_buffer}\n")
 
     def send(self, msg):
         if not self.quiet:


### PR DESCRIPTION
- Fix a dumb bug from #917 in the timeout exception code (was using an undefined variable)
- Fix bug from #917 where the expect_prompt wouldn't be identified if `consume_partial()` was called just before the expect prompt was printed.
- ignore `Esc[m` family of ansi escape codes