### PR TITLE
Add PANDA API to inject page faults for i386 and mips

### DIFF
--- a/panda/include/panda/panda_api.h
+++ b/panda/include/panda/panda_api.h
@@ -68,6 +68,8 @@ CPUState* get_cpu(void);
 
 unsigned long garray_len(GArray *list);
 void panda_cleanup_record(void);
+
+void panda_page_fault(CPUState *cpu, target_ulong address, target_ulong retaddr);
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 // don't expose to API  because we don't want to add siginfo_t understanding

--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -394,7 +394,7 @@ class Aarch64Arch(PandaArch):
 
 class MipsArch(PandaArch):
     '''
-    Register names and accessors for MIPS. Handles 32el, 32eb, and mips64
+    Register names and accessors for 32-bit MIPS
     '''
 
     # Registers are:
@@ -513,6 +513,33 @@ class MipsArch(PandaArch):
                 val = -1 * self.panda.from_unsigned_guest(val)
 
         return super().set_retval(cpu, val, convention)
+
+class Mips64Arch(MipsArch):
+    '''
+    Register names and accessors for MIPS64. Inherits from MipsArch for everything
+    except the register name and call conventions.
+    '''
+
+    def __init__(self, panda):
+        super().__init__(panda)
+        regnames = ["zero", "at",   "v0",   "v1",   "a0",   "a1",   "a2",   "a3",
+                    "a4",   "a5",   "a6",   "a7",   "t0",   "t1",   "t2",   "t3",
+                    "s0",   "s1",   "s2",   "s3",   "s4",   "s5",   "s6",   "s7",
+                    "t8",   "t9",   "k0",   "k1",   "gp",   "sp",   "s8",   "ra"]
+
+        self.reg_sp = regnames.index('sp')
+        self.reg_retaddr = regnames.index("ra")
+        # Default syscall/args are for mips 64/n32 - note the registers are different than 32
+        self.call_conventions = {"mips":          ["A0", "A1", "A2", "A3"], # XXX Unsure?
+                                 "syscall": ["V0", "A0", "A1", "A2", "A3", "A4", "A5"]}
+        self.call_conventions['default'] = self.call_conventions['mips']
+
+        self.reg_retval =  {"default":    "V0",
+                            "syscall":    'V0'}
+
+
+        # note names must be stored uppercase for get/set reg to work case-insensitively
+        self.registers = {regnames[idx].upper(): idx for idx in range(len(regnames)) }
 
 class X86Arch(PandaArch):
     '''

--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -485,7 +485,7 @@ class MipsArch(PandaArch):
         '''
         .. Deprecated:: use get_return_address
         '''
-        return self.get_return_addess(cpu)
+        return self.get_return_address(cpu)
 
     def get_return_address(self,cpu):
         '''

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -1001,24 +1001,27 @@ class Panda():
             idx += 1
         return r.decode("utf8", "ignore")
 
-    def to_unsigned_guest(self, x):
+    def to_unsigned_guest(self, x, bits=None):
         '''
         Convert a singed python int to an unsigned int32/unsigned int64
         depending on guest bit-size
 
         Args:
             x (int): Python integer
+            bits (int): Number of bits to treat this value as. If unset, uses architecture default
 
         Returns:
             int: Python integer representing x as an unsigned value in the guest's pointer-size.
         '''
         import ctypes
-        if self.bits == 32:
+        if bits is None:
+            bits = self.bits
+        if bits == 32:
             return ctypes.c_uint32(x).value
-        elif self.bits == 64:
+        elif bits == 64:
             return ctypes.c_uint64(x).value
         else:
-            raise ValueError("Unsupported number of bits")
+            raise ValueError(f"Unsupported number of bits {bits}")
 
     def from_unsigned_guest(self, x):
         '''

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -37,7 +37,7 @@ from .taint import TaintQuery
 from .panda_expect import Expect
 from .asyncthread import AsyncThread
 from .qcows import Qcows
-from .arch import ArmArch, Aarch64Arch, MipsArch, X86Arch, X86_64Arch
+from .arch import ArmArch, Aarch64Arch, MipsArch, Mips64Arch, X86Arch, X86_64Arch
 
 # Might be worth importing and auto-initilizing a PLogReader
 # object within Panda for the current architecture?
@@ -139,7 +139,7 @@ class Panda():
         elif self.arch_name in ["mips", "mipsel"]:
             self.arch = MipsArch(self)
         elif self.arch_name in ["mips64"]:
-            self.arch = MipsArch(self) # XXX: We probably need a different class?
+            self.arch = Mips64Arch(self)
         else:
             raise ValueError(f"Unsupported architecture {self.arch_name}")
         self.bits, self.endianness, self.register_size = self.arch._determine_bits()

--- a/panda/python/core/pandare/pypluginmanager.py
+++ b/panda/python/core/pandare/pypluginmanager.py
@@ -212,6 +212,10 @@ class PyPluginManager:
         '''
         import inspect, importlib
         spec = importlib.util.spec_from_file_location("plugin_file", plugin_file)
+        if spec is None:
+            # Likely an invalid path
+            raise ValueError(f"Unable to load {plugin_file}")
+
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 

--- a/panda/python/examples/fault.py
+++ b/panda/python/examples/fault.py
@@ -1,0 +1,60 @@
+from pandare import Panda
+
+panda = Panda(generic="i386")
+panda.load_plugin("syscalls2", {"load-info": True})
+
+@panda.queue_blocking
+def drive():
+    panda.revert_sync('root')
+    print(panda.run_serial_cmd("md5sum $(which whoami); find /etc/ | md5sum"))
+    panda.end_analysis()
+
+@panda.ppp("syscalls2", "on_all_sys_enter2")
+def all_sys(cpu, pc, call, rp):
+    args = panda.ffi.cast("target_ulong**", rp.args)
+
+    print(f"{pc:#08x} (from block starting at {panda.current_pc(cpu):#08x}): {panda.ffi.string(call.name).decode()}(", end="")
+    if call.nargs == 0:
+        print(")", end="")
+
+    just_dumped = False
+    for i in range(call.nargs):
+        print(f"{panda.ffi.string(call.argn[i]).decode()}=", end="")
+        sep = ", " if i != call.nargs-1 else ")"
+
+        if call.argt[i] not in [0x20, 0x21, 0x22]:
+            val = int(panda.ffi.cast("unsigned int", args[i]))
+            print(hex(val), end="")
+        else:
+            addr = int(panda.ffi.cast("unsigned int", args[i]))
+            if addr < 0xFFFF:
+                # Probably not a pointer?
+                print(hex(addr), end="")
+            else:
+                try:
+                    mem = panda.virtual_memory_read(cpu, addr, 8)
+                except ValueError:
+                    # ignore other args until fault is resolved
+                    print(f"{addr:#x} => Can't read - INJECT PANDA PAGE FAULT") # newline
+
+                    # DO FAULT
+                    panda.libpanda.panda_page_fault(cpu, addr, pc)
+                    # After fault is handled, we'll then re-run the syscall insn (and the TCG-based callback)
+                    break
+
+                # No fault
+                print(f"{addr:#x} => {repr(panda.read_str(cpu, addr))}", end="")
+
+        print(sep, end="") # , or )
+    else:
+        print()
+
+@panda.ppp("syscalls2", "on_all_sys_return2")
+def all_ret(cpu, pc, call, rp):
+    rv = panda.arch.get_return_value(cpu)
+    print(f"\t\t==> {rv:#x}")
+
+
+# XXX: with TB chaining there's a gap between when the syscall happens and our injected PF is handled
+#panda.disable_tb_chaining()
+panda.run()

--- a/panda/python/examples/fault.py
+++ b/panda/python/examples/fault.py
@@ -1,19 +1,33 @@
 from pandare import Panda
 
-panda = Panda(generic="i386")
+panda = Panda(generic="arm")
+#panda = Panda(generic="i386")
+#panda = Panda(generic="x86_64")
+#panda = Panda(generic="mips64")
+
 panda.load_plugin("syscalls2", {"load-info": True})
 
 @panda.queue_blocking
 def drive():
     panda.revert_sync('root')
-    print(panda.run_serial_cmd("md5sum $(which whoami); find /etc/ | md5sum"))
+    print(panda.run_serial_cmd("md5sum $(which whoami); find /etc/ | md5sum; apt-get update -yy"))
     panda.end_analysis()
+
+last_fault = None
+def fault(panda, cpu, addr, pc):
+    global last_fault
+    if last_fault == addr:
+        raise MemoryError(f"Double fault of {addr:x}")
+    last_fault = addr
+    panda.libpanda.panda_page_fault(cpu, addr, pc)
+
 
 @panda.ppp("syscalls2", "on_all_sys_enter2")
 def all_sys(cpu, pc, call, rp):
     args = panda.ffi.cast("target_ulong**", rp.args)
 
-    print(f"{pc:#08x} (from block starting at {panda.current_pc(cpu):#08x}): {panda.ffi.string(call.name).decode()}(", end="")
+    sc_name = panda.ffi.string(call.name).decode() if call.name != panda.ffi.NULL else 'err'
+    print(f"{pc:#08x} (from block starting at {panda.current_pc(cpu):#08x}): {sc_name}(", end="")
     if call.nargs == 0:
         print(")", end="")
 
@@ -25,29 +39,29 @@ def all_sys(cpu, pc, call, rp):
         if call.argt[i] not in [0x20, 0x21, 0x22]:
             val = int(panda.ffi.cast("unsigned int", args[i]))
             print(hex(val), end="")
+            continue
+
+        # It's a pointer type
+        addr = int(panda.ffi.cast("unsigned int", args[i]))
+        if addr < 0xFFFF:
+            # Probably not a pointer?
+            print(hex(addr), end="")
         else:
-            addr = int(panda.ffi.cast("unsigned int", args[i]))
-            if addr < 0xFFFF:
-                # Probably not a pointer?
-                print(hex(addr), end="")
-            else:
-                try:
-                    mem = panda.virtual_memory_read(cpu, addr, 8)
-                except ValueError:
-                    # ignore other args until fault is resolved
+            try:
+                s = panda.read_str(cpu, addr)
+            except ValueError:
+                # This argument can't be read - let's raise a fault on it
+                if last_fault != addr:
                     print(f"{addr:#x} => Can't read - INJECT PANDA PAGE FAULT") # newline
+                    fault(panda, cpu, addr, pc)
+                    return # Raised a fault, hope it's gonna work
+                else:
+                    s = "still can't read"
 
-                    # DO FAULT
-                    panda.libpanda.panda_page_fault(cpu, addr, pc)
-                    # After fault is handled, we'll then re-run the syscall insn (and the TCG-based callback)
-                    break
-
-                # No fault
-                print(f"{addr:#x} => {repr(panda.read_str(cpu, addr))}", end="")
+            # No fault
+            print(f"{addr:#x} => {repr(s)}", end="")
 
         print(sep, end="") # , or )
-    else:
-        print()
 
 @panda.ppp("syscalls2", "on_all_sys_return2")
 def all_ret(cpu, pc, call, rp):

--- a/panda/scripts/scgen.py
+++ b/panda/scripts/scgen.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+'''
+Reformat the syscalls2 prototypes to a mapping from callno to syscall name
+and store the results in syscalls.json in the following format:
+    {
+        'linux_arm':
+            {
+              '0': 'some_syscall',
+              '1': 'another_syscall'
+            },
+        'linux_mips':
+            {
+              ...
+            }
+    }
+
+Unfortunately syscall number keys are stored as strings
+'''
+
+
+import glob
+import json
+from os import path
+
+base = path.join(path.dirname(__file__), "../plugins/syscalls2/generated-in/")
+
+def gen_syscalls(os_arch):
+    syscalls = {}
+    num_sc = {}
+
+    fname = f"{os_arch}_prototypes.txt"
+    target = path.join(base, fname)
+    if not path.isfile(target):
+        raise ValueError(f"Unsupported os_arch: {os_arch} - could not find {target}")
+
+    with open(target) as f:
+        for line in f.readlines():
+            if not len(line):
+                continue
+
+            # num type name(args
+            try:
+                sys_no = int(line.split(" ")[0])
+            except:
+                continue
+            sys_name = line.split(" ")[2].split("(")[0]
+
+            sys_name = sys_name.replace("sys_", "")
+            if sys_name.startswith("do_"):
+                sys_name.replace("do_", "")
+            syscalls[sys_name] = sys_no
+            num_sc[sys_no] = sys_name
+
+    #return syscalls
+    return num_sc
+
+if __name__ == '__main__':
+    results = {}
+    for arch in ['linux_arm', 'linux_mips', 'linux_x64', 'linux_x86']:
+        results[arch] = gen_syscalls(arch)
+    with open("syscalls.json", 'w') as f:
+        json.dump(results, f)

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -288,3 +288,19 @@ unsigned long garray_len(GArray *list) {
 void _panda_set_library_mode(const bool b) {
   panda_set_library_mode(b);
 }
+
+// Raise a page fault on address, then return execution to retaddr
+void panda_page_fault(CPUState* cpu, target_ulong address, target_ulong retaddr) {
+
+#ifdef TARGET_I386
+    CPUX86State *env = cpu->env_ptr;
+
+    // We want to set up CPU state with x86_cpu_handle_mmu_fault
+    // and then interrupt the cpu-exec loop with raise_exception_err_ra
+    // Explicitly set EIP to retaddr so after the exception is handled, we resume from retaddr
+    // instead of restarting the block
+    env->eip = retaddr;
+    tlb_fill(cpu, address, MMU_DATA_LOAD, 0, retaddr);
+
+#endif
+}

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -291,8 +291,10 @@ void _panda_set_library_mode(const bool b) {
 
 // Raise a page fault on address, then return execution to retaddr
 void panda_page_fault(CPUState* cpu, target_ulong address, target_ulong retaddr) {
+  // Update the CPUArchstate so the PC is the desired return address, then call
+  // tlb_fill. This ensures that we always go back to retaddr
 
-#ifdef TARGET_I386
+#if defined(TARGET_I386) //|| defined(TARGET_X86_64)
     CPUX86State *env = cpu->env_ptr;
 
     // We want to set up CPU state with x86_cpu_handle_mmu_fault
@@ -301,34 +303,16 @@ void panda_page_fault(CPUState* cpu, target_ulong address, target_ulong retaddr)
     // instead of restarting the block
     env->eip = retaddr;
     tlb_fill(cpu, address, MMU_DATA_LOAD, 0, retaddr);
+//#elif defined (TARGET_ARM)
+//    CPUARMState *env = cpu->env_ptr;
+//    env->pc = retaddr;
+//    tlb_fill(cpu, address, MMU_DATA_LOAD, 0, retaddr);
+
 #elif defined(TARGET_MIPS)
     CPUMIPSState *env = cpu->env_ptr;
-    CPUState *cs = CPU(mips_env_get_cpu(env));
-    int exception = 26; //26 is EXCP_TLBL. 27 is TLBS
-    int error_code = 1; // EXCP_TLB_NOMATCH;
-
-    env->CP0_BadVAddr = address;
-    env->CP0_Context = (env->CP0_Context & ~0x007fffff) |
-                       ((address >> 9) & 0x007ffff0);
-    target_ulong val = (env->CP0_EntryHi & env->CP0_EntryHi_ASID_mask) |
-                       (env->CP0_EntryHi & (1 << CP0EnHi_EHINV)) |
-                       (address & (TARGET_PAGE_MASK << 1));
-
-    // XXX skip panda callback here - unlike in mips/helper.c
-    env->CP0_EntryHi = val;
-
-#if defined(TARGET_MIPS64)
-    env->CP0_EntryHi &= env->SEGMask;
-    env->CP0_XContext =
-        /* PTEBase */   (env->CP0_XContext & ((~0ULL) << (env->SEGBITS - 7))) |
-        /* R */         (extract64(address, 62, 2) << (env->SEGBITS - 9)) |
-        /* BadVPN2 */   (extract64(address, 13, env->SEGBITS - 13) << 4);
-#endif
-    cs->exception_index = exception;
-    env->error_code = error_code;
-
-    // Break out of the current block so the fault can be handled, then return to our current addr
-    cpu_loop_exit_restore(cs, retaddr);
-
+    env->active_tc.PC = retaddr;
+    tlb_fill(cpu, address, MMU_DATA_LOAD, 0, retaddr);
+#else
+    printf("ERROR: Unsupported architecture for panda_page_fault\n");
 #endif
 }

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -303,16 +303,21 @@ void panda_page_fault(CPUState* cpu, target_ulong address, target_ulong retaddr)
     // instead of restarting the block
     env->eip = retaddr;
     tlb_fill(cpu, address, MMU_DATA_LOAD, 0, retaddr);
-//#elif defined (TARGET_ARM)
-//    CPUARMState *env = cpu->env_ptr;
-//    env->pc = retaddr;
-//    tlb_fill(cpu, address, MMU_DATA_LOAD, 0, retaddr);
+#elif defined (TARGET_ARM)
+    CPUARMState *env = cpu->env_ptr;
+    if (is_a64(env)) {
+      env->pc = retaddr; // PC for aarch64
+    } else {
+      env->regs[15] = retaddr; // PC for arm32
+    }
+    tlb_fill(cpu, address, MMU_DATA_LOAD, 0, retaddr);
 
 #elif defined(TARGET_MIPS)
     CPUMIPSState *env = cpu->env_ptr;
     env->active_tc.PC = retaddr;
     tlb_fill(cpu, address, MMU_DATA_LOAD, 0, retaddr);
 #else
-    printf("ERROR: Unsupported architecture for panda_page_fault\n");
+    printf("\n\nnERROR: Unsupported architecture for panda_page_fault!!\n\n");
+    assert(0);
 #endif
 }


### PR DESCRIPTION
If a `panda_virtual_memory_...` function fails due to paged out memory, `panda_page_fault()` allows you to force the guest to page in that memory and return execution to a PC of your choice (typically the same PC you were at before).

Using this as a fallback for when memory is unavailable requires some intentional design of your analysis code - if you identify that memory is unavailable, you should request the page fault, bail, and then have your analysis restart after the page fault is resolved. With `syscalls2` based callbacks, this is easy as you will get the `on_sys_...` callback again after the fault is resolved. In other situations, it may be more difficult.
