### PR TITLE
FIX MIPS datatype alignment and update example

### DIFF
--- a/panda/python/core/pandare/include/panda_datatypes_MIPS_32.h
+++ b/panda/python/core/pandare/include/panda_datatypes_MIPS_32.h
@@ -1107,6 +1107,7 @@ struct CPUMIPSState;
 typedef struct CPUMIPSState CPUMIPSState;
 struct CPUMIPSState {
 	TCState                    active_tc;            /*     0   228 */
+	char pack[4];
 	/* XXX 4 bytes hole, try to pack */
 	/* --- cacheline 3 boundary (192 bytes) was 40 bytes ago --- */
 	CPUMIPSFPUContext          active_fpu;           /*   232   536 */
@@ -1116,6 +1117,7 @@ struct CPUMIPSState {
 	uint32_t                   SEGBITS;              /*   776     4 */
 	uint32_t                   PABITS;               /*   780     4 */
 	target_ulong               SEGMask;              /*   784     4 */
+	char pack2[4];
 	/* XXX 4 bytes hole, try to pack */
 	uint64_t                   PAMask;               /*   792     8 */
 	int32_t                    msair;                /*   800     4 */
@@ -1213,6 +1215,7 @@ struct CPUMIPSState {
 	TCState                    tcs[16];              /*  1356  3648 */
 	/* XXX 4 bytes hole, try to pack */
 	/* --- cacheline 78 boundary (4992 bytes) was 16 bytes ago --- */
+	char pack3[4];
 	CPUMIPSFPUContext          fpus[1];              /*  5008   536 */
 	/* --- cacheline 86 boundary (5504 bytes) was 40 bytes ago --- */
 	int                        error_code;           /*  5544     4 */
@@ -1240,6 +1243,7 @@ struct CPUMIPSState {
 	target_ulong               tlb_flush_mask;       /* 43604     4 */
 	target_ulong               vtlb_index;           /* 43608     4 */
 	/* XXX 4 bytes hole, try to pack */
+	char pack4[4];
 	CPUMIPSMVPContext *        mvp;                  /* 43616     8 */
 	CPUMIPSTLBContext *        tlb;                  /* 43624     8 */
 	const mips_def_t  *        cpu_model;            /* 43632     8 */

--- a/panda/python/examples/unicorn/mips.py
+++ b/panda/python/examples/unicorn/mips.py
@@ -19,15 +19,15 @@ nop
 addiu $t1, 1  # t1++
 """
 
-ks = keystone.Ks(keystone.KS_ARCH_MIPS, keystone.KS_MODE_MIPS32)
-#ks = keystone.Ks(keystone.KS_ARCH_MIPS, keystone.KS_MODE_MIPS32 + KS_MODE_BIG_ENDIAN)
+#ks = keystone.Ks(keystone.KS_ARCH_MIPS, keystone.KS_MODE_MIPS32)
+ks = keystone.Ks(keystone.KS_ARCH_MIPS, keystone.KS_MODE_MIPS32 + keystone.KS_MODE_BIG_ENDIAN)
 
-ADDRESS = 0x1000
+ADDRESS = 0x80000000#0x1000
 encoding, count = ks.asm(CODE, ADDRESS)
 stop_addr = ADDRESS + len(encoding)
 
-panda = Panda("mipsel",
-        extra_args=["-M", "configurable", "-nographic"],
+panda = Panda("mips",
+        extra_args=["-M", "configurable", "-nographic", '-d', 'int'],
         raw_monitor=True) # Allows for a user to ctrl-a + c then type quit if things go wrong
 
 @panda.cb_after_machine_init
@@ -42,7 +42,8 @@ def setup(cpu):
     panda.physical_memory_write(ADDRESS, bytes(encoding))
 
     # Set up registers
-    cpu.env_ptr.active_tc.gpr[panda.arch.registers['t0']] = 0x10
+    #cpu.env_ptr.active_tc.gpr[panda.arch.registers['t0']] = 0x10
+    panda.arch.set_reg(cpu, 't0', 0x10)
 
     # Set starting_pc
     cpu.env_ptr.active_tc.PC = ADDRESS
@@ -59,8 +60,8 @@ def on_insn(cpu, pc):
     if pc >= stop_addr:
         print("Finished execution")
         #dump_regs(panda, cpu)
-        print("Register t0 contains:", hex(cpu.env_ptr.active_tc.gpr[panda.arch.registers['t0']]))
-        print("Register t1 contains:", hex(cpu.env_ptr.active_tc.gpr[panda.arch.registers['t1']]))
+        print("Register t0 contains:", hex(panda.arch.get_reg(cpu, 't0')))
+        print("Register t1 contains:", hex(panda.arch.get_reg(cpu,'t1')))
         os._exit(0) # TODO: we need a better way to stop here
 
     code = panda.virtual_memory_read(cpu, pc, 12)

--- a/panda/python/examples/unicorn/mips.py
+++ b/panda/python/examples/unicorn/mips.py
@@ -27,7 +27,7 @@ encoding, count = ks.asm(CODE, ADDRESS)
 stop_addr = ADDRESS + len(encoding)
 
 panda = Panda("mips",
-        extra_args=["-M", "configurable", "-nographic", '-d', 'int'],
+        extra_args=["-M", "configurable", "-nographic"],
         raw_monitor=True) # Allows for a user to ctrl-a + c then type quit if things go wrong
 
 @panda.cb_after_machine_init

--- a/panda/python/examples/unicorn/mips.py
+++ b/panda/python/examples/unicorn/mips.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 from pandare import Panda, ffi
-import capstone
-import keystone
+from capstone import *
+from capstone.mips import *
+from keystone import *
 import os
 
 CODE = b"""
@@ -19,10 +20,9 @@ nop
 addiu $t1, 1  # t1++
 """
 
-#ks = keystone.Ks(keystone.KS_ARCH_MIPS, keystone.KS_MODE_MIPS32)
-ks = keystone.Ks(keystone.KS_ARCH_MIPS, keystone.KS_MODE_MIPS32 + keystone.KS_MODE_BIG_ENDIAN)
+ks = Ks(KS_ARCH_MIPS,KS_MODE_MIPS32 + KS_MODE_BIG_ENDIAN)
 
-ADDRESS = 0x80000000#0x1000
+ADDRESS = 0x1000
 encoding, count = ks.asm(CODE, ADDRESS)
 stop_addr = ADDRESS + len(encoding)
 
@@ -51,7 +51,7 @@ def setup(cpu):
 # Always run insn_exec
 panda.cb_insn_translate(lambda x,y: True)
 
-md = capstone.Cs(capstone.CS_ARCH_MIPS, 4) # misp32
+md = Cs(CS_ARCH_MIPS, CS_MODE_MIPS32+ CS_MODE_BIG_ENDIAN) # misp32
 @panda.cb_insn_exec
 def on_insn(cpu, pc):
     '''
@@ -64,7 +64,7 @@ def on_insn(cpu, pc):
         print("Register t1 contains:", hex(panda.arch.get_reg(cpu,'t1')))
         os._exit(0) # TODO: we need a better way to stop here
 
-    code = panda.virtual_memory_read(cpu, pc, 12)
+    code = panda.virtual_memory_read(cpu, pc, 4)
     for i in md.disasm(code, pc):
         print("0x%x:\t%s\t%s" %(i.address, i.mnemonic, i.op_str))
         break


### PR DESCRIPTION
It's unclear to me why exactly this is wrong. It's possibly a cffi bug relating to following the linux ABI. Either way this fix makes the gaps explicit.

Also updates experimental unicorn mips with new architecture standard.



CLOSES: #993 