### PR TITLE
proc_start_linux: expose pointers to arguments and environment variables

### DIFF
--- a/panda/plugins/proc_start_linux/proc_start_linux.cpp
+++ b/panda/plugins/proc_start_linux/proc_start_linux.cpp
@@ -88,6 +88,7 @@ void btc_execve(CPUState *env, TranslationBlock *tb){
                 if (ptr == 0){
                     break;
                 }else if (argc_num < MAX_NUM_ARGS){
+                    vals.arg_ptr[argc_num] = ptr;
                     string arg = read_str(env, ptr);
                     if (arg.length() > 0){
                         strncpy(vals.argv[argc_num], arg.c_str(), MAX_PATH_LEN);
@@ -110,6 +111,7 @@ void btc_execve(CPUState *env, TranslationBlock *tb){
                 if (ptr == 0){
                     break;
                 }else if (envc_num < MAX_NUM_ENV){
+                    vals.env_ptr[envc_num] = ptr;
                     string arg = read_str(env, ptr);
                     if (arg.length() > 0){
                         strncpy(vals.envp[envc_num], arg.c_str(), MAX_PATH_LEN);

--- a/panda/plugins/proc_start_linux/proc_start_linux.h
+++ b/panda/plugins/proc_start_linux/proc_start_linux.h
@@ -13,8 +13,10 @@
 // https://lwn.net/Articles/519085/
 struct auxv_values {
     int argc;
+    target_ulong arg_ptr[MAX_NUM_ARGS];
     char argv[MAX_NUM_ARGS][MAX_PATH_LEN];
     int envc;
+    target_ulong env_ptr[MAX_NUM_ARGS];
     char envp[MAX_NUM_ENV][MAX_PATH_LEN];
     char execfn[MAX_PATH_LEN];
     target_ulong phdr;


### PR DESCRIPTION
This small change will make it such that no one else has to parse the stack to find the argument pointers.