### PR TITLE
Adding hypercall support to aarch64.

### DIFF
--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -1692,6 +1692,8 @@ For ARM, PANDA specifies coprocessor 7 (p7) as the target of the MCR
 instruction (move to coprocessor from register). p7 is reserved by ARM
 and not implemented in QEMU, so it can be handled without causing
 conflicts.
+For AARCH64, PANDA uses a system register that is not implemented in QEMU.
+Specifically, it uses the instruction `msr S0_0_c5_c0_0, xzr`.
 PANDA also opted out from using an undefined opcode to implement the
 hypercall functionality. This is the approach taken by S2E, but it has
 the drawback that during development you need to output raw bytes

--- a/target/arm/translate-a64.c
+++ b/target/arm/translate-a64.c
@@ -1636,6 +1636,23 @@ static void disas_system(DisasContext *s, uint32_t insn)
         case 4: /* C5.6.130 MSR (immediate) */
             handle_msr_i(s, insn, op1, op2, crm);
             break;
+        case 5: /* PANDA hypercall */
+            /* 'msr S0_0_c5_c0_0, xzr' is used to reach this point:
+                  msr: l=0
+                  S0_0_c5_c0_0: op0=0,op1=0,crn=5,crm=0,op2=0
+                  xzr: rt=31
+            */
+            gen_a64_set_pc_im(s->pc);
+            gen_helper_panda_guest_hypercall(cpu_env);
+
+            /* End block here. This enables using hypercalls to
+             * implement advanced functionality. E.g. to switch
+             * runtime from TCG to LLVM.
+             */
+            /* Is this correct? */
+            gen_goto_tb(s, 0, s->pc);
+
+            break;
         default:
             unallocated_encoding(s);
             break;


### PR DESCRIPTION
I implemented an unused instruction to support hypercalls for aarch64. As noted in the code, I am using the instruction `msr S0_0_c5_c0_0, xzr` to reach the hypercall.