### PR TITLE
Syscalls2: pass a NULL syscall_info_t when unknown

### DIFF
--- a/panda/plugins/syscalls2/generated-tpl/syscall_switch_enter.tpl
+++ b/panda/plugins/syscalls2/generated-tpl/syscall_switch_enter.tpl
@@ -34,7 +34,15 @@ void syscall_enter_switch_{{os}}_{{arch}}(CPUState *cpu, target_ptr_t pc, int st
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	{%- for syscall in syscalls %}

--- a/panda/plugins/syscalls2/generated-tpl/syscall_switch_return.tpl
+++ b/panda/plugins/syscalls2/generated-tpl/syscall_switch_return.tpl
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_{{os}}_{{arch}}(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if {{arch_conf.qemu_target}}
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		{%- for syscall in syscalls %}
 		// {{syscall.no}} {{syscall.rettype}} {{syscall.name}} {{syscall.args_raw}}

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_freebsd_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_freebsd_x64.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 int nosys ['void']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 long sys_restart_syscall ['void']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm64.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 long sys_io_setup ['unsigned nr_reqs', 'aio_context_t __user *ctx']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_mips.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_mips.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 4001 long sys_exit ['int error_code']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x64.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 long sys_read ['unsigned int fd', 'char __user *buf', 'size_t count']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x86.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 long sys_restart_syscall ['void']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_2000_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_2000_x86.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_7_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_7_x86.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp2_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp2_x86.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp3_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp3_x86.cpp
@@ -34,7 +34,15 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
-	const syscall_info_t *call = (syscall_meta == NULL || ctx.no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx.no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx.no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx.no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx.no];
+	  }
+	}
 
 	switch (ctx.no) {
 	// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_freebsd_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_freebsd_x64.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_X86_64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 int nosys ['void']
 		case 0: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_linux_arm.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_linux_arm.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_linux_arm(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_ARM) && !defined(TARGET_AARCH64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 long sys_restart_syscall ['void']
 		case 0: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_linux_arm64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_linux_arm64.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_ARM) && defined(TARGET_AARCH64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 long sys_io_setup ['unsigned nr_reqs', 'aio_context_t __user *ctx']
 		case 0: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_linux_mips.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_linux_mips.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_linux_mips(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_MIPS)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 4001 long sys_exit ['int error_code']
 		case 4001: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_linux_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_linux_x64.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_linux_x64(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_X86_64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 long sys_read ['unsigned int fd', 'char __user *buf', 'size_t count']
 		case 0: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_linux_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_linux_x86.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_linux_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_I386) && !defined(TARGET_X86_64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 long sys_restart_syscall ['void']
 		case 0: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_windows_2000_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_windows_2000_x86.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_I386) && !defined(TARGET_X86_64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_windows_7_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_windows_7_x86.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_I386) && !defined(TARGET_X86_64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_windows_xpsp2_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_windows_xpsp2_x86.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_I386) && !defined(TARGET_X86_64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']
 		case 0: {

--- a/panda/plugins/syscalls2/generated/syscall_switch_return_windows_xpsp3_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_return_windows_xpsp3_x86.cpp
@@ -14,7 +14,15 @@ extern "C" {
 
 void syscall_return_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx) {
 #if defined(TARGET_I386) && !defined(TARGET_X86_64)
-	const syscall_info_t *call = (syscall_meta == NULL || ctx->no > syscall_meta->max_generic) ? NULL : &syscall_info[ctx->no];
+	const syscall_info_t *call = NULL;
+	syscall_info_t zero = {0};
+	if (syscall_meta != NULL && ctx->no <= syscall_meta->max_generic) {
+	  // If the syscall_info object from dso_info_....c doesn't have an entry
+	  // for this syscall, we want to leave it as a NULL pointer
+	  if (memcmp(&syscall_info[ctx->no], &zero, sizeof(syscall_info_t)) != 0) {
+		call = &syscall_info[ctx->no];
+	  }
+	}
 	switch (ctx->no) {
 		// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']
 		case 0: {


### PR DESCRIPTION
In the on_all_sys_{enter,return}2 callbacks we pass a syscall_info_t
with information about the current syscall or a NULL pointer if the
syscall cannot be identified. However, if the syscall number is below
the maximum but not defined in the os/arch-specific DSO file, we were
passing a non-null but zeroed object which would lead to unexpected
crashes in syscalls2 consumers (e.g., syscalls_logger didn't expect a
non-NULL call object but a null pointer for the syscall name) and make
it difficult to distinguish syscall #0 from an error case.