### PR TITLE
panda_unregister_callbacks: Remove all callbacks for each type

### DIFF
--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -541,9 +541,8 @@ void panda_unregister_callbacks(void *plugin)
     for (int i = 0; i < PANDA_CB_LAST; i++) {
         panda_cb_list *plist;
         plist = panda_cbs[i];
-        bool done = false;
         panda_cb_list *plist_head = plist;
-        while (!done && plist != NULL) {
+        while (plist != NULL) {
             panda_cb_list *plist_next = plist->next;
             if (plist->owner == plugin) {
                 // delete this entry -- it belongs to our plugin
@@ -563,9 +562,6 @@ void panda_unregister_callbacks(void *plugin)
                 }
                 // Free the entry we just unlinked
                 g_free(del_plist);
-                // there should only be one callback in list for this plugin so
-                // done
-                done = true;
             }
             plist = plist_next;
         }


### PR DESCRIPTION
Having multiple callbacks per plugin and callback type is a valid use
case.
In fact, this is used by the mem_hooks plugin. Unloading mem_hooks may
crash panda when continuing the execution, since now-unmapped callbacks
are called.

---
See the following code where mem_hooks registers two callbacks for each callback type: https://github.com/panda-re/panda/blob/4a269f5d1ee50ddea1dead82db2bf53fc8e82e7b/panda/plugins/mem_hooks/mem_hooks.cpp#L57-L64