### PR TITLE
panda/plugins/syscalls_logger: Support jsoncpp with other distributions

### DIFF
--- a/panda/plugins/syscalls_logger/dwarf_query.h
+++ b/panda/plugins/syscalls_logger/dwarf_query.h
@@ -7,7 +7,11 @@
 #include <iomanip>
 #include <unordered_map>
 #include <map>
+#if __has_include(<jsoncpp/json/json.h>)
 #include <jsoncpp/json/json.h>
+#else
+#include <json/json.h>
+#endif
 
 #include "panda/plugin.h"
 #include "panda/common.h"


### PR DESCRIPTION
On Fedora, the include directory does not have the jsoncpp/ prefix