### PR TITLE
Bugfix: don't always print pypanda missing end_analysis warning

### DIFF
--- a/panda/python/core/pandare/asyncthread.py
+++ b/panda/python/core/pandare/asyncthread.py
@@ -8,7 +8,7 @@ import functools
 from queue import Queue, Empty
 from time import sleep, time
 from colorama import Fore, Style
-from .utils import debug, warn
+from pandare.utils import debug, warn
 
 
 def progress(msg):
@@ -26,7 +26,7 @@ class AsyncThread:
 
         # Thread in which users can queue fns
         self.task_queue = Queue()
-        self.athread = threading.Thread(target=self.run, args=(self.task_queue,))
+        self.athread = threading.Thread(target=self.run, args=(self.task_queue, False))
         self.athread.daemon = True # Quit on main quit
         self.warned = False # Did we print a warning about empty queue?
         self.ending = False # Is main PANDA execution ending?
@@ -39,7 +39,7 @@ class AsyncThread:
         # Unfortunately we haven't found a cleaner way to just terminate whatever
         # function is running and then add internal tasks to the main queue
         self._task_queue = Queue()
-        self._athread = threading.Thread(target=self.run, args=(self._task_queue,))
+        self._athread = threading.Thread(target=self.run, args=(self._task_queue, True))
         self._athread.daemon = True # Quit on main quit
         self._athread.start()
 
@@ -57,21 +57,23 @@ class AsyncThread:
         else:
             self.task_queue.put_nowait(func)
 
-    def run(self, task_queue): # Run functions from queue
+    def run(self, task_queue, internal=False): # Run functions from queue
         #name = threading.get_ident()
         while self.running: # Note setting this to false will take some time
             try: # Try to get an item repeatedly, but also check if we want to stop running
                 func = task_queue.get(True, 1) # Implicit (blocking) wait for 1s
-                self.empty_at = None
+                if not internal:
+                    self.empty_at = None
                 self.last_called = func.__name__.replace(" (with async thread)", "")
             except Empty:
                 # If we've been empty for 5s without shutdown, warn (just once)
-                if self.empty_at is None:
-                    self.empty_at = time()
-                else:
-                    if time() - self.empty_at > 5 and not self.warned and not self.ending:
-                        warn(f"PANDA finished all the queued functions but emulation was left running. You may have forgotten to call to panda.end_analysis() in the last queued function '{self.last_called}'")
-                        self.warned = True
+                if not internal:
+                    if self.empty_at is None:
+                        self.empty_at = time()
+                    else:
+                        if time() - self.empty_at > 5 and not self.warned and not self.ending:
+                            warn(f"PANDA finished all the queued functions but emulation was left running. You may have forgotten to call to panda.end_analysis() in the last queued function '{self.last_called}'")
+                            self.warned = True
                 continue
 
             # Don't interact with guest if it isn't running
@@ -152,6 +154,27 @@ def test2():
 
     # Expected output: Main hanging, internal running
 
+def test3():
+    # Second test: hang in the main queue and exit in the internal
+    from time import sleep
+    import sys
+    started = threading.Event()
+
+    b = AsyncThread(started)
+    def slow_func():
+        print("Main slow_func sleeping")
+        sleep(10)
+        print("Main done")
+    hang_func.__blocking__ = "placeholder" # Hack to pretend it's decorated
+
+    b.queue(hang_func)
+
+    # Make sure we have time to run both fns
+    started.set()
+    sleep(10)
+    # Expected output: slow_func runs for 10s and no warning is printed
+
 if __name__ == '__main__':
     #test1()
     test2() # Exits on finish
+    #test3() # Exits on finish


### PR DESCRIPTION
#908 added a warning when PyPANDA's async thread had no tasks to run. However, that class has two task queues - one for user requested functions and one for internal functions. The prior PR failed to distinguish between these leading to warnings being printed whenever a function took more than 10s to execute.

This fixes the bug by only warning if the user task queue is empty instead of either queue.