### PR TITLE
Pypanda.arch updates for consistent function names

### DIFF
--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -267,17 +267,17 @@ class ArmArch(PandaArch):
         '''
         cpu.env_ptr.regs[reg] = val
 
-    def get_return_value(self, env):
+    def get_return_value(self, cpu):
         '''
         returns register value used to return results
         '''
-        return self.get_reg(env, "R0")
+        return self.get_reg(cpu, "R0")
 
-    def get_return_address(self,env):
+    def get_return_address(self, cpu):
         '''
         looks up where ret will go
         '''
-        return self.get_reg(env, "LR")
+        return self.get_reg(cpu, "LR")
 
 class Aarch64Arch(PandaArch):
     '''
@@ -337,17 +337,17 @@ class Aarch64Arch(PandaArch):
         '''
         cpu.env_ptr.xregs[reg] = val
 
-    def get_return_value(self, env):
+    def get_return_value(self, cpu):
         '''
         returns register value used to return results
         '''
-        return self.get_reg(env, "R0")
+        return self.get_reg(cpu, "R0")
 
-    def get_return_address(self,env):
+    def get_return_address(self, cpu):
         '''
         looks up where ret will go
         '''
-        return self.get_reg(env, "LR")
+        return self.get_reg(cpu, "LR")
 
 class MipsArch(PandaArch):
     '''
@@ -415,17 +415,23 @@ class MipsArch(PandaArch):
         '''
         cpu.env_ptr.active_tc.gpr[reg] = val
 
-    def get_return_value(self, env):
+    def get_return_value(self, cpu):
         '''
         returns register value used to return results
         '''
-        return self.get_reg(env, "V0")
+        return self.get_reg(cpu, "V0")
 
-    def get_call_return(self,env):
+    def get_call_return(self, cpu):
+        '''
+        .. Deprecated:: use get_return_address
+        '''
+        return self.get_return_addess(cpu)
+
+    def get_return_address(self,cpu):
         '''
         looks up where ret will go
         '''
-        return self.get_reg(env, "RA")
+        return self.get_reg(cpu, "RA")
 
     def set_retval(self, cpu, val, convention='default', failure=False):
         '''
@@ -490,26 +496,26 @@ class X86Arch(PandaArch):
         '''
         cpu.env_ptr.regs[reg] = val
 
-    def get_return_value(self, env):
+    def get_return_value(self, cpu):
         '''
         returns register value used to return results
         '''
-        return self.get_reg(env, "EAX")
+        return self.get_reg(cpu, "EAX")
 
-    def get_return_address(self,env):
+    def get_return_address(self,cpu):
         '''
         looks up where ret will go
         '''
-        esp = self.get_reg(env,"ESP")
-        return self.panda.virtual_memory_read(env,esp,4,fmt='int')
+        esp = self.get_reg(cpu,"ESP")
+        return self.panda.virtual_memory_read(cpu,esp,4,fmt='int')
     
     # we need this because X86 is stack based
-    def get_arg_stack(self, env, num, kernel=False):
+    def get_arg_stack(self, cpu, num, kernel=False):
         '''
         Gets arguments based on the number. Supports kernel and usermode.
         '''
-        esp = self.get_reg(env, "ESP")
-        return self.panda.virtual_memory_read(env, esp+(4*(num+1)),4,fmt='int')
+        esp = self.get_reg(cpu, "ESP")
+        return self.panda.virtual_memory_read(cpu, esp+(4*(num+1)),4,fmt='int')
 
 class X86_64Arch(PandaArch):
     '''
@@ -559,15 +565,15 @@ class X86_64Arch(PandaArch):
         '''
         cpu.env_ptr.regs[reg] = val
 
-    def get_return_value(self, env):
+    def get_return_value(self, cpu):
         '''
         returns register value used to return results
         '''
-        return self.get_reg(env, "RAX")
+        return self.get_reg(cpu, "RAX")
 
-    def get_return_address(self,env):
+    def get_return_address(self, cpu):
         '''
         looks up where ret will go
         '''
-        esp = self.get_reg(env,"RSP")
-        return self.panda.virtual_memory_read(env,esp,8,fmt='int')
+        esp = self.get_reg(cpu, "RSP")
+        return self.panda.virtual_memory_read(cpu, esp, 8, fmt='int')


### PR DESCRIPTION
Previously the MipsArch subclass had `get_call_return` while all the other subclasses had `get_return_address`. This moves the implementation into `MipsArch.get_return_address` but keeps `MipsArch.get_call_return` as a depreciated but backwards-compatible function.

This also renames the `CPUState` object passed in to be `cpu` as opposed to `env` (the cpu object has an env_ptr field, but calling the whole object `env` is a bit inaccurate)