### PR TITLE
osi_linux: avoid crash when pcomp_length is -1

### DIFF
--- a/panda/plugins/osi_linux/osi_linux.h
+++ b/panda/plugins/osi_linux/osi_linux.h
@@ -436,12 +436,20 @@ static inline char *read_dentry_name(CPUState *env, target_ptr_t dentry) {
 
         // read component
         pcomp_length = *(uint32_t *)(d_name + sizeof(uint32_t));
-        fixupendian(pcomp_length)
+        fixupendian(pcomp_length);
+        if (pcomp_length == (uint32_t)-1) { // Not sure why this happens, but it does
+              printf("Warning: OSI_linux Unhandled pcomp value, ignoring\n");
+              break;
+        }
         pcomp_length += 1; // space for string terminator
 
         if (pcomp_capacity < pcomp_length) {
             pcomp_capacity = pcomp_length + 16;
             pcomp = (char *)g_realloc(pcomp, pcomp_capacity * sizeof(char));
+            if (pcomp == NULL) {
+              printf("Warning: OSI_linux pcomp g_realloc failed\n");
+              break;
+            }
         }
 
         target_ptr_t guest_addr = *(target_ptr_t *)(d_name + ki.qstr.name_offset);


### PR DESCRIPTION
Ran into this crash on an arm guest today. Not positive that this is the best fix, but at least it doesn't crash now