### PR TITLE
Install libcapstone v4 in docker/install_ubuntu so we can use callstack_instr plugin for arm

### DIFF
--- a/panda/dependencies/ubuntu:18.04_base.txt
+++ b/panda/dependencies/ubuntu:18.04_base.txt
@@ -1,7 +1,7 @@
 # Panda dependencies
 # Note that 18.04 requires a PPA for llvm11
+# Note that libcapstone >= v4.1 is also required, but that's not available in apt
 git
-libcapstone3
 libdwarf1
 libjsoncpp-dev
 libllvm11

--- a/panda/dependencies/ubuntu:20.04_base.txt
+++ b/panda/dependencies/ubuntu:20.04_base.txt
@@ -1,6 +1,6 @@
 # Panda dependencies
+# Note that libcapstone >= v4.1 is also required, but that's not available in apt
 git
-libcapstone3
 libdwarf1
 libjsoncpp-dev
 libllvm11

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -101,6 +101,17 @@ if [ "$version" -eq 18 ]; then
   rm z3-4.8.7-x64-ubuntu-16.04.zip
 fi
 
+# Because libcapstone for Ubuntu 18 or 20 is really old, we download and install the v4.0.2 release if it's not present
+if [[ !$(ldconfig -p | grep -q libcapstone.so.4) ]]; then
+  echo "Installing libcapstone v4"
+  pushd /tmp && \
+  curl -o /tmp/cap.tgz -L https://github.com/aquynh/capstone/archive/4.0.2.tar.gz && \
+  tar xvf cap.tgz && cd capstone-4.0.2/ && ./make.sh && make install && cd /tmp && \
+  rm -rf /tmp/capstone-4.0.2
+  $SUDO ldconfig
+  popd
+fi
+
 # PyPANDA needs CFFI from pip (the version in apt is too old)
 # Install system-wide since PyPANDA install will also be system-wide
 $SUDO python3 -m pip install pip


### PR DESCRIPTION
Previously we installed capstone from apt which would get an old version of capstone which is unable to identify arm function calls. Our `callstack_isntr` plugin requires at least v4 in order to analyze arm guests.

This PR removes capstone from our dependencies.txt files (since the version we want isn't available through apt) and replaces it with logic in out Dockerfile and install_ubuntu.sh to build it from source.