### PR TITLE
Add kernel code check API

### DIFF
--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -324,17 +324,19 @@ static inline bool panda_in_kernel(const CPUState *cpu) {
  * @brief Determines if guest is currently executing kernelspace code, regardless of privilege level.
  * Necessary because there's a small bit of kernelspace code that runs AFTER a switch to usermode privileges.
  * Therefore, certain analysis logic can't rely on panda_in_kernel_mode() alone.
+ * Checking the userspace cutoff means this should work even if KASLR is enabled.
  */
 static inline bool panda_in_kernel_code_linux(CPUState *cpu) {
     target_ulong curr_pc = panda_current_pc(cpu);
 #if (TARGET_LONG_BITS == 32)
     // https://www.kernel.org/doc/html/latest/vm/highmem.html
     // Source link i386, but not arch specific
-    return (curr_pc >= 0xc0000000);
+    return (curr_pc > 0xc0000000);
 #elif (TARGET_LONG_BITS == 64)
     // https://github.com/torvalds/linux/blob/master/Documentation/x86/x86_64/mm.rst
     // Source link x86_64, but not arch specific
-    return (curr_pc >= 0x00007fffffffffff);
+    // Below cut-off will work for both 4 and 5 level page tables, we don't have to know which the guest uses!
+    return (curr_pc > 0x00ffffffffffffff);
 #else
 #error "panda_in_kernel_code() not implemented for target bit width."
     return false;


### PR DESCRIPTION
`panda_in_kernel()` checks current CPU mode, but there's a small bit of kernelspace code that runs after a switch to usermode privileges - so callbacks like `BEFORE_BLOCK_EXEC` can't rely on that API alone to filter userspace vs. kernelspace.

- Adds an alias for `panda_in_kernel`: `panda_in_kernel_mode`. This reflects what the function actually does, but keeping the old signature for backwards compatibility.
- Add API `panda_in_kernel_code_linux`, which checks for a kernelspace program counter - regardless of mode.

So callbacks that aren't interested in kernelspace can do:

```c
if (panda_in_kernel_mode(cpu) || panda_in_kernel_code_linux(cpu)) {
    return;
}
```