### PR TITLE
Add TCG callbacks to start and end of blocks

### DIFF
--- a/panda/Makefile.panda.target
+++ b/panda/Makefile.panda.target
@@ -114,6 +114,7 @@ obj-y += plog.pb-c.o
 obj-y += panda/src/rr/rr_log.o
 obj-y += panda/src/checkpoint.o
 obj-y += panda/src/tcg-utils.o
+obj-y += panda/src/cb-installer.o
 # These are for C++ protobuf pandalog
 obj-y += panda/src/plog-cc.o
 obj-y += plog.pb.o

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -636,6 +636,8 @@ PANDA_CB_AFTER_CPU_EXEC_ENTER,  // Just after cpu_exec_enter is called
 PANDA_CB_BEFORE_CPU_EXEC_EXIT,  // Just before cpu_exec_exit is called
 PANDA_CB_AFTER_MACHINE_INIT,    // Right after the machine is initialized, before any code runs
 PANDA_CB_AFTER_VMLOAD,          // Right after machine state is restored from a snapshot, before any code runs
+PANDA_CB_START_BLOCK_EXEC,      // TCG stream start of block
+PANDA_CB_END_BLOCK_EXEC,        // TCG stream end of block
 PANDA_CB_TOP_LOOP,              // At top of loop that manages emulation.  good place to take a snapshot
 ```
 For more information on each callback, see the "Callbacks" section.
@@ -2029,3 +2031,42 @@ unused
 ```C
 void after_vmload(CPUState *env);
 ```
+---
+ 
+`start_block_exec`: This is like before_block_exec except its part of the TCG stream.
+
+**Callback ID**: `PANDA_CB_START_BLOCK_EXEC`
+
+**Arguments**:
+* `CPUState *env`:        the current CPU state
+* `TranslationBlock *tb`: the TB we are executing
+
+**Return value**:
+none
+
+
+
+**Notes**
+
+This callback is inserted into the TCG stream near `before_tcg_codegen`.
+
+**Signature**
+```C
+void (*start_block_exec)(CPUState *cpu, TranslationBlock* tb);
+```
+---
+
+`end_block_exec`: This is like after_block_exec except its part of the TCG stream.
+**Callback ID**: `PANDA_CB_END_BLOCK_EXEC`
+
+**Arguments**:
+* CPUState *env:        the current CPU state
+* TranslationBlock *tb: the TB we are executing
+
+**Return value**:
+none
+
+Signature
+```C
+void (*end_block_exec)(CPUState *cpu, TranslationBlock* tb);
+``

--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -96,6 +96,8 @@ typedef enum panda_cb_type {
                                       // or squash exceptions
 
     PANDA_CB_BEFORE_HANDLE_INTERRUPT, // ditto, for interrupts
+    PANDA_CB_START_BLOCK_EXEC,
+    PANDA_CB_END_BLOCK_EXEC,
 
     PANDA_CB_LAST
 } panda_cb_type;
@@ -998,6 +1000,9 @@ typedef union panda_cb {
 
 
     int32_t (*before_handle_interrupt)(CPUState *cpu, int32_t interrupt_request);
+
+    void (*start_block_exec)(CPUState *cpu, TranslationBlock* tb);
+    void (*end_block_exec)(CPUState *cpu, TranslationBlock* tb);
 
     void (*cbaddr)(void);
 } panda_cb;

--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -1000,8 +1000,37 @@ typedef union panda_cb {
 
 
     int32_t (*before_handle_interrupt)(CPUState *cpu, int32_t interrupt_request);
+    
+    /* Callback ID: PANDA_CB_START_BLOCK_EXEC
+
+       start_block_exec:
+        This is like before_block_exec except its part of the TCG stream.
+
+       Arguments:
+        CPUState *env:        the current CPU state
+        TranslationBlock *tb: the TB we are executing
+
+       Helper call location: cpu-exec.c
+
+       Return value:
+        none
+    */
 
     void (*start_block_exec)(CPUState *cpu, TranslationBlock* tb);
+    /* Callback ID: PANDA_CB_START_BLOCK_EXEC
+
+       end_block_exec:
+        This is like after_block_exec except its part of the TCG stream.
+
+       Arguments:
+        CPUState *env:        the current CPU state
+        TranslationBlock *tb: the TB we are executing
+
+       Helper call location: cpu-exec.c
+
+       Return value:
+        none
+    */
     void (*end_block_exec)(CPUState *cpu, TranslationBlock* tb);
 
     void (*cbaddr)(void);

--- a/panda/include/panda/callbacks/cb-support.h
+++ b/panda/include/panda/callbacks/cb-support.h
@@ -135,3 +135,7 @@ void panda_callbacks_cpu_restore_state(CPUState *env, TranslationBlock *tb);
 
 
 void panda_callbacks_before_tcg_codegen(CPUState *env, TranslationBlock *tb);
+void panda_callbacks_start_block_exec(CPUState *env, TranslationBlock *tb);
+void panda_callbacks_end_block_exec(CPUState *env, TranslationBlock *tb);
+
+void panda_install_block_callbacks(CPUState* cpu, TranslationBlock* tb);

--- a/panda/include/panda/tcg-utils.h
+++ b/panda/include/panda/tcg-utils.h
@@ -150,6 +150,13 @@ TCGOp *find_first_guest_insn(void);
  */
 TCGOp *find_guest_insn_by_addr(target_ulong addr);
 
+
+/* 
+*  Search the TCG context for the last guest instruction marker and return
+*  a pointer to it.
+*/
+TCGOp *find_last_guest_insn(void);
+
 void insert_call_1p(TCGOp **after_op, void(*func)(void*), void *val);
 
 #ifdef __cplusplus

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -2425,7 +2425,7 @@ class Panda():
         if not enabled: # Note the registered_callbacks dict starts with enabled true and then we update it to false as necessary here
             self.disable_callback(name)
 
-        if "block" in cb.name:
+        if "block" in cb.name and "start" not in cb.name and "end" not in cb.name:
             if not self.disabled_tb_chaining:
                 print("Warning: disabling TB chaining to support {} callback".format(cb.name))
                 self.disable_tb_chaining()

--- a/panda/src/cb-installer.cpp
+++ b/panda/src/cb-installer.cpp
@@ -12,10 +12,19 @@ void panda_install_block_callbacks(CPUState* cpu, TranslationBlock *tb){
     }else{
         printf("error on start\n");
     }
-    TCGOp* end = find_last_guest_insn();
-    if (end != NULL){
-        insert_call(&end, panda_callbacks_end_block_exec, first_cpu, tb);
-    }else{
+    
+    bool found_exit = false;
+    TCGOp *last_op = NULL;
+    TCGOp *op = NULL;
+    for (int oi = tcg_ctx.gen_op_buf[0].next; oi != 0; oi = op->next) {
+        op = &tcg_ctx.gen_op_buf[oi];
+        if (INDEX_op_exit_tb == op->opc) {
+            insert_call(&last_op, panda_callbacks_end_block_exec, first_cpu, tb);
+            found_exit = true;
+        }
+        last_op = op;
+    }
+    if (!found_exit) {
         printf("error on end %d\n", tb->size);
     }
 }

--- a/panda/src/cb-installer.cpp
+++ b/panda/src/cb-installer.cpp
@@ -7,16 +7,15 @@ extern "C"{
 
 void panda_install_block_callbacks(CPUState* cpu, TranslationBlock *tb){
     TCGOp* start = find_first_guest_insn();
-    TCGOp* end = find_guest_insn_by_addr(tb->pc+tb->size-4);
     if (start != NULL){
         insert_call(&start, panda_callbacks_start_block_exec, first_cpu, tb);
     }else{
         printf("error on start\n");
     }
+    TCGOp* end = find_last_guest_insn();
     if (end != NULL){
         insert_call(&end, panda_callbacks_end_block_exec, first_cpu, tb);
     }else{
-        //printf("error on end %d\n", tb->size);
-        //abort();
+        printf("error on end %d\n", tb->size);
     }
 }

--- a/panda/src/cb-installer.cpp
+++ b/panda/src/cb-installer.cpp
@@ -1,0 +1,22 @@
+#include "panda/tcg-utils.h"
+
+extern "C"{
+    #include "panda/callbacks/cb-support.h"
+}
+
+
+void panda_install_block_callbacks(CPUState* cpu, TranslationBlock *tb){
+    TCGOp* start = find_first_guest_insn();
+    TCGOp* end = find_guest_insn_by_addr(tb->pc+tb->size-4);
+    if (start != NULL){
+        insert_call(&start, panda_callbacks_start_block_exec, first_cpu, tb);
+    }else{
+        printf("error on start\n");
+    }
+    if (end != NULL){
+        insert_call(&end, panda_callbacks_end_block_exec, first_cpu, tb);
+    }else{
+        //printf("error on end %d\n", tb->size);
+        //abort();
+    }
+}

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -74,6 +74,12 @@ MAKE_CALLBACK(bool, INSN_TRANSLATE, insn_translate,
 MAKE_CALLBACK(bool, AFTER_INSN_TRANSLATE, after_insn_translate,
                     CPUState*, env, target_ptr_t, pc)
 
+MAKE_CALLBACK(void, START_BLOCK_EXEC, start_block_exec,
+                    CPUState*, env, TranslationBlock*, tb)
+
+MAKE_CALLBACK(void, END_BLOCK_EXEC, end_block_exec,
+                    CPUState*, env, TranslationBlock*, tb)
+
 // Helper - get a physical address
 static inline hwaddr get_paddr(CPUState *cpu, target_ptr_t addr, void *ram_ptr) {
     if (!ram_ptr) {

--- a/panda/src/tcg-utils.cpp
+++ b/panda/src/tcg-utils.cpp
@@ -17,6 +17,23 @@ TCGOp *find_first_guest_insn()
     return first_guest_insn_mark;
 }
 
+// return the op right before exit
+TCGOp *find_last_guest_insn()
+{
+    TCGOp *last_op = NULL;
+    TCGOp *op = NULL;
+    TCGOp *last_guest_insn_mark = NULL; 
+    for (int oi = tcg_ctx.gen_op_buf[0].next; oi != 0; oi = op->next) {
+        op = &tcg_ctx.gen_op_buf[oi];
+        if (INDEX_op_exit_tb == op->opc) {
+            last_guest_insn_mark = last_op;
+            break;
+        }
+        last_op = op;
+    }
+    return last_guest_insn_mark;
+}
+
 TCGOp *find_guest_insn_by_addr(target_ulong addr)
 {
     TCGOp *op = NULL;

--- a/translate-all.c
+++ b/translate-all.c
@@ -78,6 +78,7 @@
 
 #include "panda/rr/rr_log.h"
 #include "panda/callbacks/cb-support.h"
+#include "panda/tcg-utils.h"
 
 /* #define DEBUG_TB_INVALIDATE */
 /* #define DEBUG_TB_FLUSH */
@@ -1377,6 +1378,8 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
        that should be required is to flush the TBs, allocate a new TB,
        re-initialize it per above, and re-do the actual code generation.  */
     panda_callbacks_before_tcg_codegen(first_cpu, tb);
+    panda_install_block_callbacks(first_cpu, tb);
+
     gen_code_size = tcg_gen_code(&tcg_ctx, tb);
 
 #if defined(CONFIG_LLVM)


### PR DESCRIPTION
Introduces two new callbacks:
- `start_block_exec` which is a TCG level callback at the start of blocks
- `end_block_exec` which is a TCG level callback at the end of blocks

This is a fairly early draft I'm putting out to get thoughts on.