### PR TITLE
Improve data collection for Pandelephant

### DIFF
--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -31,8 +31,10 @@ pri
 pri_dwarf
 pri_simple
 proc_start_linux
+proc_trace
 recctrl
 replaymovie
+rust_skeleton
 scissors
 signal
 snake_hook
@@ -47,4 +49,3 @@ win2000x86intro
 win7x86intro
 wintrospection
 winxpx86intro
-rust_skeleton

--- a/panda/plugins/proc_trace/Makefile
+++ b/panda/plugins/proc_trace/Makefile
@@ -1,0 +1,9 @@
+# Don't forget to add your plugin to config.panda!
+
+# If you need custom CFLAGS or LIBS, set them up here
+CFLAGS+= -std=c++1z
+# LIBS+=
+
+# The main rule for your plugin. List all object-file dependencies.
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
+	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o

--- a/panda/plugins/proc_trace/README.md
+++ b/panda/plugins/proc_trace/README.md
@@ -1,0 +1,94 @@
+Plugin: `proc_trace`
+===========
+
+Summary
+-------
+
+The `proc_trace` plugin uses OSI to determine whenever the guest has switched to a new process. With this information, two modes are available:
+
+1) Dump data about the now-running process to a pandalog (through the C++ plugin in this directory)
+2) Generate a visual representation of which processes ran over time (through the graph.py script in this directory).
+
+To use the plugin in the first mode, you'll load it as a standard panda plugin: `-panda proc_trace`.
+To load the plugin in  the second mode, you'll just load the `graph.py` script using snake_hook: `-panda snake_hook:files=/path/to/graph.py`
+
+Arguments
+---------
+
+* None
+
+Dependencies
+------------
+
+Depends on the **osi** plugin to provide OS introspection information.
+
+APIs and Callbacks
+------------------
+
+None. This plugin simply uses OSI's `on_task_change` callback.
+
+Example
+-------
+
+To run the `proc_trace` C++ plugin on an Ubuntu x64 recording:
+
+```
+panda-system-x86_64 -m 1G \
+  -os linux-64-ubuntu:4.15.0-72-generic-noaslr-nokaslr \
+  -pandalog out.plog -replay trace_test -panda proc_trace
+```
+
+To generate a graph of which processes ran over time, use the `snake_hook` plugin to load graph.py:
+
+```
+panda-system-x86_64 -m 1G \
+  -os linux-64-ubuntu:4.15.0-72-generic-noaslr-nokaslr \
+  -replay trace_test -panda snake_hook:files=graph.py
+```
+
+
+This will generate output like:
+```
+ Ins.Count PID   TID  First       Last     Names
+   8244033 7     7    39191    -> 8283224  ksoftirqd/0
+   8227419 884   884  112851   -> 8340270  bash
+   8060353 8     8    282458   -> 8342811  rcu_sched
+   7189204 1355  1355 993885   -> 8183089  bash, find
+   6588162 1356  1356 1489188  -> 8077350  bash, md5sum
+   4577872 350   350  124967   -> 4702839  systemd-journal
+   4448539 558   571  2120743  -> 6569282  gmain
+   2341708 924   924  167161   -> 2508869  systemd-resolve
+   1637794 551   582  70060    -> 1707854  in:imklog
+   1478152 551   583  927915   -> 2406067  rs:main Q:Reg
+   1166624 151   151  2416041  -> 3582665  kworker/0:1H
+    827710 506   506  197924   -> 1025634  systemd-network
+    369644 279   279  3210725  -> 3580369  jbd2/sda1-8
+    145075 31    31   83641    -> 228716   kworker/0:1
+     83991 155   155  162163   -> 246154   kworker/0:2
+     55199 2     2    142724   -> 197923   kthreadd
+     52686 1353  1353 211354   -> 264040   kthreadd, kwatchdog
+     52116 1354  1354 237598   -> 289714   kthreadd, kworker/0:0
+      6328 5     5    77312    -> 83640    kworker/u2:0
+      5833 10    10   231764   -> 237597   migration/0
+PID  TID  | --------------------------------------------------------HISTORY--------------------------------------------------------| NAMES
+2    2    | ▂▂                                                                                                                     | kthreadd
+5    5    | ▂                                                                                                                      | kworker/u2:0
+7    7    |▄  ▂                                                                                                                    | ksoftirqd/0
+8    8    |    ▅        ▂▄     ▂▂▆▆▅▇▇▇▆▃         ▃▇▇▇▇ ▃▆▂       ▂▇▇▇▇▇▇▇▇▇▇▃▂          ▆▇▇▇▇▇▇▇▇▇▇▇▇▇▅▄▇▇▇▇▇▇▇▆▇▇▇▇▅▇▇▇▇▅   ▂▄▆▅ | rcu_sched
+10   10   |                                                                                                                        | migration/0
+31   31   | ▂▂                                                                                                                     | kworker/0:1
+151  151  |                                  ▂         ▇▄  ▅▆▂                                                                     | kworker/0:1H
+155  155  |                                                                                                                        | kworker/0:2
+279  279  |                                               ▃▃ ▃                                                                     | jbd2/sda1-8
+350  350  | ▂ ▂   ▃▂▂   ▃  ▆                 ▃    ▂           ▃▅▃▂▆                                                                | systemd-journal
+506  506  |  ▃     ▂ ▃                                                                                                             | systemd-network
+551  583  |             ▂▂▇        ▃    ▄  ▆▂                                                                                      | rs:main Q:Reg
+551  582  |▄    ▆▇▃ ▂ ▆▇▂                                                                                                          | in:imklog
+558  571  |                              ▆▇   ▂▇▇▇▂           ▃                                         ▂                          | gmain
+884  884  | ▃     ▄▄▃▃▂ ▂   ▃                                                                                             ▃▇▇▇▆▄   | bash
+924  924  |         ▂▃   ▂  ▂▇▇▆            ▆▂▄                                                                                    | systemd-resolve
+1353 1353 |  ▂▂                                                                                                                    | kthreadd, kwatchdog
+1354 1354 |   ▂                                                                                                                    | kthreadd, kworker/0:0
+1355 1355 |                ▂▃   ▆▂     ▂   ▂ ▂    ▃       ▃    ▃▃                ▆▇▅                   ▂▂       ▂    ▂             | bash, find
+1356 1356 |                              ▂    ▂           ▂ ▂▄▃ ▂▆           ▄▆▇▇▂ ▃▇▇▇▇▇▂                           ▂             | bash, md5sum
+```

--- a/panda/plugins/proc_trace/graph.py
+++ b/panda/plugins/proc_trace/graph.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+'''
+Create a graph of which processes run/ran over time.
+Supports live systems or recordings
+
+Example usage with a recording of the generic x86 qcow, run from the local directory:
+    panda-system-x86_64 -m 1g -os linux-64-ubuntu:4.15.0-72-generic-noaslr-nokaslr -replay trace_test -panda snake_hook:files=graph.py
+'''
+
+class ProcGraph(PandaPlugin):
+    def __init__(self, panda):
+        # Data collection
+        self.procinfo = {} # PID: info
+        self.time_data = [] # [(PID, #blocks)]
+        self.total_insns = 0
+        self.n_insns = 0
+        self.last_pid = None
+
+        # config options - TODO can we take these as an arg?
+        self.n_cols = 120
+
+        @panda.cb_before_block_exec
+        def bbe(cpu, tb):
+            self.n_insns += tb.icount
+            self.total_insns += tb.icount
+
+        @panda.ppp("osi", "on_task_change")
+        def task_change(cpu):
+            proc = panda.plugins['osi'].get_current_process(cpu)
+            thread = panda.plugins['osi'].get_current_thread(cpu)
+
+            if proc == panda.ffi.NULL:
+                print(f"Warning: Unable to identify process at {self.n_insns}")
+                return
+            if thread == panda.ffi.NULL:
+                print(f"Warning: Unable to identify thread at {self.n_insns}")
+                return
+
+            proc_key = (proc.pid, thread.tid)
+            if proc_key not in self.procinfo:
+                self.procinfo[proc_key] = {"names": set(), #"tids": set(),
+                                      "first": self.total_insns, "last": None,
+                                      "count": 0}
+
+            name = panda.ffi.string(proc.name)  if proc.name != panda.ffi.NULL else "(error)"
+            self.procinfo[proc_key]["names"].add(name)
+
+            # Update insn count for last process and indicate it (maybe) ends at total_insns-1
+            if self.last_pid:
+                # count since we last ran is it's old end value, minus where it just ended
+                self.procinfo[self.last_pid]["count"] += (self.total_insns-1) - self.procinfo[self.last_pid]["last"]  \
+                                                if self.procinfo[self.last_pid]["last"] is not None \
+                                                else (self.total_insns-1) - self.procinfo[self.last_pid]["first"]
+                self.procinfo[self.last_pid]["last"] = self.total_insns-1
+
+            self.last_pid = proc_key
+
+            self.time_data.append((proc_key, self.n_insns))
+            self.n_insns = 0
+
+    def __del__(self):
+        col_size = self.total_insns / self.n_cols
+        pids = set([x for x,y in self.time_data]) # really a list of (pid, tid) tuples
+        merged = {} # pid: [(True, 100), False, 9999)
+
+        for pid in pids:
+            on_off_times = []
+
+            off_count = 0
+
+            for (pid2, block_c) in self.time_data:
+                if pid2 == pid:
+                    # On!
+                    on_off_times.append((True, block_c))
+                else:
+                    # Off
+                    on_off_times.append((False, block_c))
+
+            merged[pid] = on_off_times
+
+        # Render output: Stage 1 - PID -> procname details
+        #   Count   Pid              Name/tid              Asid    First         Last
+        #    297  1355   [bash find  / 1355]          3b14e000   963083  ->  7829616
+
+        print(" Ins.Count PID   TID  First       Last     Names")
+
+        for (pid, tid) in sorted(self.procinfo, key=lambda v: self.procinfo[v]['count'], reverse=True):
+            details = self.procinfo[(pid, tid)]
+            names = ", ".join([x.decode() for x in details['names']])
+            print(f"{details['count']: >10} {pid:<5} {tid:<5}{details['first']:<8} -> {details['last']:<8} {names}")
+
+
+        # Render output: Stage 2: ascii art
+        ascii_art = {} # (pid, tid): art
+        for (pid, tid), times in merged.items():
+            row = ""
+            pending = None
+            queue = merged[(pid, tid)]
+            # Consume data from pending+merged in chunks of col_size
+            # e.g. col_size=10 (True, 8), (False, 1), (True, 10)
+            # simplifies to {True:9, False:1} and adds (True:9) to pending
+
+            for cur_col in range(self.n_cols):
+                counted = 0
+                on_count = 0
+                off_count = 0
+                import ipdb
+                while (counted < col_size and len(queue)): #or pending is not None:
+                    if pending is not None:
+                        (on_bool, cnt) = pending
+                        pending = None
+                    else:
+                        old_len = len(queue)
+                        (on_bool, cnt) = queue.pop(0)
+                        assert(len(queue) < old_len), "pop don't happen"
+
+                    if cnt > col_size-counted: #Hard case: count part, move remainder to pending
+                        remainder = cnt - (col_size-counted)
+                        cnt = col_size-counted # Maximum allowed now
+                        pending = (on_bool, remainder)
+
+                    assert(cnt <= col_size-counted) # Now it's (always) the easy case for what's left
+                    if on_bool:
+                        on_count += cnt
+                    else:
+                        off_count += cnt
+                    counted += cnt
+
+                # /while
+                # Use on_count and off_count to determine how to label this cell
+                density_map = " ▂▃▄▅▆▇"
+                on_count / col_size
+
+                idx = round((on_count/col_size)*(len(density_map)-1))
+                c = density_map[idx]
+                row += c
+
+            ascii_art[(pid, tid)] = row
+
+        # Render art
+        print("PID  TID  | "+ "-"*(self.n_cols//2-4) + "HISTORY" + "-"*(self.n_cols//2-4) + "| NAMES")
+        for (pid, tid) in sorted(ascii_art, key=lambda x: x[0]):
+            row = ascii_art[(pid, tid)]
+            details = self.procinfo[(pid, tid)]
+            names = ", ".join([x.decode() for x in details['names']])
+            print(f"{pid: <4} {tid: <4} |{row}| {names}")

--- a/panda/plugins/proc_trace/proc_trace.cpp
+++ b/panda/plugins/proc_trace/proc_trace.cpp
@@ -1,0 +1,96 @@
+/* PANDABEGINCOMMENT
+ * 
+ * Authors:
+ *  Andrew Fasano          fasano@mit.edu
+ * 
+ * This work is licensed under the terms of the GNU GPL, version 2. 
+ * See the COPYING file in the top-level directory. 
+ * 
+PANDAENDCOMMENT */
+// This needs to be defined before anything is included in order to get
+// the PRIx64 macro
+#define __STDC_FORMAT_MACROS
+
+#include "panda/plugin.h"
+#include "panda/plog.h"
+
+extern "C" {
+#include "osi/osi_types.h"
+#include "osi/osi_ext.h"
+#include "osi/os_intro.h"
+
+
+#include "syscalls2/syscalls_ext_typedefs.h"
+#include "syscalls2/syscalls2_info.h"
+#include "syscalls2/syscalls2_ext.h"
+
+bool init_plugin(void *);
+void uninit_plugin(void *);
+}
+
+// count for non-replay
+uint64_t instr_count = 0;
+
+// returns an instr count
+// either using rr (if we are in replay)
+// or by computing it if we are live
+uint64_t get_instr_count() {
+    if (rr_in_replay())
+        return rr_get_guest_instr_count();
+    else
+        return instr_count;
+}
+
+// Only enable this callback for live guests - we need to track
+// number of instructions since we don't have rr_get_guest_instr_count
+void bbe(CPUState *env, TranslationBlock *tb) {
+    instr_count += tb->icount; // num instr in this block
+}
+
+void task_changed(CPUState *cpu) {
+    OsiProc *proc = get_current_process(cpu);
+    OsiThread *thread = get_current_thread(cpu);
+
+    if (proc == NULL || thread == NULL) {
+        printf("Warning NULL task or process returned from OSI\n");
+        return;
+    }
+
+    Panda__ProcTrace *pt = (Panda__ProcTrace *) malloc(sizeof(Panda__ProcTrace));
+    assert(pt != NULL && "Failed to allocate ProcTrace object");
+    *pt = PANDA__PROC_TRACE__INIT;
+
+    pt->pid =  proc->pid;
+    pt->create_time = proc->create_time;
+    pt->ppid = proc->ppid;
+    pt->name = strdup(proc->name);
+    pt->tid = thread->tid;
+    pt->start_instr = get_instr_count();
+
+    Panda__LogEntry ple = PANDA__LOG_ENTRY__INIT;
+    ple.proc_trace = pt;
+    pandalog_write_entry(&ple);
+    free(pt);
+    free_osithread(thread);
+    free_osiproc(proc);
+}
+
+
+bool init_plugin(void *self) {
+    if (!pandalog) {
+        fprintf(stderr, "ERROR: proc_trace can only be used when a pandalog is specified\n");
+        return false;
+    }
+    panda_require("osi");
+    assert(init_osi_api());
+
+    if (!rr_in_replay()) {
+      panda_cb pcb = { .before_block_exec = bbe };
+      panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+    }
+
+    PPP_REG_CB("osi", on_task_change, task_changed);
+    return true;
+}
+
+void uninit_plugin(void *self) { }

--- a/panda/plugins/proc_trace/proc_trace.proto
+++ b/panda/plugins/proc_trace/proc_trace.proto
@@ -1,0 +1,13 @@
+message ProcTrace {
+    required uint32 pid = 1;
+    required uint64 create_time = 2;
+    required uint32 ppid = 3;
+    required uint64 asid = 4; 
+    required string name = 5;
+    required uint32 tid = 6;
+    required uint64 start_instr = 7;
+    //required uint64 end_instr = 8;
+    //optional uint64 count = 9;
+}
+
+optional ProcTrace proc_trace = 103;

--- a/panda/plugins/proc_trace/trace.py
+++ b/panda/plugins/proc_trace/trace.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+'''
+Generate a recording if one does not exist, then use the on_task_change
+callback to collect information about when various processes are running.
+
+Also load asidstory plugin to compare output.
+'''
+from pandare import Panda
+
+panda = Panda(generic="x86_64")
+
+# If no recording exists, generate one
+rec_name = "trace_test"
+if not panda.recording_exists(rec_name):
+    @panda.queue_blocking
+    def drive():
+        panda.record_cmd("find /tmp | md5sum", recording_name=rec_name)
+        panda.end_analysis()
+    panda.run()
+
+
+# Data collection
+procinfo = {} # PID: info
+time_data = [] # [(PID, #blocks)]
+total_insns = 0
+n_insns = 0
+last_pid = None
+
+@panda.cb_before_block_exec
+def bbe(cpu, tb):
+    global n_insns, total_insns
+    n_insns += tb.icount
+    total_insns += tb.icount
+
+@panda.ppp("osi", "on_task_change")
+def task_change(cpu):
+    proc = panda.plugins['osi'].get_current_process(cpu)
+    thread = panda.plugins['osi'].get_current_thread(cpu)
+
+    global n_insns
+    if proc == panda.ffi.NULL:
+        print(f"Warning: Unable to identify process at {n_insns}")
+        return
+    if thread == panda.ffi.NULL:
+        print(f"Warning: Unable to identify thread at {n_insns}")
+        return
+
+    proc_key = (proc.pid, thread.tid)
+    if proc_key not in procinfo:
+        procinfo[proc_key] = {"names": set(), #"tids": set(),
+                              "first": total_insns, "last": None,
+                              "count": 0}
+
+    name = panda.ffi.string(proc.name)  if proc.name != panda.ffi.NULL else "(error)"
+    procinfo[proc_key]["names"].add(name)
+    #procinfo[proc_key]["tids"].add(thread.tid)
+
+    # Update insn count for last process and indicate it (maybe) ends at total_insns-1
+    global last_pid
+    if last_pid:
+        # count since we last ran is it's old end value, minus where it just ended
+        procinfo[last_pid]["count"] += (total_insns-1) - procinfo[last_pid]["last"]  \
+                                        if procinfo[last_pid]["last"] is not None \
+                                        else (total_insns-1) - procinfo[last_pid]["first"]
+        procinfo[last_pid]["last"] = total_insns-1
+
+    last_pid = proc_key
+
+    time_data.append((proc_key, n_insns))
+    n_insns = 0
+
+# For testing: compare to asidstory
+panda.load_plugin("asidstory", {"width": 120})
+panda.run_replay(rec_name)
+
+# config
+n_cols = 120
+
+# Analyze data
+col_size = total_insns / n_cols
+pids = set([x for x,y in time_data]) # really a list of (pid, tid) tuples
+merged = {} # pid: [(True, 100), False, 9999)
+
+for pid in pids:
+    on_off_times = []
+
+    off_count = 0
+
+    for (pid2, block_c) in time_data:
+        if pid2 == pid:
+            # On!
+            on_off_times.append((True, block_c))
+        else:
+            # Off
+            on_off_times.append((False, block_c))
+
+    merged[pid] = on_off_times
+
+# Render output: Stage 1 - PID -> procname details
+#   Count   Pid              Name/tid              Asid    First         Last
+#    297  1355   [bash find  / 1355]          3b14e000   963083  ->  7829616
+
+print(" Ins.Count PID   TID  First       Last     Names")
+
+for (pid, tid) in sorted(procinfo, key=lambda v: procinfo[v]['count'], reverse=True):
+    details = procinfo[(pid, tid)]
+    names = ", ".join([x.decode() for x in details['names']])
+    print(f"{details['count']: >10} {pid:<5} {tid:<5}{details['first']:<8} -> {details['last']:<8} {names}")
+
+
+# Render output: Stage 2: ascii art
+ascii_art = {} # (pid, tid): art
+for (pid, tid), times in merged.items():
+    row = ""
+    pending = None
+    queue = merged[(pid, tid)]
+    # Consume data from pending+merged in chunks of col_size
+    # e.g. col_size=10 (True, 8), (False, 1), (True, 10)
+    # simplifies to {True:9, False:1} and adds (True:9) to pending
+
+    for cur_col in range(n_cols):
+        counted = 0
+        on_count = 0
+        off_count = 0
+        import ipdb
+        while (counted < col_size and len(queue)): #or pending is not None:
+            #print(f"Cell {cur_col}: Counted {counted} of {col_size} with {len(queue)} remaining. Pending is none: {pending is None}")
+            #ipdb.set_trace()
+            if pending is not None:
+                # Pull from pending
+                #print("Pending POP:", on_bool, cnt)
+                (on_bool, cnt) = pending
+                pending = None
+            else:
+                old_len = len(queue)
+                (on_bool, cnt) = queue.pop(0)
+                #print("Queue POP:", on_bool, cnt)
+                assert(len(queue) < old_len), "pop don't happen"
+
+            if cnt > col_size-counted: #Hard case: count part, move remainder to pending
+                remainder = cnt - (col_size-counted)
+                cnt = col_size-counted # Maximum allowed now
+                #print("Set pending with remainder {remainder}")
+
+                pending = (on_bool, remainder)
+
+            assert(cnt <= col_size-counted) # Now it's (always) the easy case for what's left
+            if on_bool:
+                on_count += cnt
+            else:
+                off_count += cnt
+            counted += cnt
+
+
+        # /while
+        # Use on_count and off_count to determine how to label this cell
+
+        #□▢▭▯▤▥▦▧▨▩▫▣▪▬▮■
+        #" □◍▲◕■"
+        #density_map = " ◌○◔◒◕●"
+        density_map = " ▂▃▄▅▆▇"
+                #      01234567
+        on_count / col_size
+
+        idx = round((on_count/col_size)*(len(density_map)-1))
+        c = density_map[idx]
+        row += c
+
+    ascii_art[(pid, tid)] = row
+
+# Render art
+print("PID  TID  | "+ "-"*(n_cols//2-4) + "HISTORY" + "-"*(n_cols//2-4) + "| NAMES")
+for (pid, tid) in sorted(ascii_art, key=lambda x: x[0]):
+    row = ascii_art[(pid, tid)]
+    details = procinfo[(pid, tid)]
+    names = ", ".join([x.decode() for x in details['names']])
+    print(f"{pid: <4} {tid: <4} |{row}| {names}")

--- a/panda/scripts/plog_to_pandelephant.py
+++ b/panda/scripts/plog_to_pandelephant.py
@@ -10,13 +10,14 @@ import collections
 import pandelephant
 
 # PLogReader from pandare package is easiest to import,
-# but if it's unavailable, fallback to searching PYTHONPATH
+# but if it's unavailable, fallback to searching
+# local directory, then PYTHONPATH
 # which users should add panda/panda/scripts to
 try:
-    from plog_reader import PLogReader
+    from pandare.plog_reader import PLogReader
 except ImportError:
     try:
-        from pandare.plog_reader import PLogReader
+        from plog_reader import PLogReader
     except ImportError:
         import PLogReader
     except ImportError:
@@ -150,7 +151,8 @@ def AssociateThreadsAndProcesses(processes, threads, thread_names):
     for proc in proc2threads.keys():
         print('Process (ProcessId {} ParentProcessId {}) has {} Threads'.format(proc.ProcessId, proc.ParentProcessId, len(proc2threads[proc])))
         for thread in proc2threads[proc]:
-            print('\tThread (ThreadId {} CreateTime {:#x}) names: {}'.format(thread.ThreadId, thread.CreateTime, thread_names[thread]))
+            if thread in thread_names:
+                print('\tThread (ThreadId {} CreateTime {:#x}) names: {}'.format(thread.ThreadId, thread.CreateTime, thread_names[thread]))
 
     return proc2threads, thread2proc
 
@@ -335,7 +337,7 @@ def CollectTaintFlowsAndSyscalls(pandalog, CollectedBetterMappingRanges):
                         CollectFrom[k](msg, getattr(msg, k))
                     except Exception as e:
                         FailCounts[k] += 1
-                        print(e)
+                        print("Exception:", e)
                     break
     for k in CollectFrom.keys():
         print('\t{} Attempts: {}, Failures: {}'.format(k, AttemptCounts[k], FailCounts[k]))

--- a/panda/scripts/plog_to_pandelephant.py
+++ b/panda/scripts/plog_to_pandelephant.py
@@ -54,7 +54,7 @@ CollectedMappingSlice = collections.namedtuple('CollectedMappingSlice', ['Instru
 CollectedMapping = collections.namedtuple('CollectedMapping', ['Name', 'File', 'BaseAddress', 'Size'])
 BetterCollectedMapping = collections.namedtuple('BetterCollectedMapping', ['AddressSpaceId', 'Process', 'Name', 'File', 'BaseAddress', 'Size'])
 CollectedCodePoint = collections.namedtuple('CollectedCodePoint', ['Mapping', 'Offset'])
-CollectedSyscall = collections.namedtuple('CollectedSyscall', ['Name', 'RetVal', 'Thread', 'InstructionCount', 'Arguments'])
+CollectedSyscall = collections.namedtuple('CollectedSyscall', ['Name', 'RetVal', 'Thread', 'InstructionCount', 'Arguments', 'ProgramCounter'])
 CollectedSyscallArgument = collections.namedtuple('CollectedSyscallArgument', ['Name', 'Type', 'Value'])
 CollectedTaintFlow = collections.namedtuple('CollectedTaintFlow', ['IsStore', 'SourceCodePoint', 'SourceThread', 'SourceInstructionCount', 'SinkCodePoint', 'SinkThread', 'SinkInstructionCount'])
 
@@ -240,7 +240,7 @@ def ConvertTaintFlowsAndSyscallsToDatabase(datastore, CollectedSyscalls, Collect
         for a in s.Arguments:
             args.append({'name': a.Name, 'type': a.Type, 'value': a.Value})
         if s.Thread in CollectedThreadToDatabaseThread:
-            CollectedSyscallToDatabaseSyscall[s] = datastore.new_syscall(CollectedThreadToDatabaseThread[s.Thread], s.Name, s.RetVal, args, s.InstructionCount)
+            CollectedSyscallToDatabaseSyscall[s] = datastore.new_syscall(CollectedThreadToDatabaseThread[s.Thread], s.Name, s.RetVal, args, s.InstructionCount, s.ProgramCounter)
 
     for tf in CollectedTaintFlows:
         src_thread = CollectedThreadToDatabaseThread[tf.SourceThread]
@@ -292,7 +292,8 @@ def CollectTaintFlowsAndSyscalls(pandalog, CollectedBetterMappingRanges):
             Arguments=tuple(
                 CollectedSyscallArgument(*syscall_arg_value(arg))
                 for arg in msg.args
-            )
+            ),
+            ProgramCounter=entry.pc
         ))
         return
     def CollectFrom_taint_flow(entry, msg):


### PR DESCRIPTION
1) Update syscalls logger to collect return values, data from fixed-length buffers & port information from `bind` syscalls.
2) Create new plugin proc_trace to use OSI's `on_task_change` callback to identify when processes are started/switched to
3) Updates to pandalog_to_pandelephant to:
3a) support importing data collected by the `proc_trace` plugin
3b) handle the case where thread names are missing
3c) support skipping parts of the import process with CLI flags
3d) prefer pandare.plog_reader over the one in the local directory (these are duplicated scripts and the pandare version is newer than what we've left in panda/scripts which is where plog_to_pandelephant lives)