### PR TITLE
Add option to coverage plugin to exclude a range of PCs from instrumentation

### DIFF
--- a/panda/include/panda/tcg-utils.h
+++ b/panda/include/panda/tcg-utils.h
@@ -124,12 +124,18 @@ void insert_call(TCGOp **after_op, F *func_ptr, A... args)
 template<typename T>
 T try_parse(const std::string& value)
 {
+	std::string::size_type sz = 0;
+	std::string::size_type full_len = value.length();
     auto max_value = std::numeric_limits<T>::max();
-    auto tmp = std::stoull(value, NULL, 0);
+    auto tmp = std::stoull(value, &sz, 0);
     if (max_value < tmp) {
         std::stringstream ss;
         ss << "Value cannot be larger than " <<  max_value << ".";
         throw std::overflow_error(ss.str());
+    } else if (sz < full_len) {
+    	std::stringstream ss;
+    	ss << "Invalid character(s) found in " << value << ".";
+    	throw std::range_error(ss.str());
     }
     return static_cast<T>(tmp);
 }

--- a/panda/plugins/coverage/ExcludedPcRangePredicate.cpp
+++ b/panda/plugins/coverage/ExcludedPcRangePredicate.cpp
@@ -1,0 +1,17 @@
+#include "ExcludedPcRangePredicate.h"
+
+namespace coverage
+{
+
+ExcludedPcRangePredicate::ExcludedPcRangePredicate(target_ulong start, target_ulong end)
+        : pc_start(start), pc_end(end)
+{
+}
+
+bool ExcludedPcRangePredicate::eval(CPUState *cpu, TranslationBlock *tb)
+{
+	// the (pc+size) is the address of the first byte OUTSIDE this block
+	return ((tb->pc + tb->size) <= pc_start) || (tb->pc > pc_end);
+}
+
+}

--- a/panda/plugins/coverage/ExcludedPcRangePredicate.h
+++ b/panda/plugins/coverage/ExcludedPcRangePredicate.h
@@ -1,0 +1,26 @@
+#ifndef COVERAGE_EXCLUDEDPCRANGE_PREDICATE_H
+#define COVERAGE_EXCLUDEDPCRANGE_PREDICATE_H
+
+#include "Predicate.h"
+
+namespace coverage
+{
+
+/**
+ * A predicate that determines if a block falls entirely outside a given PC
+ * range.
+ */
+class ExcludedPcRangePredicate : public Predicate
+{
+public:
+    ExcludedPcRangePredicate(target_ulong start, target_ulong end);
+
+    bool eval(CPUState *cpu, TranslationBlock *tb) override;
+private:
+    target_ulong pc_start;
+    target_ulong pc_end;
+};
+
+}
+
+#endif

--- a/panda/plugins/coverage/Makefile
+++ b/panda/plugins/coverage/Makefile
@@ -15,6 +15,7 @@ $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
     $(PLUGIN_OBJ_DIR)/Predicate.o \
     $(PLUGIN_OBJ_DIR)/InKernelPredicate.o \
     $(PLUGIN_OBJ_DIR)/PcRangePredicate.o \
+    $(PLUGIN_OBJ_DIR)/ExcludedPcRangePredicate.o \
     $(PLUGIN_OBJ_DIR)/CompoundPredicate.o \
     $(PLUGIN_OBJ_DIR)/AlwaysTruePredicate.o \
     $(PLUGIN_OBJ_DIR)/PredicateBuilder.o \

--- a/panda/plugins/coverage/PredicateBuilder.cpp
+++ b/panda/plugins/coverage/PredicateBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include "AlwaysTruePredicate.h"
 #include "CompoundPredicate.h"
+#include "ExcludedPcRangePredicate.h"
 #include "InKernelPredicate.h"
 #include "PcRangePredicate.h"
 
@@ -16,6 +17,13 @@ PredicateBuilder& PredicateBuilder::with_pc_range(target_ulong low, target_ulong
 {
     std::unique_ptr<Predicate> pcrp(new PcRangePredicate(low, high));
     predicate.reset(new CompoundPredicate(std::move(predicate), std::move(pcrp)));
+    return *this;
+}
+
+PredicateBuilder& PredicateBuilder::without_pc_range(target_ulong low, target_ulong high)
+{
+    std::unique_ptr<Predicate> epcrp(new ExcludedPcRangePredicate(low, high));
+    predicate.reset(new CompoundPredicate(std::move(predicate), std::move(epcrp)));
     return *this;
 }
 

--- a/panda/plugins/coverage/PredicateBuilder.h
+++ b/panda/plugins/coverage/PredicateBuilder.h
@@ -17,6 +17,7 @@ class PredicateBuilder
 public:
     PredicateBuilder();
     PredicateBuilder& with_pc_range(target_ulong low, target_ulong high);
+    PredicateBuilder& without_pc_range(target_ulong low, target_ulong high);
     PredicateBuilder& in_kernel(bool ik);
     std::unique_ptr<Predicate> build(); 
 private:

--- a/panda/plugins/coverage/README.md
+++ b/panda/plugins/coverage/README.md
@@ -81,6 +81,8 @@ matches this argument (requires OSI). Note this filter is done at runtime, not
 instrumentation time.
 * `pc` - Filter option, only instrument blocks within a given range. Format: 
 `<Start PC in Hex or Decimal>-<End PC in Hex or Decimal>`.
+* `exclude_pc` - Filter option, do not instrument blocks which fall at least partially within a given range.  Format:
+`<Start PC in Hex or Decimal>-<End PC in Hex or Decimal>`.
 * `privilege` - Filter option, only instrument blocks executed with the
 specified privileges. Either: `user` or `kernel`.
 * `hook_filter` - Filter option that is controlled by two user provided hooks.


### PR DESCRIPTION
A block is not instrumented for coverage if it is partially (or entirely) within a given range of PCs.
While unit testing, I discovered that the utility used to parse a start or end point from a range quietly parses a partial string instead of complaining.  As this is most likely due to a typo on the user's part, I enhanced the parsing utility to throw an error if only part of the start point or end point string is parsed.