### PR TITLE
remove pyperipheral3 by default

### DIFF
--- a/configure
+++ b/configure
@@ -415,7 +415,7 @@ jemalloc="no"
 replication="yes"
 #AVATAR
 pyperipheral2="no"
-pyperipheral3="yes"
+pyperipheral3="no"
 
 
 supported_cpu="no"


### PR DESCRIPTION
Removes pyperipheral3 enabled by default.

CLOSES #893 