### PR TITLE
Add option to ignore tainted_branch reports from helper functions

### DIFF
--- a/panda/plugins/taint2/README.md
+++ b/panda/plugins/taint2/README.md
@@ -41,9 +41,9 @@ APIs and Callbacks
 
 Name: **on_branch2**
 
-Signature: `typedef void (*on_branch2_t) (Addr addr, uint64_t size)`
+Signature: `typedef void (*on_branch2_t) (Addr addr, uint64_t size, bool from_helper, bool *tainted)`
 
-Description: Called when a branch that depends on tainted data is encountered. The `Addr` parameter (a union of the various types of memory that can be tracked by the taint system) provides the address of the data that the tainted branch depends on.
+Description: Called when a branch that depends on tainted data is encountered. The `Addr` parameter (a union of the various types of memory that can be tracked by the taint system) provides the address of the data that the tainted branch depends on.  The `size` parameter is the number of bytes in the data.  The `from_helper` parameter indicates whether or not this taint report was generated from within a helper function.  The output parameter `tainted` should be set to true by the implementing callback if taint was found on any of the bytes.
 
 Name: **on_taint_change**
 

--- a/panda/plugins/taint2/llvm_taint_lib.h
+++ b/panda/plugins/taint2/llvm_taint_lib.h
@@ -288,13 +288,16 @@ class PandaTaintFunctionPass : public FunctionPass {
 private:
     ShadowState *shad;
     taint2_memlog *taint_memlog;
+    bool processing_helper;
 
 public:
     static char ID;
     PandaTaintVisitor *PTV; // Our LLVM instruction visitor
 
     PandaTaintFunctionPass(ShadowState *shad, taint2_memlog *taint_memlog)
-        : FunctionPass(ID), shad(shad), taint_memlog(taint_memlog), PTV(new PandaTaintVisitor(shad, taint_memlog)) {}
+        : FunctionPass(ID), shad(shad), taint_memlog(taint_memlog),
+		  processing_helper(false),
+		  PTV(new PandaTaintVisitor(shad, taint_memlog)) {}
 
     ~PandaTaintFunctionPass() { }
 
@@ -308,6 +311,20 @@ public:
 
     virtual void getAnalysisUsage(AnalysisUsage &AU) const {
         AU.setPreservesAll();
+    }
+
+    // the processing_helper flag is used to tweak some taint op arguments based
+    // on whether or not instrumenting a helper function
+    void setProcessingHelper() {
+    	processing_helper = true;
+    }
+
+    void clearProcessingHelper() {
+    	processing_helper = false;
+    }
+
+    bool processingHelper() {
+    	return processing_helper;
     }
 };
 

--- a/panda/plugins/taint2/taint2.cpp
+++ b/panda/plugins/taint2/taint2.cpp
@@ -319,9 +319,11 @@ void taint2_enable_taint(void) {
     FPM->doInitialization();
 
     // Populate module with helper function taint ops
+    PTFP->setProcessingHelper();
     for (auto i = mod->begin(); i != mod->end(); i++){
         if (!i->isDeclaration()) PTFP->runOnFunction(*i);
     }
+    PTFP->clearProcessingHelper();
 
     std::cerr << PANDA_MSG "Done processing helper functions for taint." << std::endl;
 

--- a/panda/plugins/taint2/taint2.h
+++ b/panda/plugins/taint2/taint2.h
@@ -35,8 +35,8 @@ typedef const std::set<uint32_t> *LabelSetP;
 // api autogen needs it.  And don't put any compiler directives
 // between this and END_PYPANDA_NEEDS_THIS except includes of other
 // files in this directory that contain subsections like this one.
-typedef void (*on_branch2_t) (Addr, uint64_t, bool*);
-typedef void (*on_indirect_jump_t) (Addr, uint64_t, bool*);
+typedef void (*on_branch2_t) (Addr, uint64_t, bool, bool*);
+typedef void (*on_indirect_jump_t) (Addr, uint64_t, bool, bool*);
 typedef void (*on_taint_change_t) (Addr, uint64_t);
 typedef void (*on_taint_prop_t) (Addr, Addr, uint64_t);
 typedef void (*on_ptr_load_t) (Addr, uint64_t, uint64_t);

--- a/panda/plugins/tainted_branch/README.md
+++ b/panda/plugins/tainted_branch/README.md
@@ -47,7 +47,9 @@ The PANDA log "summary" mode is not really a summary of the PANDA log default mo
 
 In either PANDA log mode, the liveness option can be used to include a list of the labels which have appeared on tainted branches and the number of times each one has appeared.  This option makes it easier to determine if a particular label was ever used to determine which path to take in a conditional branch.
 
-Output in CSV format can also be done in "summary" or default mode.  The "summary" output lists the same information as seen in the PANDA log summary output.  The default mode lists for each tainted branch the guest address of the blocking including the tainted branch, the instruction count, and a space-separated list of labels.  Note that the liveness option cannot be used with CSV output.  It is also not possible to produce PANDA log and CSV output at the same time.
+The "ignore_helpers" option can be used to omit taint reports that are generated from within LLVM helper functions.  This can be useful if the output will be processed by analysis tools that cannot process helper functions.
+
+Output in CSV format can also be done in "summary" or default mode.  The "summary" output lists the same information as seen in the PANDA log summary output.  The default mode lists for each tainted branch the guest address of the block including the tainted branch, the instruction count, and a space-separated list of labels.  Note that the liveness option cannot be used with CSV output.  It is also not possible to produce PANDA log and CSV output at the same time.
 
 Arguments
 ---------
@@ -55,6 +57,7 @@ Arguments
 - `csvfile`: string, optional:  name of file to save CSV output to
 - `indirect_jumps`: boolean, optional: also report indirect jumps
 - `liveness`:  boolean, optional:  report live labels to the PANDA log
+- `ignore_helpers`:  boolean, optional:  do not report taint from within helper functions
 - `summary`: boolean, optional:  only save the ASID and PC of the tainted branches
 
 Dependencies

--- a/panda/python/examples/taint.py
+++ b/panda/python/examples/taint.py
@@ -27,7 +27,7 @@ def read(cpu, tb, fd, buf, cnt):
             panda.taint_label_ram(buf+idx)
 
 @panda.ppp("taint2", "on_branch2")
-def something(addr, pc):
+def something(addr, size, from_helper, tainted):
     print("Tainted branch")
 
 panda.run()


### PR DESCRIPTION
We have a use case where we need to distinguish between tainted branches generated from helper functions, and ones that are generated from the top-level guest code (ie. the LLVM you see in the console output when you do "-d llvm_ir").
The taint2 plugin was changed to add a flag to the tainted branch callback to state whether the call is being made from a helper or not.  The instrumenting of helper functions in taint2 was changed so that the flag is true, whereas it is false in all other cases.
The tainted_branch plugin was modified by adding an option to ignore reports from helper functions.  The default is to not ignore such reports, so any existing tests should not need any changes.