### PR TITLE
Adding task_start and task_end callbacks to OSI.

### DIFF
--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -47,6 +47,8 @@ PPP_PROT_REG_CB(on_get_process_pid)
 PPP_PROT_REG_CB(on_get_process_ppid)
 
 PPP_PROT_REG_CB(on_task_change)
+PPP_PROT_REG_CB(on_task_start)
+PPP_PROT_REG_CB(on_task_end)
 
 PPP_CB_BOILERPLATE(on_get_processes)
 PPP_CB_BOILERPLATE(on_get_process_handles)
@@ -60,6 +62,8 @@ PPP_CB_BOILERPLATE(on_get_process_pid)
 PPP_CB_BOILERPLATE(on_get_process_ppid)
 
 PPP_CB_BOILERPLATE(on_task_change)
+PPP_CB_BOILERPLATE(on_task_start)
+PPP_CB_BOILERPLATE(on_task_end)
 
 // The copious use of pointers to pointers in this file is due to
 // the fact that PPP doesn't support return values (since it assumes
@@ -128,6 +132,16 @@ target_pid_t get_process_ppid(CPUState *cpu, const OsiProcHandle *h) {
 void notify_task_change(CPUState *cpu)
 {
     PPP_RUN_CB(on_task_change, cpu);
+}
+
+void notify_task_end(CPUState *cpu, const OsiProcHandle *h)
+{
+    PPP_RUN_CB(on_task_end, cpu, h);
+}
+
+void notify_task_start(CPUState *cpu, const OsiProcHandle *h)
+{
+    PPP_RUN_CB(on_task_start, cpu, h);
 }
 
 bool in_shared_object(CPUState *cpu, OsiProc *p) {

--- a/panda/plugins/osi/os_intro.h
+++ b/panda/plugins/osi/os_intro.h
@@ -19,6 +19,8 @@ typedef void (*on_get_process_pid_t)(CPUState *, const OsiProcHandle *, target_p
 typedef void (*on_get_process_ppid_t)(CPUState *, const OsiProcHandle *, target_pid_t *);
 
 typedef void (*on_task_change_t)(CPUState *);
+typedef void (*on_task_end_t)(CPUState *, const OsiProcHandle *h);
+typedef void (*on_task_start_t)(CPUState *, const OsiProcHandle *h);
 
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 

--- a/panda/plugins/osi/osi_int_fns.h
+++ b/panda/plugins/osi/osi_int_fns.h
@@ -34,18 +34,21 @@ void cleanup_garray(GArray *g);
 // returns true if execution is currently within a dynamically-linked function, else false.
 bool in_shared_object(CPUState *cpu, OsiProc *p);
 
+// gets the process pointed to by the handle
+OsiProc *get_process(CPUState *cpu, const OsiProcHandle *h);
+
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 // gets the currently running process handle
 OsiProcHandle *get_current_process_handle(CPUState *cpu);
 
-// gets the process pointed to by the handle
-OsiProc *get_process(CPUState *cpu, const OsiProcHandle *h);
 
 // functions retrieving partial process information via an OsiProcHandle
 target_pid_t get_process_pid(CPUState *cpu, const OsiProcHandle *h);
 target_pid_t get_process_ppid(CPUState *cpu, const OsiProcHandle *h);
 
 void notify_task_change(CPUState *cpu);
+void notify_task_end(CPUState *cpu, const OsiProcHandle *h);
+void notify_task_start(CPUState *cpu, const OsiProcHandle *h);
 
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!

--- a/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo.h
+++ b/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo.h
@@ -57,6 +57,8 @@ PACKED_STRUCT(task_info) {
     uint64_t per_cpu_offsets_addr;
     uint64_t per_cpu_offset_0_addr;
     uint64_t switch_task_hook_addr; /**< Address to hook for task switch notifications. */
+    uint64_t free_task_hook_addr; /**< Address to hook for task ending. */
+    uint64_t wake_up_new_task_hook_addr; /**< Address to hook for task starting. */
     uint64_t current_task_addr;
 	uint64_t init_addr;			/**< Address of the `struct task_struct` of the init task. */
 	size_t size;				/**< Size of `struct task_struct`. */

--- a/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
+++ b/panda/plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
@@ -153,8 +153,10 @@ int read_kernelinfo(gchar const *file, gchar const *group, struct kernelinfo *ki
 	READ_INFO_INT(ki, task.comm_size, gerr, err.task, &errbmp);
 	READ_INFO_INT(ki, task.files_offset, gerr, err.task, &errbmp);
 	OPTIONAL_READ_INFO_INT(ki, task.start_time_offset, gerr, err.task, &errbmp);
-    OPTIONAL_READ_INFO_UINT64(ki, task.switch_task_hook_addr, gerr, err.task, &errbmp);
-        
+	OPTIONAL_READ_INFO_UINT64(ki, task.switch_task_hook_addr, gerr, err.task, &errbmp);
+	OPTIONAL_READ_INFO_UINT64(ki, task.free_task_hook_addr, gerr, err.task, &errbmp);
+	OPTIONAL_READ_INFO_UINT64(ki, task.wake_up_new_task_hook_addr, gerr, err.task, &errbmp);
+
 	/* read mm information */
 	READ_INFO_INT(ki, mm.size, gerr, err.mm, &errbmp);
 	READ_INFO_INT(ki, mm.mmap_offset, gerr, err.mm, &errbmp);

--- a/panda/plugins/osi_linux/utils/kernelinfo_gdb/extract_kernelinfo.py
+++ b/panda/plugins/osi_linux/utils/kernelinfo_gdb/extract_kernelinfo.py
@@ -17,6 +17,11 @@ def print_offset_from_member(structp, memb_base, memb_dest, cfgname):
     offset = gdb.execute(f'printf "%lld", (int64_t)&(({structp})*0)->{memb_dest} - (int64_t)&(({structp})*0)->{memb_base}',to_string=True)
     print(f"{cfgname}.{memb_dest}_offset = {offset}",file=file_out)
 
+def print_function(cfgname, funcname):
+    offset = gdb.execute(f'printf "%llu", {funcname}',to_string=True)
+    print(f"#{cfgname} = {hex(int(offset))}",file=file_out)
+    print(f"{cfgname} = {offset}",file=file_out)
+
 def get_symbol_as_string(name):
     return gdb.execute(f'printf "%s",{name}',to_string=True)
 
@@ -136,8 +141,14 @@ class KernelInfo(gdb.Command):
             # fields in struct vfsmount 
             print_offset("struct vfsmount",         "mnt_parent",               "path");
             print_offset("struct vfsmount",         "mnt_mountpoint",           "path");
+
+        print_function("task.switch_task_hook_addr", "finish_task_switch")
+        print_function("task.free_task_hook_addr", "free_task")
+        print_function("task.wake_up_new_task_hook_addr", "wake_up_new_task")
+
         if file_out != sys.stdout:
             file_out.close()
+
 
 # This registers our class to the gdb runtime at "source" time.
 KernelInfo()


### PR DESCRIPTION
Unsure if there is much interest but I added callbacks for when a task starts and ends in OSI. This change hooks  [wake_up_new_task()](https://elixir.bootlin.com/linux/v5.12-rc7/source/kernel/sched/core.c#L3819) for starting tasks and 
[free_task()](https://elixir.bootlin.com/linux/v5.12-rc7/source/kernel/fork.c#L443) for ending tasks. 

This is marked as a draft because I've only tested on an arm-32 system, and the documentation for OSI would need to be updated. Specifically, `get_arg0()` should be tested on other systems. Also, `free_task()` was introduced in 2.5.71, and `wake_up_new_task()` was introduced in 2.6.9, so if support below these versions is desired, I need to find an equivalent functions to hook. 