### PR TITLE
Add summarize mode to coverage plugin

### DIFF
--- a/panda/plugins/coverage/ModeBuilder.cpp
+++ b/panda/plugins/coverage/ModeBuilder.cpp
@@ -20,7 +20,7 @@ namespace coverage
 
 ModeBuilder::ModeBuilder(std::vector<CoverageMonitorDelegate *>& mds) :
     monitor_delegates(mds), mode(""), process_name(""),
-    filename("coverage.csv"), unique(false), start_disabled(false),
+    filename("coverage.csv"), unique(false), start_disabled(false), summarize_results(false),
     pass_hook(0), block_hook(0)
 {
 }
@@ -52,6 +52,12 @@ ModeBuilder& ModeBuilder::with_unique_filter()
 ModeBuilder& ModeBuilder::with_start_disabled()
 {
     start_disabled = true;
+    return *this;
+}
+
+ModeBuilder& ModeBuilder::with_summarize_results()
+{
+    summarize_results = true;
     return *this;
 }
 
@@ -116,8 +122,11 @@ std::vector<std::shared_ptr<InstrumentationDelegate>> ModeBuilder::build()
         std::shared_ptr<RecordProcessor<Block>> block_processor(new AsidBlockGenerator(first_cpu, rp));
         result.push_back(std::shared_ptr<InstrumentationDelegate>(new BlockInstrumentationDelegate(block_processor)));
     } else if ("osi-block" == mode) {
+
         std::shared_ptr<RecordProcessor<OsiBlock>> rp;
-        std::shared_ptr<OsiBlockCsvWriter> writer(new OsiBlockCsvWriter(filename, start_disabled));
+        std::shared_ptr<OsiBlockCsvWriter> writer(new OsiBlockCsvWriter(filename, summarize_results, start_disabled));
+
+
         monitor_delegates.push_back(writer.get());
         rp = writer;
         if (unique) {

--- a/panda/plugins/coverage/ModeBuilder.h
+++ b/panda/plugins/coverage/ModeBuilder.h
@@ -21,6 +21,7 @@ public:
     ModeBuilder& with_filename(const std::string& filename);
     ModeBuilder& with_unique_filter();
     ModeBuilder& with_start_disabled();
+    ModeBuilder& with_summarize_results();
     ModeBuilder& with_hook_filter(target_ulong pass_hook, target_ulong block_hook);
 
     std::vector<std::shared_ptr<InstrumentationDelegate>> build();
@@ -33,6 +34,7 @@ private:
     std::string filename;
     bool unique;
     bool start_disabled;
+    bool summarize_results;
     target_ulong pass_hook; 
     target_ulong block_hook;
 };

--- a/panda/plugins/coverage/OsiBlockCsvWriter.cpp
+++ b/panda/plugins/coverage/OsiBlockCsvWriter.cpp
@@ -5,34 +5,47 @@ namespace coverage
 {
 
 OsiBlockCsvWriter::OsiBlockCsvWriter(const std::string &filename,
-    bool start_disabled)
+    bool _summarize_results, bool start_disabled)
 {
     os.exceptions(std::ofstream::failbit | std::ofstream::badbit);
     if (!start_disabled) {
         os.open(filename);
         write_header();
     }
+
+    summarize_results = _summarize_results;
 }
 
 void OsiBlockCsvWriter::handle(OsiBlock record)
 {
-    if (!os.is_open()) {
-        return;
-    }
+    if (summarize_results) {
+        // If this is a new key, initialize it with an empty set
+        cov_map.emplace(record.process_name, std::unordered_set<target_ulong>());
+        // Set must exist now, add this block
+        cov_map[record.process_name].insert(record.block.addr);
+    } else {
+        if (!os.is_open()) {
+            return;
+        }
 
-    os << record.process_name << ","
-       << std::dec << record.pid << ","
-       << std::dec << record.tid << ","
-       << std::dec << record.in_kernel << ","
-       << "0x" << std::hex << record.block.addr << ","
-       << std::dec << record.block.size << "\n";
+        os << record.process_name << ","
+            << std::dec << record.pid << ","
+            << std::dec << record.tid << ","
+            << std::dec << record.in_kernel << ","
+            << "0x" << std::hex << record.block.addr << ","
+            << std::dec << record.block.size << "\n";
+    }
 }
 
 void OsiBlockCsvWriter::write_header()
 {
     write_metadata(os);
     os << "process\n";
-    os << "process name,process id,thread id,in kernel,block address,block size\n";
+    if (summarize_results){
+        os << "process name,block count\n";
+    } else {
+        os << "process name,process id,thread id,in kernel,block address,block size\n";
+    }
 }
 
 void OsiBlockCsvWriter::handle_enable(const std::string& filename)
@@ -43,6 +56,18 @@ void OsiBlockCsvWriter::handle_enable(const std::string& filename)
 
 void OsiBlockCsvWriter::handle_disable()
 {
+    if (!os.is_open()) {
+        return;
+    }
+
+    if (summarize_results) {
+        // dump results
+        for ( auto it = cov_map.begin(); it != cov_map.end(); ++it )  {
+            std::string name = it->first;
+            size_t sz = it->second.size();
+            os << name << "," << sz << "\n";
+        }
+    }
     os.close();
 }
 

--- a/panda/plugins/coverage/OsiBlockCsvWriter.cpp
+++ b/panda/plugins/coverage/OsiBlockCsvWriter.cpp
@@ -8,12 +8,11 @@ OsiBlockCsvWriter::OsiBlockCsvWriter(const std::string &filename,
     bool _summarize_results, bool start_disabled)
 {
     os.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+    summarize_results = _summarize_results;
     if (!start_disabled) {
         os.open(filename);
         write_header();
     }
-
-    summarize_results = _summarize_results;
 }
 
 void OsiBlockCsvWriter::handle(OsiBlock record)

--- a/panda/plugins/coverage/OsiBlockCsvWriter.h
+++ b/panda/plugins/coverage/OsiBlockCsvWriter.h
@@ -3,6 +3,8 @@
 
 #include <fstream>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "CoverageMonitorDelegate.h"
 #include "OsiBlock.h"
@@ -11,6 +13,8 @@
 namespace coverage
 {
 
+
+
 /**
  * Writes OsiBlock structs to a CSV file.
  */
@@ -18,14 +22,16 @@ class OsiBlockCsvWriter : public RecordProcessor<OsiBlock>,
                           public CoverageMonitorDelegate
 {
 public:
-    OsiBlockCsvWriter(const std::string &filename, bool start_disabled);
+    OsiBlockCsvWriter(const std::string &filename, bool summarize_results, bool start_disabled);
     void handle(OsiBlock record) override;
 
     void handle_enable(const std::string& filename) override;
     void handle_disable() override;
 private:
     void write_header();
+    bool summarize_results;
     std::ofstream os;
+    std::unordered_map<std::string, std::unordered_set<target_ulong>> cov_map;
 };
 
 }

--- a/panda/plugins/coverage/README.md
+++ b/panda/plugins/coverage/README.md
@@ -73,6 +73,7 @@ Arguments
 * `mode` - Output mode, one of `asid-block`, `osi-block`, or `edge` (default:
 `asid-block`). Note that `edge` requires OSI.
 * `full` - When `true`, logs each record every time it is generated (default:
+* `summary` - When `true`, only report total distinct blocks executed per process. Requires OSI and a mode of `osi-block` (default:
 `false`)
 * `start_disabled` - When `true`, does not start data collection when the
 plugin is initialized (default: `false`)


### PR DESCRIPTION
Adds `-summary=true` option to `coverage` plugin which records aggregate information about coverage per process.

Example output:
```
PANDA Build Date,2021-10-19
Execution Time,2021-10-20T15:54:58Z
process
process name,block count
gmain,706
ps,5553
ls,4099
systemd-journal,1712
in:imklog,683
rs:main Q:Reg,694
bash,3714
whoami,3931
(kernel),21841
```
