### PR TITLE
panda/plugins/{callstack_instr,taint2}: Support recent toolchain

### DIFF
--- a/panda/plugins/callstack_instr/prog_point.h
+++ b/panda/plugins/callstack_instr/prog_point.h
@@ -14,6 +14,8 @@ PANDAENDCOMMENT */
 #ifndef __PROG_POINT_H
 #define __PROG_POINT_H
 
+#include <functional>
+
 // different ways to segregate the stacks
 enum stack_type {
     STACK_ASID = 0,

--- a/panda/plugins/taint2/label_set.cpp
+++ b/panda/plugins/taint2/label_set.cpp
@@ -16,13 +16,13 @@ extern "C" {
 template<typename T>
 class ArenaAlloc {
 private:
-    uint8_t *next = NULL;
+    uint8_t *next = nullptr;
     std::vector<std::pair<uint8_t *, size_t>> blocks;
     size_t next_block_size = 1 << 15;
 
     void alloc_block() {
         //printf("taint2: allocating block of size %lu\n", next_block_size);
-        next = (uint8_t *)mmap(NULL, next_block_size, PROT_READ | PROT_WRITE,
+        next = (uint8_t *)mmap(nullptr, next_block_size, PROT_READ | PROT_WRITE,
                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         assert(next);
         blocks.push_back(std::make_pair(next, next_block_size));
@@ -34,7 +34,7 @@ private:
         std::pair<uint8_t *, size_t>& block = blocks.back();
         if (next + sizeof(T) > block.first + block.second) {
             alloc_block();
-            assert(next != NULL);
+            assert(next != nullptr);
         }
 
         T *result = new(next) T;

--- a/panda/plugins/taint2/taint2_hypercalls.cpp
+++ b/panda/plugins/taint2/taint2_hypercalls.cpp
@@ -24,10 +24,8 @@
 #include <vector>
 #include "taint2_hypercalls.h"
 #include "taint_api.h"
-extern "C" {
 #include "callstack_instr/callstack_instr.h"
 #include "callstack_instr/callstack_instr_ext.h"
-}
 
 #ifdef TARGET_I386
 // shorcuts for accesing the values of x86 registers


### PR DESCRIPTION
Fixes compilation on Fedora 34

---

Together with PR #1022, #1023, #1024, #1025, #1026, this makes it possible to compile Panda on Fedora 34 (which has very recent software) with the following command, after installing the appropriate dependencies from the distribution's repos:

`LLVM_CONFIG_BINARY=llvm-config-11-64 ../build.sh --python x86_64-softmmu  --disable-werror --disable-xen --extra-cxxflags=-I/usr/include/z3`

There are still some warnings which would need to be fixed to get rid of ``--disable-werror``.
panda's xen module is not compatible with recent Xen headers. I have not bothered to find the fixes from upstream qemu, thus I just disable Xen support (don't know what it is needed for on Linux anyway).
Regarding z3 (which is used by the taint2 plugin), the z3 headers on Fedora reside in /usr/include/z3. I have tried a workaround with `__has_include` like in PR #1025, however this does not work because /usr/include/z3/z3++.h on Fedora 34 has an `#include<z3.h>` statement (as opposed to `"z3.h"` as in other headers in the same directory), which might be considered a bug in the Fedora package.

Some of these PRs will probably also be helpful when panda will want to support newer Ubuntu releases.