### PR TITLE
PyPanda Expect.unansi: Fix using prior_lines

### DIFF
--- a/panda/python/core/pandare/panda_expect.py
+++ b/panda/python/core/pandare/panda_expect.py
@@ -110,7 +110,7 @@ class Expect(object):
         # Join prior lines into a single text element in our reformatted list
         reformatted = []
         if len(self.prior_lines):
-            reformatted = [('text', '\n'.join(self.prior_lines))]
+            reformatted = [('text', ['\n'.join(self.prior_lines)])]
 
         # Then split current line into the tuple format describe above
         msg = self.current_line


### PR DESCRIPTION
Later code expects the text to be in an array. Before this fix, only the
first character ended up being taken.