### PR TITLE
loaded_libs minor bugfix

### DIFF
--- a/panda/plugins/loaded_libs/loaded_libs.cpp
+++ b/panda/plugins/loaded_libs/loaded_libs.cpp
@@ -1,5 +1,6 @@
 #define __STDC_FORMAT_MACROS
 
+#include <stdlib.h>
 #include <cstdio>
 
 #include "panda/plugin.h"
@@ -11,54 +12,51 @@ extern "C" {
 
 #include "osi/osi_types.h"
 #include "osi/osi_ext.h"
-} 
+}
 
 #include "asidstory/asidstory.h"
 
 #include<map>
-#include<vector> 
+#include<vector>
 #include<set>
 #include<iostream>
-using namespace std; 
+using namespace std;
 
 typedef target_ulong Asid;
-map<Asid, vector<vector<OsiModule>>> asid_module_list; 
+map<Asid, vector<vector<OsiModule>>> asid_module_list;
 
 //bool asid_changed(CPUState *cpu, target_ulong old_pgd, target_ulong new_pgd);
 
-const char* program_name; 
-
-
+const char* program_name;
 
 void get_libs(CPUState *env) {
-    OsiProc *current =  get_current_process(env); 
-    target_ulong asid = panda_current_asid(env); 
+    OsiProc *current =  get_current_process(env);
+    target_ulong asid = panda_current_asid(env);
 
     if (current != NULL) {
-        GArray *ms = get_mappings(env, current); 
+        GArray *ms = get_mappings(env, current);
 
         //if (current) printf("current->name: %s  asid: " TARGET_FMT_lx "\n", current->name, asid);
-        if (program_name != NULL && strcmp(current->name, program_name) != 0) return; 
-        if (ms == NULL) return; 
+        if (program_name != NULL && strcmp(current->name, program_name) != 0) return;
+        if (ms == NULL) return;
 
         vector<OsiModule> module_list;
-        for (int i = 0; i < ms->len; i++) { 
-            OsiModule *m = &g_array_index(ms, OsiModule, i); 
-            OsiModule mm; 
+        for (int i = 0; i < ms->len; i++) {
+            OsiModule *m = &g_array_index(ms, OsiModule, i);
+            OsiModule mm;
             mm.modd = m->modd;
             mm.base = m->base;
-            mm.size = m->size; 
-            if (m->file) mm.file = strdup(m->file); 
-            else mm.file = strdup("Unknown_file"); 
-            if (m->name) mm.name = strdup(m->name); 
+            mm.size = m->size;
+            if (m->file) mm.file = strdup(m->file);
+            else mm.file = strdup("Unknown_file");
+            if (m->name) mm.name = strdup(m->name);
             else mm.name = strdup("Unknown_name");
-            module_list.push_back(mm); 
+            module_list.push_back(mm);
         }
-        asid_module_list[asid].push_back(module_list); 
+        asid_module_list[asid].push_back(module_list);
     }
 
 }
-
 
 void asidstory_proc_changed(CPUState *env, target_ulong asid, OsiProc *proc) {
     get_libs(env);
@@ -69,15 +67,17 @@ bool asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
     return false; // allow OS to change ASID
 }
 
+// Sample about 2% of BBs, or at least 1 BB
 void before_block(CPUState *env, TranslationBlock *tb) {
-    // check up on module list ever 50 bb
-    if (((float)(random())) / RAND_MAX < 0.02) 
-        get_libs(env);
+    static bool no_sample = true;
+    if (no_sample || (((float)(rand())) / RAND_MAX < 0.02)) {
+       get_libs(env);
+       no_sample = false;
+    }
 }
 
-
 bool init_plugin(void *self) {
-    panda_require("osi"); 
+    panda_require("osi");
     assert(init_osi_api());
     panda_require("asidstory");
 
@@ -86,67 +86,71 @@ bool init_plugin(void *self) {
     panda_register_callback(self, PANDA_CB_ASID_CHANGED, pcb);
 
     // we'll let asidstory tell us when the process changes
-    // which should catch execv as well 
+    // which should catch execv as well
     PPP_REG_CB("asidstory", on_proc_change, asidstory_proc_changed);
-    
+
     pcb.before_block_exec = before_block;
     panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
-    
-    panda_arg_list *args; 
-    args = panda_get_args("loaded_libs"); 
-    program_name = panda_parse_string_opt(args, "program_name", NULL, "program name to collect libraries for"); 
+
+    panda_arg_list *args;
+    args = panda_get_args("loaded_libs");
+    program_name = panda_parse_string_opt(args, "program_name", NULL, "program name to collect libraries for");
+
+    // Seed for deterministic sampling with rand()
+    srand(0xDEADC0DE);
+
     return true;
 }
 
-void uninit_plugin(void *self) { 
-    //size_t nm = asid_module_list.size(); 
-    if (!pandalog) return; 
+void uninit_plugin(void *self) {
+    //size_t nm = asid_module_list.size();
+    if (!pandalog) return;
 
     cout << "asid_module_list is " << asid_module_list.size() << " items\n";
 
-    for (auto kvp : asid_module_list) { 
+    for (auto kvp : asid_module_list) {
         auto asid = kvp.first;
         auto all_module_list = kvp.second; // vector<vector<OsiModule>>
         cout << "asid=" << hex << asid << " has " << dec << all_module_list.size() << "modules\n";
-        int max_size = 0; 
+        int max_size = 0;
         int i, idx;
-        i = idx = 0; 
-        // We're going to choose the one with the most amount of loaded modules 
-        for (auto module_list : all_module_list) { 
-            if (module_list.size() > max_size) { 
+        i = idx = 0;
+        // We're going to choose the one with the most amount of loaded modules
+        for (auto module_list : all_module_list) {
+            if (module_list.size() > max_size) {
                 max_size = module_list.size();
-                idx = i; 
+                idx = i;
             }
             i++;
         }
 
-        Panda__LoadedLibs * ll = (Panda__LoadedLibs *) malloc (sizeof (Panda__LoadedLibs)); 
-        *ll = PANDA__LOADED_LIBS__INIT; 
+        Panda__LoadedLibs * ll = (Panda__LoadedLibs *) malloc (sizeof (Panda__LoadedLibs));
+        *ll = PANDA__LOADED_LIBS__INIT;
 
-        Panda__Module** m = (Panda__Module **) malloc (sizeof (Panda__Module *) * max_size);  
-        i = 0; 
+        Panda__Module** m = (Panda__Module **) malloc (sizeof (Panda__Module *) * max_size);
+        i = 0;
         for (auto module : all_module_list[idx]) {
-            m[i] = (Panda__Module *) malloc (sizeof (Panda__Module)); 
-            *(m[i]) = PANDA__MODULE__INIT; 
-            m[i]->name = module.name; 
+            m[i] = (Panda__Module *) malloc (sizeof (Panda__Module));
+            *(m[i]) = PANDA__MODULE__INIT;
+            m[i]->name = module.name;
             m[i]->file = module.file;
-            m[i]->base_addr = module.base; 
-            m[i]->size = module.size; 
+            m[i]->base_addr = module.base;
+            m[i]->size = module.size;
             i++;
         }
-        ll->modules = m;  
-        ll->n_modules = max_size;   
-        Panda__LogEntry ple = PANDA__LOG_ENTRY__INIT; 
+        ll->modules = m;
+        ll->n_modules = max_size;
+        Panda__LogEntry ple = PANDA__LOG_ENTRY__INIT;
         ple.has_asid = 1;
         ple.asid = asid;
-        ple.asid_libraries =  ll; 
-        pandalog_write_entry(&ple); 
+        ple.asid_libraries =  ll;
+        pandalog_write_entry(&ple);
 
         // Free things!
-        for (int i = 0; i < max_size; i++) 
-            free(m[i]); 
+        for (int i = 0; i < max_size; i++)
+            free(m[i]);
         free(m);
-        free(ll); 
+        free(ll);
 
     }
 }

--- a/panda/plugins/loaded_libs/loaded_libs.cpp
+++ b/panda/plugins/loaded_libs/loaded_libs.cpp
@@ -1,6 +1,5 @@
 #define __STDC_FORMAT_MACROS
 
-#include <stdlib.h>
 #include <cstdio>
 
 #include "panda/plugin.h"
@@ -70,7 +69,7 @@ bool asid_changed(CPUState *env, target_ulong old_asid, target_ulong new_asid) {
 // Sample about 2% of BBs, or at least 1 BB
 void before_block(CPUState *env, TranslationBlock *tb) {
     static bool no_sample = true;
-    if (no_sample || (((float)(rand())) / RAND_MAX < 0.02)) {
+    if (no_sample || (((float)(random())) / RAND_MAX < 0.02)) {
        get_libs(env);
        no_sample = false;
     }
@@ -97,7 +96,7 @@ bool init_plugin(void *self) {
     program_name = panda_parse_string_opt(args, "program_name", NULL, "program name to collect libraries for");
 
     // Seed for deterministic sampling with rand()
-    srand(0xDEADC0DE);
+    srandom(0xDEADC0DE);
 
     return true;
 }


### PR DESCRIPTION
Sorry my editor config removes trailing spaces - good for file size but bad for diff readability. 

Minor bugfix in `loaded_libs` - force at least one sample.

Edit:

Regarding sampling determinism across replays - thought there was a bug when `random()` is not explicitly seeded, but [per the man page](https://man7.org/linux/man-pages/man3/random.3.html) it gets seeded with `1` automatically. So the explicit `srandom()` call in `init_plugin()` isn't actually necessary - but might be clearer.