### PR TITLE
Bugfixes related to snapshot reverts in the middle of analyses

### DIFF
--- a/panda/plugins/osi_linux/default_profile.cpp
+++ b/panda/plugins/osi_linux/default_profile.cpp
@@ -59,7 +59,11 @@ target_ptr_t default_get_current_task_struct(CPUState *cpu)
     current_task_addr = ki.task.current_task_addr;
 #endif
     err = struct_get(cpu, &ts, current_task_addr, ki.task.per_cpu_offset_0_addr);
-    assert(err == struct_get_ret_t::SUCCESS && "failed to get current task struct");
+    //assert(err == struct_get_ret_t::SUCCESS && "failed to get current task struct");
+    if (err != struct_get_ret_t::SUCCESS) {
+      // Callers need to check if we return NULL!
+      return 0;
+    }
     fixupendian(ts);
     return ts;
 }

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -644,7 +644,10 @@ class Panda():
         # First unload python plugins, should be safe to do anytime
         #for name in self.registered_callbacks.keys():
         while len(list(self.registered_callbacks)) > 0:
-            self.delete_callback(list(self.registered_callbacks.keys())[0])
+            try:
+                self.delete_callback(list(self.registered_callbacks.keys())[0])
+            except IndexError:
+                continue
             #self.disable_callback(name)
 
         # Then unload C plugins. May be unsafe to do except from the top of the main loop (taint segfaults otherwise)

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -74,7 +74,7 @@ MAKE_CALLBACK(bool, INSN_TRANSLATE, insn_translate,
 MAKE_CALLBACK(bool, AFTER_INSN_TRANSLATE, after_insn_translate,
                     CPUState*, env, target_ptr_t, pc)
 
-// Custom CB
+// Helper - get a physical address
 static inline hwaddr get_paddr(CPUState *cpu, target_ptr_t addr, void *ram_ptr) {
     if (!ram_ptr) {
         return panda_virt_to_phys(cpu, addr);
@@ -85,8 +85,11 @@ static inline hwaddr get_paddr(CPUState *cpu, target_ptr_t addr, void *ram_ptr) 
     if (!block) {
         return panda_virt_to_phys(cpu, addr);
     } else {
-        assert(block->mr);
-        return block->mr->addr + offset;
+        if (block->mr) {
+          return block->mr->addr + offset;
+        } else {
+          return -1;
+        }
     }
 }
 
@@ -261,6 +264,7 @@ void PCB(mem_before_read)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     }
     if (panda_cbs[PANDA_CB_PHYS_MEM_BEFORE_READ]) {
         hwaddr paddr = get_paddr(env, addr, ram_ptr);
+        if (paddr == -1) return;
         for(plist = panda_cbs[PANDA_CB_PHYS_MEM_BEFORE_READ]; plist != NULL;
             plist = panda_cb_list_next(plist)) {
             if (plist->enabled) plist->entry.phys_mem_before_read(env, env->panda_guest_pc,
@@ -281,6 +285,7 @@ void PCB(mem_after_read)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     }
     if (panda_cbs[PANDA_CB_PHYS_MEM_AFTER_READ]) {
         hwaddr paddr = get_paddr(env, addr, ram_ptr);
+        if (paddr == -1) return;
         for(plist = panda_cbs[PANDA_CB_PHYS_MEM_AFTER_READ]; plist != NULL;
             plist = panda_cb_list_next(plist)) {
             /* mstamat: Passing &result as the last cb arg doesn't make much sense. */
@@ -302,6 +307,7 @@ void PCB(mem_before_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     }
     if (panda_cbs[PANDA_CB_PHYS_MEM_BEFORE_WRITE]) {
         hwaddr paddr = get_paddr(env, addr, ram_ptr);
+        if (paddr == -1) return;
         for(plist = panda_cbs[PANDA_CB_PHYS_MEM_BEFORE_WRITE]; plist != NULL;
             plist = panda_cb_list_next(plist)) {
             /* mstamat: Passing &val as the last cb arg doesn't make much sense. */
@@ -323,6 +329,7 @@ void PCB(mem_after_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     }
     if (panda_cbs[PANDA_CB_PHYS_MEM_AFTER_WRITE]) {
         hwaddr paddr = get_paddr(env, addr, ram_ptr);
+        if (paddr == -1) return;
         for (plist = panda_cbs[PANDA_CB_PHYS_MEM_AFTER_WRITE]; plist != NULL;
              plist = panda_cb_list_next(plist)) {
             /* mstamat: Passing &val as the last cb arg doesn't make much sense. */

--- a/panda/src/rr/README.md
+++ b/panda/src/rr/README.md
@@ -1,0 +1,65 @@
+Record Replay
+===
+
+This documentation was created while debugging RR for arm virt machine, not by the original RR devlopers. It's better than nothing but not great.
+
+
+## Reading your XYZ-rr-nondet.log files
+In build directory under architecture - `rr_print_[arch] [infile]`
+dumps data like:
+
+```
+opened ./dd-rr-nondet.log for read.  len=288558 bytes.
+RR Log with 136917553 instructions
+{guest_instr_count=0}
+        RR_INTERRUPT_REQUEST_2 from RR_CALLSITE_CPU_HANDLE_INTERRUPT_BEFORE
+{guest_instr_count=2}
+        RR_INTERRUPT_REQUEST_6 from RR_CALLSITE_CPU_HANDLE_INTERRUPT_AFTER
+{guest_instr_count=3}
+        RR_INTERRUPT_REQUEST_2 from RR_CALLSITE_CPU_HANDLE_INTERRUPT_BEFORE
+{guest_instr_count=57}
+        RR_INPUT_8 27 from RR_CALLSITE_IO_READ_ALL
+{guest_instr_count=61}
+        RR_INTERRUPT_REQUEST_0 from RR_CALLSITE_CPU_HANDLE_INTERRUPT_BEFORE
+{guest_instr_count=7730}
+        RR_INPUT_8 1023 from RR_CALLSITE_IO_READ_ALL
+{guest_instr_count=19796}
+        RR_INTERRUPT_REQUEST_2 from RR_CALLSITE_CPU_HANDLE_INTERRUPT_BEFORE
+```
+
+
+## Skipped calls
+`rr_record_skipped_call` - special case for when guest needs to be explicitly modified. E.g., `rr_record_hd_transfer` which records data transfered to/from hd.
+
+
+## diverge.py
+*Incredible* python script to use mozilla RR + PANDA to root cause a divergence between record and replay. Not perfect for non x86.
+
+The script auto calculates the ram base pointer by using an physical pointer to RAM to find the memory region. This varies per arch/machine so you might need to reconfigure it (you'll get an assertion if so).
+Once you get the base ram pointer (you'll see it in a bunch of the calculations) you can use that to read guest RAM as follows:
+
+### Read guest memory from debugger.
+Short version: Guest virt addr -> guest physaddr -> host virtaddr -> gdb read with `x`
+
+First convert the guest virtual address (ZZZ) to a physical one:
+```
+panda_virt_to_phys(current_cpu, ZZZ)
+```
+
+Then identify the memory region containing that address and get a HOST pointer to it:
+
+```
+p memory_region_find(get_system_memory(), GUEST_PHYS_ADDR, 0).mr->name
+p/x memory_region_find(get_system_memory(), GUEST_PHYS_ADDR, 0).mr->ram_block.host
+```
+
+Then find the offset from that host pointer to your memory
+```
+p/x memory_region_find(get_system_memory(), GUEST_PHYS_ADDR, 0).offset_within_region
+```
+
+Finally, read host memory at the (memory region + the offset to the address) and that will give you guest memory.
+
+```
+p/10x [ram_block.host] + [offset_within_region]
+```


### PR DESCRIPTION
Ran into a few issues doing snapshot reverts to pre-kernel init which are fixed by this PR.
1. OSI_linux needs to re-initialize after the guest is reverted (instead of assuming it already is initialized)
2. Fix a possible race condition in pypanda plugin unload
3.  Fix the get_paddr helper in cb-support to avoid an assert when the memory_read/write family of callbacks get a ram block but it doesn't have a memory region setup (could happen during machine init). Now the callbacks simply don't run in this rare/early-init case instead of raising an assertion.