### PR TITLE
Add TCGContext argument to before_tcg_codegen callback

### DIFF
--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -132,13 +132,14 @@ typedef union panda_cb {
        Arguments:
         CPUState *env:        the current CPU state
         TranslationBlock *tb: the TB about to be compiled
+        TCGContext *s: the current TCG context
 
        Helper call location: translate-all.c
 
        Return value:
         None
     */
-    void (*before_tcg_codegen)(CPUState *env, TranslationBlock *tb);
+    void (*before_tcg_codegen)(CPUState *env, TranslationBlock *tb, TCGContext *s);
 
     /* Callback ID: PANDA_CB_BEFORE_BLOCK_EXEC
 

--- a/panda/include/panda/callbacks/cb-support.h
+++ b/panda/include/panda/callbacks/cb-support.h
@@ -53,9 +53,8 @@ exit 0
  ***************************************************************************/
 #include <stdbool.h>
 #include "panda/types.h"
+#include "tcg.h" // TCGContext, TranslationBlock (indirectly)
 #ifndef EXEC_ALL_H
-// If this file is included from a file that doesn't define TranslationBlock (e.g., memory.c), we still need to be valid
-typedef struct {} TranslationBlock;
 #endif
 /* shared helpers for virtual/physical memory callbacks */
 void panda_callbacks_mem_before_read(CPUState *env, target_ptr_t pc, target_ptr_t addr, size_t data_size, void *ram_ptr);
@@ -134,7 +133,7 @@ bool panda_callbacks_guest_hypercall(CPUState *env);
 void panda_callbacks_cpu_restore_state(CPUState *env, TranslationBlock *tb);
 
 
-void panda_callbacks_before_tcg_codegen(CPUState *env, TranslationBlock *tb);
+void panda_callbacks_before_tcg_codegen(CPUState *env, TranslationBlock *tb, TCGContext *s);
 void panda_callbacks_start_block_exec(CPUState *env, TranslationBlock *tb);
 void panda_callbacks_end_block_exec(CPUState *env, TranslationBlock *tb);
 

--- a/panda/plugins/coverage/coverage.cpp
+++ b/panda/plugins/coverage/coverage.cpp
@@ -80,7 +80,7 @@ static void after_loadvm(CPUState *cpu)
     notify_task_change_observers(cpu);
 }
 
-static void before_tcg_codegen(CPUState *cpu, TranslationBlock *tb)
+static void before_tcg_codegen(CPUState *cpu, TranslationBlock *tb, TCGContext *s)
 {
     // Determine if we should instrument.
     if (inst_dels.empty() || !predicate->eval(cpu, tb)) {

--- a/panda/plugins/forcedexec/forcedexec.cpp
+++ b/panda/plugins/forcedexec/forcedexec.cpp
@@ -31,7 +31,7 @@ panda_cb tcg_cb;
 
 PPP_CB_BOILERPLATE(on_branch);
 
-void tcg_parse(CPUState *env, TranslationBlock *tb) {
+void tcg_parse(CPUState *env, TranslationBlock *tb, TCGContext *s) {
     // Called after we generated a TCG block but before it's lowered to host ISA
 
     // If the block contains a branch, call out
@@ -46,7 +46,6 @@ void tcg_parse(CPUState *env, TranslationBlock *tb) {
     // Iterate oi until it's last instruction in block
     TCGOp *op;
     int oi;
-    TCGContext *s = &tcg_ctx; // global tcg context
 
     // For each branch in the block - consider flipping it
     size_t idx = 0;

--- a/panda/plugins/hooks/hooks.cpp
+++ b/panda/plugins/hooks/hooks.cpp
@@ -265,11 +265,11 @@ bool cb_ ## NAME ## _callback PASSED_ARGS { \
     return ret; \
 }
     
-void cb_tcg_codegen_middle_filter(CPUState* cpu, TranslationBlock *tb) {
-    HOOK_GENERIC_RET_EXPR(/*printf("TCG calling %llx from %llx with hook %llx guest_pc %llx\n", (long long unsigned int) panda_current_pc(cpu), (long long unsigned int)tb->pc, (long long unsigned int)h->addr, (long long unsigned int)cpu->panda_guest_pc); printf("made it to hook %p\n", (void*)h->cb.before_block_exec);*/ (*(h->cb.before_tcg_codegen))(cpu, tb, h);, BEFORE_TCG_CODEGEN, before_tcg_codegen, , < tb->pc + tb->size, tb->pc );
+void cb_tcg_codegen_middle_filter(CPUState* cpu, TranslationBlock *tb, TCGContext *s) {
+    HOOK_GENERIC_RET_EXPR(/*printf("TCG calling %llx from %llx with hook %llx guest_pc %llx\n", (long long unsigned int) panda_current_pc(cpu), (long long unsigned int)tb->pc, (long long unsigned int)h->addr, (long long unsigned int)cpu->panda_guest_pc); printf("made it to hook %p\n", (void*)h->cb.before_block_exec);*/ (*(h->cb.before_tcg_codegen))(cpu, tb, s, h);, BEFORE_TCG_CODEGEN, before_tcg_codegen, , < tb->pc + tb->size, tb->pc );
 }
 
-void cb_before_tcg_codegen_callback (CPUState* cpu, TranslationBlock *tb) {
+void cb_before_tcg_codegen_callback (CPUState* cpu, TranslationBlock *tb, TCGContext *s) {
     if (unlikely(! temp_before_tcg_codegen_hooks.empty())){
         for (auto &h: temp_before_tcg_codegen_hooks) {
             before_tcg_codegen_hooks[h.asid].insert(h);
@@ -307,7 +307,7 @@ void cb_before_tcg_codegen_callback (CPUState* cpu, TranslationBlock *tb) {
                                 op = find_guest_insn_by_addr(h->addr);
                             }
                             if (op != NULL){
-                                insert_call(&op, cb_tcg_codegen_middle_filter, cpu, tb);
+                                insert_call(&op, cb_tcg_codegen_middle_filter, cpu, tb, s);
                                 inserted_addresses.insert(h->addr);
                             }
                         } 

--- a/panda/plugins/hooks/hooks_int_fns.h
+++ b/panda/plugins/hooks/hooks_int_fns.h
@@ -2,6 +2,7 @@
 #define __HOOKS_INT_FNS_H__
 
 #include "dynamic_symbols/dynamic_symbols_int_fns.h"
+#include "tcg.h"
 
 extern "C" {
 
@@ -21,7 +22,7 @@ typedef bool (*hook_func_t)(CPUState *, TranslationBlock *, struct hook* h);
 typedef bool (*dynamic_symbol_hook_func_t)(CPUState *, TranslationBlock *, struct hook* h);
 
 typedef union hooks_panda_cb {
-    void (*before_tcg_codegen)(CPUState *env, TranslationBlock *tb, struct hook*);
+    void (*before_tcg_codegen)(CPUState *env, TranslationBlock *tb, TCGContext *s, struct hook*);
     void (*before_block_translate)(CPUState *env, target_ptr_t pc, struct hook*);
     void (*after_block_translate)(CPUState *env, TranslationBlock *tb, struct hook*);
     bool (*before_block_exec_invalidate_opt)(CPUState *env, TranslationBlock *tb, struct hook*);

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -735,7 +735,7 @@ static void exec_check(CPUState *cpu)
     }
 }
 
-static void before_tcg_codegen_callback(CPUState *cpu, TranslationBlock *tb)
+static void before_tcg_codegen_callback(CPUState *cpu, TranslationBlock *tb, TCGContext *s)
 {
     TCGOp *op = find_first_guest_insn();
     assert(NULL != op);

--- a/panda/plugins/proc_start_linux/proc_start_linux.cpp
+++ b/panda/plugins/proc_start_linux/proc_start_linux.cpp
@@ -61,7 +61,7 @@ string read_str(CPUState* cpu, target_ulong ptr){
     return buf;
 }
 
-void btc_execve(CPUState *env, TranslationBlock *tb){
+void btc_execve(CPUState *env, TranslationBlock *tb, TCGContext *s){
     if (unlikely(!panda_in_kernel(env))){
         target_ulong sp = panda_current_sp(env);
         target_ulong argc;

--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -828,6 +828,7 @@ static uint32_t impossibleToReadPCs = 0;
 
 // Check if the instruction is sysenter (0F 34),
 // syscall (0F 05) or int 0x80 (CD 80)
+// Returns program counter of syscall
 target_ulong doesBlockContainSyscall(CPUState *cpu, TranslationBlock *tb) {
 #if defined(TARGET_I386)
     unsigned char buf[2] = {};
@@ -935,7 +936,7 @@ target_ulong doesBlockContainSyscall(CPUState *cpu, TranslationBlock *tb) {
 }
 
 
-void before_tcg_codegen(CPUState *cpu, TranslationBlock *tb){
+void before_tcg_codegen(CPUState *cpu, TranslationBlock *tb, TCGContext *s) {
     target_ulong res = doesBlockContainSyscall(cpu,tb);
 #ifdef DEBUG
     if(res == (target_ulong) -1){
@@ -948,8 +949,7 @@ void before_tcg_codegen(CPUState *cpu, TranslationBlock *tb){
     }
 }
 
-// This will only be called for instructions where the
-// translate_callback returned true
+// A call to this function will be inserted into the TCG stream if the block contains a syscall
 void exec_callback(CPUState *cpu, TranslationBlock *tb, target_ulong pc) {
 #if defined(SYSCALL_RETURN_DEBUG) && defined(TARGET_I386)
     CPUArchState *env = (CPUArchState*)cpu->env_ptr;

--- a/panda/plugins/wintrospection/wintrospection.c
+++ b/panda/plugins/wintrospection/wintrospection.c
@@ -737,7 +737,7 @@ void fill_osimod(CPUState *cpu, OsiModule *m, PTR mod, bool ignore_basename) {
     assert(m->name);
 }
 
-static void before_tcg_codegen(CPUState *cpu, TranslationBlock *tb)
+static void before_tcg_codegen(CPUState *cpu, TranslationBlock *tb, TCGContext *s)
 {
     if (0x0 == task_change_hook_addr && 0 == strcmp(panda_os_variant, "7")) {
         // On Windows 7, we have to compute the task change hook address

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -43,7 +43,7 @@ MAKE_REPLAY_ONLY_CALLBACK(REPLAY_AFTER_DMA, replay_after_dma,
                     hwaddr, addr, size_t ,size,
                     bool, is_write)
 
-MAKE_CALLBACK(void, BEFORE_TCG_CODEGEN, before_tcg_codegen, CPUState*, cpu, TranslationBlock*, tb);
+MAKE_CALLBACK(void, BEFORE_TCG_CODEGEN, before_tcg_codegen, CPUState*, cpu, TranslationBlock*, tb, TCGContext*, s);
 
 // These are used in cpu-exec.c
 MAKE_CALLBACK(void, BEFORE_BLOCK_EXEC, before_block_exec,

--- a/translate-all.c
+++ b/translate-all.c
@@ -1377,8 +1377,8 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
        the tcg optimization currently hidden inside tcg_gen_code.  All
        that should be required is to flush the TBs, allocate a new TB,
        re-initialize it per above, and re-do the actual code generation.  */
-    panda_callbacks_before_tcg_codegen(first_cpu, tb);
-    panda_install_block_callbacks(first_cpu, tb);
+    panda_callbacks_before_tcg_codegen(cpu, tb, &tcg_ctx);
+    panda_install_block_callbacks(cpu, tb);
 
     gen_code_size = tcg_gen_code(&tcg_ctx, tb);
 


### PR DESCRIPTION
We could previously access this through a global, but I'm not sure if that would always be correct. This should be more future-proof.

This PR also updates all the plugins using the callback and changes the callback to pass the actual `CPUState` object it has instead of just using `first_cpu` (which is bad practice)