### PR TITLE
Standardize PyPlugin interface for rust/pypanda

### DIFF
--- a/panda/docs/pyplugins.md
+++ b/panda/docs/pyplugins.md
@@ -1,0 +1,69 @@
+# PANDA PyPlugins
+
+PyPlugins are Python3 classes which implement some reusable PANDA capability.
+
+The anatomy of a PANDA PyPlugin in its current form is one or more types which subclass `PandaPlugin`. The constructor takes a `panda` object, which is of type [pandare.Panda](https://docs.panda.re/panda.html#pandare.panda.Panda).
+
+From there, you can add hooks and declare initial state for your plugin. The destructor (`__del__`) is optional, but can be used to perform cleanup when `snake_hook` is unloaded.
+
+## API Docs
+
+* `PandaPlugin`:
+  * `get_arg(name)` - returns either the argument value as a string or `None` if the argument is not present
+  * `get_arg_bool(name)` - returns `True` if the argument is present and truthy.
+
+
+# Examples
+
+## Trivial plugin
+```py
+from pandare import PandaPlugin
+
+class TestPlugin(PandaPlugin):
+    def __init__(self, panda):
+        print("Initialized test plugin")
+        
+        @panda.cb_before_block_exec
+        def before_block(cpustate, transblock):
+            panda.unload_plugin("snake_hook")
+            print("snake_hook unloaded")
+
+    def __del__(self):
+        print("Uninitialized test plugin")
+```
+
+## Basic block counter
+```python
+from pandare import PandaPlugin
+
+class BasicBlockCount(PandaPlugin):
+    def __init__(self, panda):
+        self.bb_count = 0
+
+        @panda.cb_before_block_exec
+        def my_before_block_fn(_cpu, _trans):
+            self.bb_count += 1
+
+    def webserver_init(self, app):
+        @app.route("/")
+        def test_index():
+            return """<html>
+            <body>
+                <p>
+                    Basic Block Count: <span id="bb_count">""" + str(self.bb_count) +  """</span>
+                </p>
+            </body>
+            </html>"""
+```
+
+
+## Hello
+```py
+class TestPlugin(PandaPlugin):
+    def __init__(self, panda):
+        path = self.get_arg('path')
+        print(f"path = {path}")
+        should_print_hello = self.get_arg_bool('should_print_hello')
+        if should_print_hello:
+            print("Hello!")
+```

--- a/panda/plugins/snake_hook/README.md
+++ b/panda/plugins/snake_hook/README.md
@@ -61,7 +61,7 @@ class BasicBlockCount(PandaPlugin):
             return """<html>
             <body>
                 <p>
-                    Basic Block Count: <span id="bb_count">""" + self.bb_count +  """</span>
+                    Basic Block Count: <span id="bb_count">""" + str(self.bb_count) +  """</span>
                 </p>
             </body>
             </html>"""

--- a/panda/plugins/snake_hook/README.md
+++ b/panda/plugins/snake_hook/README.md
@@ -1,6 +1,6 @@
 # snake_hook
 
-A compiled plugin for running [PyPlugins](../../..//docs/pyplugins.md) Unlike traditional pypanda usage, this allows PANDA to drive python, rather than python driving PANDA. This allows for a higher level of uncoordinated composability than is possible from using pypanda itself.
+A compiled plugin for running [PyPlugins](/panda/docs/pyplugins.md) Unlike traditional pypanda usage, this allows PANDA to drive python, rather than python driving PANDA. This allows for a higher level of uncoordinated composability than is possible from using pypanda itself.
 
 ### Example Usage
 
@@ -20,7 +20,7 @@ panda-system-x86_64 -panda snake_hook:files=print_pcs.py:print_strings.py -nogra
 
 ### PyPlugins
 
-See [docs/pyplugins.md](../../../docs/pyplugins.md) for examples and details of PyPlugins.
+See [docs/pyplugins.md](/panda/docs/pyplugins.md) for examples and details of PyPlugins.
 
 Note that when `snake_hook` is unloaded, it will call a destructor if you have defined one in your class.
 

--- a/panda/plugins/snake_hook/README.md
+++ b/panda/plugins/snake_hook/README.md
@@ -1,6 +1,6 @@
 # snake_hook
 
-A plugin for running pypanda scripts in a plugin-style architecture. Unlike traditional pypanda usage, this allows PANDA to drive python, rather than python driving PANDA. This allows for a higher level of uncoordinated composability than is possible from using pypanda itself.
+A compiled plugin for running [PyPlugins](../../..//docs/pyplugins.md) Unlike traditional pypanda usage, this allows PANDA to drive python, rather than python driving PANDA. This allows for a higher level of uncoordinated composability than is possible from using pypanda itself.
 
 ### Example Usage
 
@@ -18,29 +18,15 @@ panda-system-x86_64 -panda snake_hook:files=print_pcs.py:print_strings.py -nogra
 
 \*See 'passing arguments to plugins' for more info
 
-### Example Plugin
+### PyPlugins
 
-```py
-class TestPlugin(PandaPlugin):
-    def __init__(self, panda):
-        print("Initialized test plugin")
-        
-        @panda.cb_before_block_exec
-        def before_block(cpustate, transblock):
-            panda.unload_plugin("snake_hook")
-            print("snake_hook unloaded")
+See [docs/pyplugins.md](../../../docs/pyplugins.md) for examples and details of PyPlugins.
 
-    def __del__(self):
-        print("Uninitialized test plugin")
-```
-
-The anatomy of a pypanda plugin in its current form is one or more types which subclass `PandaPlugin` (`PandaPlugin` is a type that will already be in scope). The constructor takes a `panda` object, which is of type [pandare.Panda](https://docs.panda.re/panda.html#pandare.panda.Panda).
-
-From there, you can add hooks and declare initial state for your plugin. The destructor (`__del__`) is optional, but can be used to perform cleanup when `snake_hook` is unloaded.
+Note that when `snake_hook` is unloaded, it will call a destructor if you have defined one in your class.
 
 ### Flask Integration
 
-Example plugins can be found in the [pypanda-plugins](https://github.com/panda-re/pypanda-plugins) repository, [in the plugins folder](https://github.com/panda-re/pypanda-plugins/tree/main/plugins).
+Example PyPANDA Plugins can be found in the [pypanda-plugins](https://github.com/panda-re/pypanda-plugins) repository, [in the plugins folder](https://github.com/panda-re/pypanda-plugins/tree/main/plugins).
 
 Each plugin can host its own endpoints under `localhost:port/[plugin_name]` by means of declaring a `webpage_init(app)` then writing a flask application using `app` as normal. In order to mount all plugin-specifc routes under `/[plugin_name]/` the variable `app` is a [`Blueprint`](https://flask.palletsprojects.com/en/2.0.x/blueprints/). If you need access to the `Flask` object itself, use `self.flask` (`flask` is a member of the `PandaPlugin` class).
 
@@ -48,30 +34,14 @@ Note: `plugin_name` is the class name of the subclass of `PandaPlugin`. So a plu
 
 ```python
 class BasicBlockCount(PandaPlugin):
-    def __init__(self, panda):
-        self.bb_count = 0
-
-        @panda.cb_before_block_exec
-        def my_before_block_fn(_cpu, _trans):
-            self.bb_count += 1
-
-    def webserver_init(self, app):
-        @app.route("/")
-        def test_index():
-            return """<html>
-            <body>
-                <p>
-                    Basic Block Count: <span id="bb_count">""" + str(self.bb_count) +  """</span>
-                </p>
-            </body>
-            </html>"""
+    ...
 ```
 
 Will be mounted at `https://localhost:8080/BasicBlockCount` by default.
 
 ### Passing Arguments to Plugins
 
-Arguments passed to pypanda plugins take the form of `file_path.py|arg=value|bool_arg|arg2=val`, where `|` separates arguments, arguments themselves take the form of `key=value` (or for bool args, just `key` for true, alternatively '1', 'yes', 'y', and 'true' are all accepted as truthy).
+Arguments passed to pypanda plugins via `snake_hook` take the form of `file_path.py|arg=value|bool_arg|arg2=val`, where `|` separates arguments, arguments themselves take the form of `key=value` (or for bool args, just `key` for true, alternatively '1', 'yes', 'y', and 'true' are all accepted as truthy).
 
 #### API Docs
 
@@ -79,8 +49,7 @@ Arguments passed to pypanda plugins take the form of `file_path.py|arg=value|boo
   * `get_arg(name)` - returns either the argument as a string or `None` if the argument wasn't passed (arguments passed in bool form instead of key/value form will also return `None`)
   * `get_arg_bool(name)` - returns `True` if the argument is truthy (either by passing the argument with no value, or with a value of any of the following: '1', 'yes', 'y', 'true'), otherwise returns `False`
 
-#### Example
-
+#### Snake_hook examples
 ```py
 class TestPlugin(PandaPlugin):
     def __init__(self, panda):

--- a/panda/plugins/snake_hook/src/loader.rs
+++ b/panda/plugins/snake_hook/src/loader.rs
@@ -116,6 +116,12 @@ pub(crate) fn initialize_pyplugins(args: Args) {
                     // inject the 'PandaPlugin' type into execution before running the module
                     plugin.PandaPlugin = 'panda_plugin
 
+                    // A script may import the normal PandaPlugin class from pandare.extras
+                    // but we need to overwrite that with the rust PandaPlugin class in order
+                    // for all our snake_hook stuff to work.
+                    import pandare.extras
+                    pandare.extras.PandaPlugin = 'panda_plugin
+
                     // run the module so any types can be declared
                     spec.loader.exec_module(plugin)
                 });

--- a/panda/plugins/snake_hook/src/loader.rs
+++ b/panda/plugins/snake_hook/src/loader.rs
@@ -116,11 +116,11 @@ pub(crate) fn initialize_pyplugins(args: Args) {
                     // inject the 'PandaPlugin' type into execution before running the module
                     plugin.PandaPlugin = 'panda_plugin
 
-                    // A script may import the normal PandaPlugin class from pandare.extras
+                    // A script may import the normal PandaPlugin class from pandare
                     // but we need to overwrite that with the rust PandaPlugin class in order
                     // for all our snake_hook stuff to work.
-                    import pandare.extras
-                    pandare.extras.PandaPlugin = 'panda_plugin
+                    import pandare
+                    pandare.PandaPlugin = 'panda_plugin
 
                     // run the module so any types can be declared
                     spec.loader.exec_module(plugin)

--- a/panda/python/core/pandare/__init__.py
+++ b/panda/python/core/pandare/__init__.py
@@ -12,8 +12,9 @@ Example plugins are available in the [examples directory](https://github.com/pan
 
 from .panda import Panda, blocking
 from .plog_reader import PLogReader
+from .panda_plugin import PandaPlugin
 
-__all__ = ['Panda', 'PLogReader', 'Callbacks']
+__all__ = ['Panda', 'PLogReader', 'Callbacks', 'PandaPlugin']
 
 __pdoc__ = {}
 

--- a/panda/python/core/pandare/extras/__init__.py
+++ b/panda/python/core/pandare/extras/__init__.py
@@ -10,6 +10,8 @@ from .fileHook import FileHook
 from .ioctlFaker import IoctlFaker
 from .modeFilter import ModeFilter
 from .procWriteCapture import ProcWriteCapture
+from .snake import PandaPlugin, Snake
 
 
-__all__ = ['FakeFile', 'FileFaker', 'FileHook', 'IoctlFaker', 'ModeFilter', 'ProcWriteCapture']
+__all__ = ['FakeFile', 'FileFaker', 'FileHook', 'IoctlFaker', 'ModeFilter', 'ProcWriteCapture',
+           'PandaPlugin', 'Snake']

--- a/panda/python/core/pandare/extras/__init__.py
+++ b/panda/python/core/pandare/extras/__init__.py
@@ -10,7 +10,6 @@ from .fileHook import FileHook
 from .ioctlFaker import IoctlFaker
 from .modeFilter import ModeFilter
 from .procWriteCapture import ProcWriteCapture
-from .snake import PandaPlugin, Snake
 
 
 __all__ = ['FakeFile', 'FileFaker', 'FileHook', 'IoctlFaker', 'ModeFilter', 'ProcWriteCapture',

--- a/panda/python/core/pandare/extras/snake.py
+++ b/panda/python/core/pandare/extras/snake.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+
+"""
+Class to manage loading PyPANDA plugins of standard format
+which is compatable with the snake_hook plugin for CLI-panda
+"""
+
+class PandaPlugin:
+    def __init__(self, panda):
+        '''
+        Base class which PyPANDA plugins should inherit. Subclasses may
+        register callbacks using the provided panda object and use
+        PandaPlugin.get_args or PandaPlugin.get_arg_bool to check argument
+        values (note these helpers should be accessed with `self.get_...`).
+
+        This PyPANDA extra aims to mirror the snake_hook (rust) plugin
+        so a single PyPANDA plugin can be used from both pure PyPANDA (with this class)
+        or from CLI panda with snake_hook.
+
+        For more information, read the snake_hook documentation
+        '''
+        pass
+
+    def __preinit__(self, args):
+        self.args = args
+
+    def get_arg(self, arg_name):
+        '''
+        returns either the argument as a string or None if the argument
+        wasn't passed (arguments passed in bool form (i.e., set but with no value)
+        instead of key/value form will also return None).
+        '''
+        if arg_name in self.args:
+            return self.args[arg_name]
+
+        return None
+
+    def get_arg_bool(self, arg_name):
+        '''
+        returns True if the argument is True
+        '''
+        return arg_name in self.args and self.args[arg_name]==True
+
+
+class Snake:
+    def __init__(self, panda, flask=False, port=8080, host='127.0.0.1'):
+        '''
+        panda- a panda object
+        flask - a bool indicating whether to enable the flask server
+        port - a number (0-65535) indicating the port number to host the flask server at
+                (default: 8080)
+        host - host for flask server to listen on
+        '''
+        self.panda = panda
+        self.plugins = {}
+
+        # Flask specific vars
+        self.flask = flask
+        self.port = port
+        self.host=host
+        self.flask_thread = None
+        self.app = None
+        self.blueprint = None
+
+        if self.flask:
+            from flask import Flask, Blueprint
+            self.app = Flask(__name__)
+            self.blueprint = Blueprint
+
+    def register(self, pluginclass, args=None, name=None):
+        '''
+        Register a PyPANDA plugin  to run. It can later be unloaded
+        by using Snake.unregister(name). If name is unspecified, a
+        string representation of the class will be used instead
+        '''
+
+        if args is None:
+            args = {}
+        # This is a little tricky - we can't just instantiate
+        # an instance of the object- it may use self.get_arg
+        # in its init method. To allow this behavior, we create
+        # the object, use the __preinit__ function defined above
+        # and then ultimately call the __init__ method
+        # See https://stackoverflow.com/a/6384982/2796854
+
+        if not isinstance(pluginclass, type) or not issubclass(pluginclass, PandaPlugin):
+            raise ValueError(f"pluginclass must be an uninstantiated subclass of PandaPlugin")
+
+        if name is None:
+            name = pluginclass.__name__ 
+
+        self.plugins[name] = pluginclass.__new__(pluginclass)
+        self.plugins[name].__preinit__(args)
+        self.plugins[name].__init__(self.panda)
+
+        # Setup webserver if necessary
+        if self.flask:
+            self.plugins[name].flask = self.app
+            bp = self.blueprint(name, __name__)
+            self.plugins[name].webserver_init(bp)
+            self.app.register_blueprint(bp, url_prefix="/" + name)
+
+    def unregister(self, pluginclass, name=None):
+        if name is None:
+            name = pluginclass.__name__ 
+        del self.plugins[name]
+
+    def is_registered(self, pluginclass, name=None):
+        if name is None:
+            name = pluginclass.__name__ 
+        return name in self.plugins
+
+    def serve(self):
+        assert(self.flask)
+        assert(self.flask_thread is None)
+        from threading import Thread
+        self.flask_thread = Thread(target=self._do_serve, daemon=True)
+        self.flask_thread.start() # TODO: shut down more gracefully?
+
+    def _do_serve(self):
+        print("Started thread")
+        assert(self.flask)
+
+        @self.app.route("/")
+        def index():
+            return "PANDA web server"
+
+        self.app.run(host=self.host, port=self.port)
+
+if __name__ == '__main__':
+    from pandare import Panda
+    panda = Panda(generic="x86_64")
+
+    globals()['_test_class_init_ran'] = False
+    globals()['_test_get_arg_foo'] = False
+    globals()['_test_print_hello_false'] = False
+    globals()['_test_print_hello2_true'] = False
+    globals()['_test_deleted'] = False
+
+    class TestPlugin(PandaPlugin):
+        def __init__(self, panda):
+            path = self.get_arg('path')
+            print(f"path = {path}")
+            global _test_class_init_ran, _test_get_arg_foo, \
+                   _test_print_hello_false, _test_print_hello2_true
+            _test_class_init_ran = True
+            _test_get_arg_foo = path == "/foo"
+
+            should_print_hello = self.get_arg_bool('should_print_hello')
+            if should_print_hello:
+                print("Hello!")
+            else:
+                _test_print_hello_false = True
+
+            should_print_hello2 = self.get_arg_bool('should_print_hello2')
+            if should_print_hello2:
+                _test_print_hello2_true = True
+
+
+        def __del__(self):
+            global _test_deleted
+            _test_deleted = True
+    s = Snake(panda)
+    s.register(TestPlugin, {'path': '/foo', 'should_print_hello': False,
+                                            'should_print_hello2': True})
+    @panda.queue_blocking
+    def driver():
+        panda.revert_sync("root")
+        assert(panda.run_serial_cmd("whoami") == 'root'), "Bad guest behavior"
+        s.unregister(TestPlugin)
+        panda.end_analysis()
+
+    panda.run()
+
+    for k in ['_test_class_init_ran', '_test_print_hello_false', '_test_get_arg_foo',
+              '_test_print_hello2_true','_test_deleted']:
+        assert(globals()[k] == True), f"Failed test {k}"

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -1066,6 +1066,9 @@ class Panda():
     # PyPlugin helpers
     @property
     def pyplugin(self):
+        """
+        A reference to an auto-instantiated `pandare.pyplugin.PyPluginManager` class.
+        """
         if not hasattr(self, "_pyplugin_manager"):
             from .pyplugin import PyPluginManager
             self._pyplugin_manager = PyPluginManager(self)

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -1063,6 +1063,16 @@ class Panda():
             self.queue_async(f)
         return f
 
+    # PyPlugin helpers
+    @property
+    def pyplugin(self):
+        if not hasattr(self, "_pyplugin_manager"):
+            from .pyplugin import PyPluginManager
+            self._pyplugin_manager = PyPluginManager(self)
+        return self._pyplugin_manager
+
+
+
 
     ########################## LIBPANDA FUNCTIONS ########################
     # Methods that directly pass data to/from PANDA with no extra logic beyond argument reformatting.

--- a/panda/python/core/pandare/panda_plugin.py
+++ b/panda/python/core/pandare/panda_plugin.py
@@ -1,0 +1,37 @@
+class PandaPlugin:
+    def __init__(self, panda):
+        '''
+        Base class which PyPANDA plugins should inherit. Subclasses may
+        register callbacks using the provided panda object and use
+        PandaPlugin.get_args or PandaPlugin.get_arg_bool to check argument
+        values (note these helpers should be accessed with `self.get_...`).
+
+        This PyPANDA extra aims to mirror the snake_hook (rust) plugin
+        so a single PyPANDA plugin can be used from both pure PyPANDA (with this class)
+        or from CLI panda with snake_hook.
+
+        For more information, read the snake_hook documentation
+        '''
+        pass
+
+    def __preinit__(self, args):
+        self.args = args
+
+    def get_arg(self, arg_name):
+        '''
+        returns either the argument as a string or None if the argument
+        wasn't passed (arguments passed in bool form (i.e., set but with no value)
+        instead of key/value form will also return None).
+        '''
+        if arg_name in self.args:
+            return self.args[arg_name]
+
+        return None
+
+    def get_arg_bool(self, arg_name):
+        '''
+        returns True if the argument is True
+        '''
+        return arg_name in self.args and self.args[arg_name]==True
+
+

--- a/panda/python/core/pandare/pyplugin.py
+++ b/panda/python/core/pandare/pyplugin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Class to manage loading Panda PyPlugins. Compatable with the snake_hook plugin for CLI-panda
+Class to manage loading Panda PyPlugins. See docs/pyplugins.md for details.
 """
 from pathlib import Path
 from pandare import PandaPlugin
@@ -9,12 +9,9 @@ from pandare import PandaPlugin
 class PyPluginManager:
     def __init__(self, panda, flask=False, host='127.0.0.1', port=8080, silence_warning=False):
         '''
-        panda- a panda object
-        flask - a bool indicating whether to enable the flask server
-        port - a number (0-65535) indicating the port number to host the flask server at
-                (default: 8080)
-        host - host for flask server to listen on
+        Set up an instance of PyPluginManager.
         '''
+
         self.panda = panda
         self.plugins = {}
         self.silence_warning = silence_warning
@@ -30,11 +27,16 @@ class PyPluginManager:
             self.enable_flask(host, port)
 
     def enable_flask(self, host='127.0.0.1', port=8080):
+        '''
+        Enable flask mode for this instance of the PyPlugin manager. Registered PyPlugins
+        which support flask will be made available at the web interfaces.
+        '''
         if len(self.plugins) and not self.silence_warning:
             print("WARNING: You've previously registered some PyPlugins prior to enabling flask")
             print(f"Plugin(s) {self.plugins.keys()} will be unable to use flask")
 
         from flask import Flask, Blueprint
+        self.flask = True
         self.app = Flask(__name__)
         self.blueprint = Blueprint
         self.host = host
@@ -52,7 +54,7 @@ class PyPluginManager:
 
         Note you can also just add `from pandare import PandaPlugin` to
         the plugin file and then just import the class(es) you want and pass them
-        directly to snake.register()
+        directly to panda.pyplugin.register()
 
         This avoids the `NameError: name 'PandaPlugin' is not defined` which
         you would get from directly doing `import [class_name] from [plugin_file]`
@@ -73,7 +75,7 @@ class PyPluginManager:
     def register(self, pluginclass, args=None, name=None, template_dir=None):
         '''
         Register a PyPANDA plugin  to run. It can later be unloaded
-        by using Snake.unregister(name).
+        by using panda.pyplugin.unregister(name).
 
         pluginclass can either be an uninstantiated python class
         or a tuple of (path_to_module.py, classname) where classname subclasses PandaPlugin.
@@ -118,7 +120,7 @@ class PyPluginManager:
                 elif (Path(".") / "templates").exists():
                     template_dir = (Path(".") / "templates").absolute()
                 else:
-                    print("Warning: snake couldn't find a template dir")
+                    print("Warning: pyplugin couldn't find a template dir")
 
             bp = self.blueprint(name, __name__, template_folder=template_dir)
             self.plugins[name].webserver_init(bp)

--- a/panda/python/examples/bbc_www.py
+++ b/panda/python/examples/bbc_www.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+'''
+Example use of a snake_hook-style PyPANDA plugin complete with a flask webserver
+'''
+
+from pandare import Panda
+from pandare.extras import Snake, PandaPlugin
+
+panda = Panda(generic="x86_64")
+
+class BasicBlockCount(PandaPlugin):
+    def __init__(self, panda):
+        self.bb_count = 0
+
+        @panda.cb_before_block_exec
+        def my_before_block_fn(_cpu, _trans):
+            self.bb_count += 1
+
+    def webserver_init(self, app):
+        @app.route("/")
+        def test_index():
+            return """<html>
+            <body>
+                <p>
+                    Basic Block Count: <span id="bb_count">""" + str(self.bb_count) +  """</span>
+                </p>
+            </body>
+            </html>"""
+
+s = Snake(panda, flask=True, host='0.0.0.0')
+s.register(BasicBlockCount)
+
+@panda.queue_blocking
+def driver():
+    panda.revert_sync("root")
+    assert(panda.run_serial_cmd("sleep 10"))
+    panda.end_analysis()
+s.serve()
+
+panda.run()

--- a/panda/python/examples/strace.py
+++ b/panda/python/examples/strace.py
@@ -3,7 +3,7 @@ This is an example of building a pypanda plugin class to do analysis with PANDA.
 how it's used look at pypanda_plugin_user.py
 '''
 
-from pandare.extras import PandaPlugin
+from pandare import PandaPlugin
 
 class Strace(PandaPlugin):
     def enter_cb(self, syscall_name, fname_ptr_pos, **kwargs):

--- a/panda/python/examples/strace.py
+++ b/panda/python/examples/strace.py
@@ -3,7 +3,9 @@ This is an example of building a pypanda plugin class to do analysis with PANDA.
 how it's used look at pypanda_plugin_user.py
 '''
 
-class Strace:
+from pandare.extras import PandaPlugin
+
+class Strace(PandaPlugin):
     def enter_cb(self, syscall_name, fname_ptr_pos, **kwargs):
         cpu=kwargs['args'][0]
         pcu=kwargs['args'][1]

--- a/panda/python/examples/strace_snake_user.py
+++ b/panda/python/examples/strace_snake_user.py
@@ -6,14 +6,13 @@ Run with: python3 pypanda_plugin_user.py
 '''
 
 from pandare import Panda
-from pandare.extras import PandaPlugin, Snake
 from sys import argv
 from strace import Strace
 
 arch = argv[1] if len(argv) > 1 else "i386"
 panda = Panda(generic=arch)
 
-Snake(panda).register(Strace)
+panda.pyplugin.register(Strace)
 
 @panda.queue_blocking
 def revert():

--- a/panda/python/examples/strace_snake_user.py
+++ b/panda/python/examples/strace_snake_user.py
@@ -1,19 +1,19 @@
 '''
-helper_example.py
-
-This demo shows off using a pypanda pluginto do analysis. In this case we use
-strace.py from strace.py and provide the Panda object to it.
+This demo shows off using a pypanda plugin to do analysis. In this case we use
+strace.py from strace.py
 
 Run with: python3 pypanda_plugin_user.py
 '''
 
 from pandare import Panda
-from strace import Strace
+from pandare.extras import PandaPlugin, Snake
 from sys import argv
+from strace import Strace
 
 arch = argv[1] if len(argv) > 1 else "i386"
 panda = Panda(generic=arch)
-Strace(panda)
+
+Snake(panda).register(Strace)
 
 @panda.queue_blocking
 def revert():


### PR DESCRIPTION
[Snake_hook](https://github.com/panda-re/panda/tree/dev/panda/plugins/snake_hook) defines a nice class-based API for creating PANDA plugins in pure Python aka **PyPlugins**.

This PR adds support for loading these PyPlugins through PyPANDA or the CLI (with the rust `snake_hook` plugin). In particular, it adds the `pyplugin` property to the pandare class and initializes it on the first access to be an instance of the `pandare.pyplugin`. By using the methods defined in this class, users can load and configure PyPlugins.

Plugins can be registered to run in one of three ways

## 1) Inline classes as PyPANDA plugins
```py

from pandare import Panda, PandaPlugin

panda = Panda(generic="x86_64")

class TestPlugin(PandaPlugin):
    def __init__(self, panda):
        path = self.get_arg('path')
        print(f"path = {path}")
        should_print_hello = self.get_arg_bool('should_print_hello')
        if should_print_hello:
            print("Hello!")

panda.pyplugin.register(TestPlugin, {'path': '/foo'})

@panda.queue_blocking
def drive():
    ...

panda.run()
```


## 2) Files as PyPANDA Plugins with PandaPlugin undefined
Per the original `snake_hook` spec, a plugin could subclass PandaPlugin without importing that object - as such special care must be used when loading these classes from a file. For now we support running with PandaPlugin undefined with the `panda.pyplugin.load_plugin()` APIs as shown below:

myplugin.py
```py
class MyPlugin(PandaPlugin):
    def __init__(self, panda):
        ....
```

runner.py
```py

from pandare import Panda

panda = Panda(generic="x86_64")

MyPlugin = panda.pyplugin.load_plugin_class("myplugin.py", "MyPlugin")
panda.pyplugin.register(MyPlugin, {'path': '/foo'})
# alternatively panda.pyplugin.register(("myplugin.py", "MyPlugin"), {'path': '/foo'})

@panda.queue_blocking
def drive():
    ...

panda.run()
```

## 3) Files as PyPANDA Plugins with PandaPlugin defined
myplugin.py
```py
from pandareimport PandaPlugin

class MyPlugin(PandaPlugin):
    def __init__(self, panda):
        ....
```

runner.py
```py

from pandare import Panda

panda = Panda(generic="x86_64")

from myplugin import MyPlugin
panda.pyplugin.register(MyPlugin, {'path': '/foo'})

@panda.queue_blocking
def drive():
    ...

panda.run()
```

This PR also adds a new script in the PyPANDA examples directory which uses the PyPANDA plugin flask option to show an updating basic block counter in a web app. It also updates an old example (strace.py) of using python classes for basic plugin functionality to use the pypanda plugin model.

If this PR is merged, it means that users should be able to create a single PyPANDA Plugin and load/configure it from either CLI panda (with snake_hook) or PyPANDA (with panda.pyplugin)

In the future, we might wish to consider renaming `snake_hook` to `pyplugin` for consistency.

PR #1106 should be merged prior to this (and then that commit should be dropped from here).