### PR TITLE
PyPanda: Panda.callstack_callers: Arch-dependent type

### DIFF
--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -861,7 +861,7 @@ class Panda():
             progress("enabling callstack_instr plugin")
             self.load_plugin("callstack_instr")
 
-        callers = ffi.new("uint32_t[%d]" % lim)
+        callers = ffi.new("uint%d_t[%d]" % (self.bits, lim))
         n = self.plugins['callstack_instr'].get_callers(callers, lim, cpu)
         c = []
         for pc in callers:


### PR DESCRIPTION
callback_instr uses target_ulong for the first parameter of
get_callers().
This commit makes the type dependent on panda.bits so that it works on
architectures other than 32 bits.

--

Note that I have only tested this on x64. I don't know whether there are architectures in which ulong_target is different to what my new code does.