### PR TITLE
Bugfixes for PyPANDA, syscalls_logger, arm snapshotting & panda_current_pc

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -697,9 +697,11 @@ void cpu_address_space_init(CPUState *cpu, AddressSpace *as, int asidx)
         memory_listener_register(&newas->tcg_as_listener, as);
 
         // PANDA Record and Replay
-        rr_listener.region_add = rr_mem_region_added_cb;
-        rr_listener.region_del = rr_mem_region_deleted_cb;
-        memory_listener_register(&rr_listener, as);
+        if (asidx == 0) {
+            rr_listener.region_add = rr_mem_region_added_cb;
+            rr_listener.region_del = rr_mem_region_deleted_cb;
+            memory_listener_register(&rr_listener, as);
+        }
     }
 }
 

--- a/panda/plugins/syscalls_logger/syscalls_logger.cpp
+++ b/panda/plugins/syscalls_logger/syscalls_logger.cpp
@@ -666,12 +666,16 @@ void log_argument(CPUState* cpu, const syscall_info_t *call, int i, Panda__Named
                 assert(strcmp("sys_write", call->name) != 0);
 
                 int len = get_string(cpu, addr, buf);
-                if (len > 0) {
-                    sa->str = strdup((const char *) buf);
-                } else {
-                    sa->str = strdup("n/a");
+                if (sa) {
+                  if (len > 0) {
+                      sa->str = strdup((const char *) buf);
+                  } else {
+                      sa->str = strdup("n/a");
+                  }
+                }else{
+                  printf("\"%.*s\"", (int)len, buf);
                 }
-            }
+              }
             break;
         }
 

--- a/panda/python/core/pandare/panda_expect.py
+++ b/panda/python/core/pandare/panda_expect.py
@@ -6,7 +6,7 @@ import select
 import sys
 import string
 
-from datetime import datetime
+from time import monotonic
 from errno import EAGAIN, EWOULDBLOCK
 from colorama import Fore, Style
 
@@ -354,11 +354,11 @@ class Expect(object):
             raise RuntimeError("Must connect() prior to expect()")
 
         self.current_line = bytearray()
-        start_time = datetime.now()
+        start_time = monotonic()
         time_passed = 0
         while (timeout is None or time_passed < timeout) and self.running:
             if timeout is not None:
-                time_passed = (datetime.now() - start_time).total_seconds()
+                time_passed = (monotonic() - start_time)
                 time_left = timeout - time_passed
             else:
                 time_left = float("inf")

--- a/panda/src/common.c
+++ b/panda/src/common.c
@@ -143,6 +143,9 @@ target_ulong panda_current_asid(CPUState *cpu) {
 }
 
 target_ulong panda_current_pc(CPUState *cpu) {
+    if (cpu == NULL) {
+        return 0;
+    }
     CPUArchState *env = (CPUArchState *)cpu->env_ptr;
     target_ulong pc, cs_base;
     uint32_t flags;


### PR DESCRIPTION
This PR has 4 bug fixes (details in commit messages):
1) Don't crash in panda_current_pc if CPU is null
2) Fix syscalls_logger to not use the pandalog if no pandalog is set
3) Switch pandare's expect timeout to use time.monotonic - fixes #1079 
4) Patch by Collin May to fix #643