### PR TITLE
coverage: Fix handling of edges when an X86-64 guest is in compatibility mode (32-bit).

### DIFF
--- a/panda/plugins/coverage/EdgeInstrumentationDelegate.cpp
+++ b/panda/plugins/coverage/EdgeInstrumentationDelegate.cpp
@@ -475,7 +475,7 @@ const static std::unordered_map<unsigned int,
 
 EdgeInstrumentationDelegate::EdgeInstrumentationDelegate(
     std::shared_ptr<RecordProcessor<Edge>> ep) : edge_processor(ep)
-                                                , edge_state(new EdgeState())
+                                               , edge_state(new EdgeState())
 {
 #ifdef TARGET_I386
     cs_open(CS_ARCH_X86, CS_MODE_32, &handle32);
@@ -503,10 +503,14 @@ void EdgeInstrumentationDelegate::instrument(CPUState *cpu,
 {
     csh handle = 0;
 #ifdef TARGET_I386
-    handle = handle32;
 #ifdef TARGET_X86_64
-    if ((tb->flags & HF_CS64_SHIFT) & 1) {
+    CPUArchState *env = static_cast<CPUArchState *>(cpu->env_ptr);
+    if ((env->hflags & (1 << HF_LMA_SHIFT)) && (env->hflags & (1 << HF_CS64_SHIFT))) {
         handle = handle64;
+    } else {
+#endif
+        handle = handle32;
+#ifdef TARGET_X86_64
     }
 #endif
 #endif

--- a/panda/plugins/coverage/EdgeInstrumentationDelegate.h
+++ b/panda/plugins/coverage/EdgeInstrumentationDelegate.h
@@ -33,9 +33,14 @@ public:
 
 private:
     std::shared_ptr<RecordProcessor<Edge>> edge_processor;
-    bool capstone_initialized;
-    csh handle;
     std::unique_ptr<EdgeState> edge_state;
+
+#ifdef TARGET_I386
+    csh handle32;
+#ifdef TARGET_X86_64
+    csh handle64;
+#endif
+#endif
 };
 
 }


### PR DESCRIPTION
There are a few instructions that capstone ends up interpreting differently depending on whether or not the CPU is in compatibility mode (32-bit mode) or 64-bit mode. In other words, this patch should fix some issues with assertion errors or missing edges when collecting coverage data for a 32-bit application on a 64-bit guest.