### PR TITLE
Install scripts bugfix: install pycparser

### DIFF
--- a/.github/workflows/parallel_tests.yml
+++ b/.github/workflows/parallel_tests.yml
@@ -97,6 +97,7 @@ jobs:
       run: |
         docker system prune -af --filter "until=72h"
         docker builder prune -af --filter "until=72h"
+        [[ ! -z "$GITHUB_WORKSPACE" ]] && rm -rf $GITHUB_WORKSPACE
 
   build_and_check_fork: # Forked repos can't use self-hosted test suite - just checkout and run make check
     if: github.repository != 'panda-re/panda'

--- a/.github/workflows/parallel_tests.yml
+++ b/.github/workflows/parallel_tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # Clones to $GITHUB_WORKSPACE. NOTE: this requires git > 2.18 (not on ubuntu 18.04 by default) to get .git directory
     - name: Run install_ubuntu.sh
-      run: cd $GITHUB_WORKSPACE/panda/scripts && ./install_ubuntu.sh
+      run: cd $GITHUB_WORKSPACE && ./panda/scripts/install_ubuntu.sh
 
 
   build_container:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN [ -e /tmp/${BASE_IMAGE}_build.txt ] && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     python3 -m pip install --upgrade --no-cache-dir pip && \
-    python3 -m pip install --upgrade --no-cache-dir setuptools wheel && \
-    python3 -m pip install --upgrade --no-cache-dir pycparser "protobuf" "cffi>1.14.3" colorama
+    python3 -m pip install --upgrade --no-cache-dir "cffi>1.14.3"
 
 # Build and install panda
 # Copy repo root directory to /panda, note we explicitly copy in .git directory

--- a/panda/dependencies/ubuntu:18.04_base.txt
+++ b/panda/dependencies/ubuntu:18.04_base.txt
@@ -20,6 +20,8 @@ wget
 libpython3-dev
 
 # pypanda dependencies
+python3-colorama
+python3-protobuf
 genisoimage
 libffi-dev
 

--- a/panda/dependencies/ubuntu:18.04_build.txt
+++ b/panda/dependencies/ubuntu:18.04_build.txt
@@ -23,10 +23,12 @@ llvm-11-dev
 protobuf-c-compiler
 protobuf-compiler
 python3-dev
+python3-pycparser
 zip
 
-# pypanda build dependencies
+# pypanda dependencies
 python3-setuptools
+python3-wheel
 
 # pypanda test dependencies
 gcc-multilib

--- a/panda/dependencies/ubuntu:20.04_base.txt
+++ b/panda/dependencies/ubuntu:20.04_base.txt
@@ -19,6 +19,8 @@ wget
 libpython3-dev
 
 # pypanda dependencies
+python3-colorama
+python3-protobuf
 genisoimage
 libffi-dev
 

--- a/panda/dependencies/ubuntu:20.04_build.txt
+++ b/panda/dependencies/ubuntu:20.04_build.txt
@@ -18,11 +18,13 @@ llvm-11-dev
 protobuf-c-compiler
 protobuf-compiler
 python3-dev
+python3-pycparser
 libpixman-1-dev
 zip
 
-# pypanda build dependencies
+# pypanda dependencies
 python3-setuptools
+python3-wheel
 
 # pypanda test dependencies
 gcc-multilib

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -3,7 +3,7 @@
 # Note that it doesn't actually *install* panda, it just install dependencies and *builds* panda.
 # If you want to install run `make install` in the build directory after this runs
 
-set -e
+set -ex
 
 # Tested for architectures listed in panda/panda/dependencies/
 
@@ -87,6 +87,11 @@ else
   echo "Unsupported Ubuntu version: $version. Create a list of build dependencies in ${dep_base}_{base,build}.txt and try again."
   exit 1
 fi
+
+# PyPANDA needs CFFI from pip (the version in apt is too old)
+# Install system-wide since PyPANDA install will also be system-wide
+$SUDO python3 -m pip install pip
+$SUDO python3 -m pip install "cffi>1.14.3"
 
 progress "Trying to update DTC submodule"
 git submodule update --init dtc || true


### PR DESCRIPTION
A new CI test revealed that install_ubuntu wasn't working from a clean docker ubuntu image. This cleans up how that script was managing dependencies (by moving some pip dependencies into our list of apt packages) and adds some that were missing.

These changes don't really need to be backported to the stable branch as they don't affect any core PANDA code, just a helper script for the install process. But they should be incorporated in our next release.