### PR TITLE
PyPlugin Bugfixes

### DIFF
--- a/panda/docs/pyplugins.md
+++ b/panda/docs/pyplugins.md
@@ -4,7 +4,7 @@ PyPlugins are Python3 classes which implement some reusable PANDA capability.
 
 The anatomy of a PANDA PyPlugin in its current form is one or more types which subclass `PyPlugin`. The constructor takes a `panda` object, which is of type [pandare.Panda](https://docs.panda.re/panda.html#pandare.panda.Panda).
 
-From there, you can add hooks and declare initial state for your plugin. The destructor (`__del__`) is optional, but can be used to perform cleanup when your plugin is unloaded.
+From there, you can add hooks and declare initial state for your plugin. An `uninit` method can optionally be defined which will run prior to your plugin being unloaded (often due to the end of the guest execution or replay).
 
 ## Relevant API Docs
 

--- a/panda/python/core/pandare/pypluginmanager.py
+++ b/panda/python/core/pandare/pypluginmanager.py
@@ -206,11 +206,14 @@ class PyPluginManager:
         all classes that subclass PyPlugin and passing them to self.load()
         '''
         import inspect, importlib
-        spec = importlib.util.spec_from_file_location("snake_hook", plugin_file)
+        spec = importlib.util.spec_from_file_location("plugin_file", plugin_file)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
-        for name, cls in inspect.getmembers(module, lambda x: inspect.isclass(x) and x.__module__ == "snake_hook"): # matches module set above
+        for name, cls in inspect.getmembers(module, lambda x: inspect.isclass(x)):
+            if not issubclass(cls, PyPlugin):
+                continue
+            cls.__name__ = name
             self.load(cls, args, template_dir)
 
     def unload(self, pluginclass, do_del=True):
@@ -226,8 +229,8 @@ class PyPluginManager:
             del self.plugins[name]
 
     def unload_all(self):
-        for instance in self.plugins.values():
-            self.unload(instance, do_del=False)
+        for name in self.plugins.keys():
+            self.unload(name, do_del=False)
         self.plugins.clear()
 
     def is_loaded(self, pluginclass):


### PR DESCRIPTION
* Change API and existing pyplugins to use `uninit` method at end of analysis over `__del__` so we don't run into issues calling functions like `open()` or with the uninit code running at unexpected times. This function is explicitly called on plugin unload.
* Change load_all function so it only loads pyplugin subclasses, not all classes in a file