### PR TITLE
syscalls_logger: trace single process, strace-like output if no pandalog

### DIFF
--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -155,7 +155,7 @@ void fill_osiproc(CPUState *cpu, OsiProc *p, target_ptr_t task_addr) {
 
     // p->ppid = taskd->real_parent->pid
     err = struct_get(cpu, &p->ppid, task_addr,
-                     {ki.task.real_parent_offset, ki.task.pid_offset});
+                     {ki.task.real_parent_offset, ki.task.tgid_offset});
 
     // Convert asid to physical to be able to compare it with the pgd register.
     p->asid = p->asid ? panda_virt_to_phys(cpu, p->asid) : (target_ulong) NULL;

--- a/panda/plugins/syscalls_logger/README.md
+++ b/panda/plugins/syscalls_logger/README.md
@@ -120,6 +120,7 @@ Arguments
 
 * `dwarf_json`: string, path to JSON file with the kernels DWARF info. Enables richer logging if present, as described above. Optional.
 * `verbose`: bool, defaults to false. Enables verbose logging if set.
+* `target`: string, name of a process to log syscalls for. If unset, syscalls for all processes are logged.
 
 Dependencies
 ------------


### PR DESCRIPTION
Updates syscalls_logger to support tracing a single named process and to print recursive syscall arguments to stdout when dwarfinfo is available and no pandalog is specified.