### PR TITLE
hooks: drop procname for symbol hooks; add offset into library

### DIFF
--- a/panda/plugins/dynamic_symbols/dynamic_symbols.cpp
+++ b/panda/plugins/dynamic_symbols/dynamic_symbols.cpp
@@ -158,7 +158,7 @@ void new_assignment_check_symbols(CPUState* cpu, unordered_map<string, struct sy
                             struct symbol s;
                             memset(&s, 0, sizeof(struct symbol));
                             s.address = m->base + hook_candidate.offset;
-                            strncpy((char*)&s.section, m->name, MAX_PATH_LEN);
+                            strncpy((char*)&s.section, m->name, MAX_PATH_LEN-1);
                             symbols_to_flush.push_back(make_tuple(hook_candidate,s, *m));
                         }else{
                             for (auto sym: ss){

--- a/panda/plugins/dynamic_symbols/dynamic_symbols.cpp
+++ b/panda/plugins/dynamic_symbols/dynamic_symbols.cpp
@@ -158,7 +158,7 @@ void new_assignment_check_symbols(CPUState* cpu, unordered_map<string, struct sy
                             struct symbol s;
                             memset(&s, 0, sizeof(struct symbol));
                             s.address = m->base + hook_candidate.offset;
-                            strncpy((char*)&s.section, m->name, MAX_PATH_LEN-1);
+                            strncpy((char*)&s.section, m->name, sizeof(s.section)-2);
                             symbols_to_flush.push_back(make_tuple(hook_candidate,s, *m));
                         }else{
                             for (auto sym: ss){
@@ -210,7 +210,7 @@ struct symbol resolve_symbol(CPUState* cpu, target_ulong asid, char* section_nam
             if (it != section_vec->end()){
                 struct symbol val = it->second;
                 string val_str (val.name);
-                strncpy((char*) &val.section, section.first.c_str(), MAX_PATH_LEN -1);
+                strncpy((char*) &val.section, section.first.c_str(), sizeof(val.section) -2);
                 return val;
             }
         } 
@@ -537,8 +537,8 @@ void find_symbols(CPUState* cpu, target_ulong asid, OsiProc *current, OsiModule 
                     fixupendian(a->st_value);
                     if (a->st_name < strtab_size && a->st_value != 0){
                         struct symbol s;
-                        strncpy((char*)&s.name, &strtab_buf[a->st_name], MAX_PATH_LEN-1);
-                        strncpy((char*)&s.section, m->name, MAX_PATH_LEN-1);
+                        strncpy((char*)&s.name, &strtab_buf[a->st_name], sizeof(s.name)-2);
+                        strncpy((char*)&s.section, m->name, sizeof(s.section)-2);
                         s.address = m->base + a->st_value;
                         //printf("found symbol %s %s 0x%llx\n",s.section, &strtab_buf[a->st_name],(long long unsigned int)s.address);
                         string sym_name(s.name);

--- a/panda/plugins/dynamic_symbols/dynamic_symbols_int_fns.h
+++ b/panda/plugins/dynamic_symbols/dynamic_symbols_int_fns.h
@@ -20,8 +20,9 @@ typedef void (*dynamic_hook_func_t)(CPUState *, struct hook_symbol_resolve *, st
 
 struct hook_symbol_resolve{
     char name[MAX_PATH_LEN];
+    target_ulong offset;
+    bool hook_offset;
     char section[MAX_PATH_LEN];
-    char procname[MAX_PATH_LEN];
     dynamic_hook_func_t cb;
     bool enabled;
     int id;

--- a/panda/plugins/hooks/hooks.cpp
+++ b/panda/plugins/hooks/hooks.cpp
@@ -122,11 +122,11 @@ void add_symbol_hook(struct symbol_hook* h){
     if (h->hook_offset){
         sh.hook_offset = true;
         sh.offset = h->offset;
-        memset((char*) &sh.name, 0, sizeof(sh.name));
+        memset((void*) &sh.name, 0, sizeof(sh.name));
     }else{
-        strncpy((char*) &sh.name, (char*) &h->name, sizeof(sh.name)-2);
+        memcpy((void*) &sh.name, (void*) &h->name, sizeof(sh.name));
     }
-    strncpy((char*) &sh.section,(char*) &h->section, sizeof(sh.section)-2);
+    memcpy((void*) &sh.section,(void*) &h->section, sizeof(sh.section));
     void* dynamic_symbols = panda_get_plugin_by_name("dynamic_symbols");
     if (dynamic_symbols == NULL){
         panda_require("dynamic_symbols");

--- a/panda/plugins/hooks/hooks.cpp
+++ b/panda/plugins/hooks/hooks.cpp
@@ -124,9 +124,9 @@ void add_symbol_hook(struct symbol_hook* h){
         sh.offset = h->offset;
         memset((char*) &sh.name, 0, sizeof(sh.name));
     }else{
-        strncpy((char*) &sh.name, (char*) &h->name, MAX_PATH_LEN-1);
+        strncpy((char*) &sh.name, (char*) &h->name, sizeof(sh.name)-2);
     }
-    strncpy((char*) &sh.section,(char*) &h->section, MAX_PATH_LEN-1);
+    strncpy((char*) &sh.section,(char*) &h->section, sizeof(sh.section)-2);
     void* dynamic_symbols = panda_get_plugin_by_name("dynamic_symbols");
     if (dynamic_symbols == NULL){
         panda_require("dynamic_symbols");

--- a/panda/plugins/hooks/hooks.cpp
+++ b/panda/plugins/hooks/hooks.cpp
@@ -100,7 +100,7 @@ vector<pair<hooks_panda_cb, panda_cb_type>> symbols_to_handle;
 void handle_hook_return (CPUState *cpu, struct hook_symbol_resolve *sh, struct symbol s, OsiModule* m){
     int id = sh->id;
     pair<hooks_panda_cb,panda_cb_type> resolved = symbols_to_handle[id];
-    //.printf("handle_hook_return @ 0x%llx for \"%s\" in \"%s\" @ 0x%llx ASID: 0x%llx offset: 0x%llx\n", (long long unsigned int)rr_get_guest_instr_count(), s.name, s.section, (long long unsigned int) s.address, (long long unsigned int) panda_current_asid(cpu), (long long unsigned int) s.address - m->base);
+    //printf("handle_hook_return @ 0x%llx for \"%s\" in \"%s\" @ 0x%llx ASID: 0x%llx offset: 0x%llx\n", (long long unsigned int)rr_get_guest_instr_count(), s.name, s.section, (long long unsigned int) s.address, (long long unsigned int) panda_current_asid(cpu), (long long unsigned int) s.address - m->base);
     struct hook new_hook;
     new_hook.addr = s.address;
     new_hook.asid = panda_current_asid(cpu);
@@ -119,8 +119,13 @@ void add_symbol_hook(struct symbol_hook* h){
     sh.cb = handle_hook_return;
     symbols_to_handle.push_back(p);
     sh.id = symbols_to_handle.size() - 1;
-    strncpy((char*) &sh.procname, (char*) & h->procname, MAX_PATH_LEN);
-    strncpy((char*) &sh.name, (char*) &h->name, MAX_PATH_LEN);
+    if (h->hook_offset){
+        sh.hook_offset = true;
+        sh.offset = h->offset;
+        memset((char*) &sh.name, 0, sizeof(sh.name));
+    }else{
+        strncpy((char*) &sh.name, (char*) &h->name, MAX_PATH_LEN);
+    }
     strncpy((char*) &sh.section,(char*) &h->section, MAX_PATH_LEN);
     void* dynamic_symbols = panda_get_plugin_by_name("dynamic_symbols");
     if (dynamic_symbols == NULL){

--- a/panda/plugins/hooks/hooks.cpp
+++ b/panda/plugins/hooks/hooks.cpp
@@ -124,9 +124,9 @@ void add_symbol_hook(struct symbol_hook* h){
         sh.offset = h->offset;
         memset((char*) &sh.name, 0, sizeof(sh.name));
     }else{
-        strncpy((char*) &sh.name, (char*) &h->name, MAX_PATH_LEN);
+        strncpy((char*) &sh.name, (char*) &h->name, MAX_PATH_LEN-1);
     }
-    strncpy((char*) &sh.section,(char*) &h->section, MAX_PATH_LEN);
+    strncpy((char*) &sh.section,(char*) &h->section, MAX_PATH_LEN-1);
     void* dynamic_symbols = panda_get_plugin_by_name("dynamic_symbols");
     if (dynamic_symbols == NULL){
         panda_require("dynamic_symbols");

--- a/panda/plugins/hooks/hooks_int_fns.h
+++ b/panda/plugins/hooks/hooks_int_fns.h
@@ -48,8 +48,9 @@ typedef struct hook {
 
 struct symbol_hook {
     char name[MAX_PATH_LEN];
+    target_ulong offset;
+    bool hook_offset;
     char section[MAX_PATH_LEN];
-    char procname[MAX_PATH_LEN];
     panda_cb_type type;
     hooks_panda_cb cb;
 };

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -2588,7 +2588,7 @@ class Panda():
         return decorator
 
 
-    def hook_symbol(self, libraryname, symbolname, kernel=False, procname=None,name=None,cb_type="before_tcg_codegen"):
+    def hook_symbol(self, libraryname, symbol, kernel=False, name=None,cb_type="before_tcg_codegen"):
         '''
         Decorate a function to setup a hook: when a guest goes to execute a basic block beginning with addr,
         the function will be called with args (CPUState, TranslationBlock)
@@ -2612,19 +2612,20 @@ class Panda():
             new_hook = self.ffi.new("struct symbol_hook*")
             type_num = getattr(self.libpanda, "PANDA_CB_"+cb_type.upper())
             new_hook.type = type_num
-            if procname is not None:
-                procname_ffi = self.ffi.new("char[]",bytes(procname,"utf-8"))
-            else:
-                procname_ffi = self.ffi.new("char[]",bytes("\x00\x00\x00\x00","utf-8"))
-            self.ffi.memmove(new_hook.procname,procname_ffi,len(procname_ffi))
             if libraryname is not None:
                 libname_ffi = self.ffi.new("char[]",bytes(libraryname,"utf-8"))
             else:
                 libname_ffi = self.ffi.new("char[]",bytes("\x00\x00\x00\x00","utf-8"))
             self.ffi.memmove(new_hook.section,libname_ffi,len(libname_ffi))
 
-            if symbolname is not None:
-                symbolname_ffi = self.ffi.new("char[]",bytes(symbolname,"utf-8"))
+            new_hook.hook_offset = False
+            if symbol is not None:
+                if isinstance(symbol, int):
+                    new_hook.offset = symbol
+                    new_hook.hook_offset = True
+                    symbolname_ffi = self.ffi.new("char[]",bytes("\x00\x00\x00\x00","utf-8"))
+                else:
+                    symbolname_ffi = self.ffi.new("char[]",bytes(symbol,"utf-8"))
             else:
                 symbolname_ffi = self.ffi.new("char[]",bytes("\x00\x00\x00\x00","utf-8"))
             self.ffi.memmove(new_hook.name,symbolname_ffi,len(symbolname_ffi))

--- a/panda/python/core/pandare/panda_expect.py
+++ b/panda/python/core/pandare/panda_expect.py
@@ -20,7 +20,6 @@ class Expect(object):
 
         self.name = name
         self.logfile = None
-        logfile_base = "/tmp/expect"
         if logfile_base:
             self.logfile = open(f"{logfile_base}_{name}.txt", "wb")
 


### PR DESCRIPTION
- We're dropping support for the procname filter argument. Users will manage this better for their use-cases.
- handle offset into library (e.g. "libc-"+0x120) hooks in symbol_hooks.