### PR TITLE
PyPANDA: add option to raise exceptions - use this mode from snake_hook

### DIFF
--- a/panda/plugins/snake_hook/src/loader.rs
+++ b/panda/plugins/snake_hook/src/loader.rs
@@ -51,7 +51,7 @@ pub(crate) fn initialize_pyplugins(args: Args) {
     let context: Context = python! {
         from pandare import Panda
 
-        panda = Panda(arch='ARCH, libpanda_path='libpanda_path)
+        panda = Panda(arch='ARCH, libpanda_path='libpanda_path, catch_exceptions=False)
 
         if 'use_flask:
             from flask import Flask, Blueprint


### PR DESCRIPTION
Previously, PyPANDA would detect exceptions in ppp functions and callbacks and call `panda.end_analysis()` and then later print the exception after the guest has stopped.

However, when running PyPANDA scripts from snake_hook this would result in exceptions being silently swallowed and ignored.