### PR TITLE
Update Pypanda's arch class - better arg handling + mips64 support

### DIFF
--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -394,7 +394,7 @@ class Aarch64Arch(PandaArch):
 
 class MipsArch(PandaArch):
     '''
-    Register names and accessors for MIPS. Handles 32el, 32eb, and mips64
+    Register names and accessors for 32-bit MIPS
     '''
 
     # Registers are:
@@ -513,6 +513,33 @@ class MipsArch(PandaArch):
                 val = -1 * self.panda.from_unsigned_guest(val)
 
         return super().set_retval(cpu, val, convention)
+
+class Mips64Arch(MipsArch):
+    '''
+    Register names and accessors for MIPS64. Inherits from MipsArch for everything
+    except the register name and call conventions.
+    '''
+
+    def __init__(self, panda):
+        super().__init__(panda)
+        regnames = ["zero", "at",   "v0",   "v1",   "a0",   "a1",   "a2",   "a3",
+                    "a4",   "a5",   "a6",   "a7",   "t0",   "t1",   "t2",   "t3",
+                    "s0",   "s1",   "s2",   "s3",   "s4",   "s5",   "s6",   "s7",
+                    "t8",   "t9",   "k0",   "k1",   "gp",   "sp",   "s8",   "ra"]
+
+        self.reg_sp = regnames.index('sp')
+        self.reg_retaddr = regnames.index("ra")
+        # Default syscall/args are for mips 64/n32 - note the registers are different than 32
+        self.call_conventions = {"mips":          ["A0", "A1", "A2", "A3"], # XXX Unsure?
+                                 "syscall": ["V0", "A0", "A1", "A2", "A3", "A4", "A5"]}
+        self.call_conventions['default'] = self.call_conventions['mips']
+
+        self.reg_retval =  {"default":    "V0",
+                            "syscall":    'V0'}
+
+
+        # note names must be stored uppercase for get/set reg to work case-insensitively
+        self.registers = {regnames[idx].upper(): idx for idx in range(len(regnames)) }
 
 class X86Arch(PandaArch):
     '''

--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -485,7 +485,7 @@ class MipsArch(PandaArch):
         '''
         .. Deprecated:: use get_return_address
         '''
-        return self.get_return_addess(cpu)
+        return self.get_return_address(cpu)
 
     def get_return_address(self,cpu):
         '''

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -37,7 +37,7 @@ from .taint import TaintQuery
 from .panda_expect import Expect
 from .asyncthread import AsyncThread
 from .qcows import Qcows
-from .arch import ArmArch, Aarch64Arch, MipsArch, X86Arch, X86_64Arch
+from .arch import ArmArch, Aarch64Arch, MipsArch, Mips64Arch, X86Arch, X86_64Arch
 
 # Might be worth importing and auto-initilizing a PLogReader
 # object within Panda for the current architecture?
@@ -139,7 +139,7 @@ class Panda():
         elif self.arch_name in ["mips", "mipsel"]:
             self.arch = MipsArch(self)
         elif self.arch_name in ["mips64"]:
-            self.arch = MipsArch(self) # XXX: We probably need a different class?
+            self.arch = Mips64Arch(self)
         else:
             raise ValueError(f"Unsupported architecture {self.arch_name}")
         self.bits, self.endianness, self.register_size = self.arch._determine_bits()

--- a/panda/python/core/pandare/pypluginmanager.py
+++ b/panda/python/core/pandare/pypluginmanager.py
@@ -211,6 +211,10 @@ class PyPluginManager:
         '''
         import inspect, importlib
         spec = importlib.util.spec_from_file_location("plugin_file", plugin_file)
+        if spec is None:
+            # Likely an invalid path
+            raise ValueError(f"Unable to load {plugin_file}")
+
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 

--- a/panda/scripts/scgen.py
+++ b/panda/scripts/scgen.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+'''
+Reformat the syscalls2 prototypes to a mapping from callno to syscall name
+and store the results in syscalls.json in the following format:
+    {
+        'linux_arm':
+            {
+              '0': 'some_syscall',
+              '1': 'another_syscall'
+            },
+        'linux_mips':
+            {
+              ...
+            }
+    }
+
+Unfortunately syscall number keys are stored as strings
+'''
+
+
+import glob
+import json
+from os import path
+
+base = path.join(path.dirname(__file__), "../plugins/syscalls2/generated-in/")
+
+def gen_syscalls(os_arch):
+    syscalls = {}
+    num_sc = {}
+
+    fname = f"{os_arch}_prototypes.txt"
+    target = path.join(base, fname)
+    if not path.isfile(target):
+        raise ValueError(f"Unsupported os_arch: {os_arch} - could not find {target}")
+
+    with open(target) as f:
+        for line in f.readlines():
+            if not len(line):
+                continue
+
+            # num type name(args
+            try:
+                sys_no = int(line.split(" ")[0])
+            except:
+                continue
+            sys_name = line.split(" ")[2].split("(")[0]
+
+            sys_name = sys_name.replace("sys_", "")
+            if sys_name.startswith("do_"):
+                sys_name.replace("do_", "")
+            syscalls[sys_name] = sys_no
+            num_sc[sys_no] = sys_name
+
+    #return syscalls
+    return num_sc
+
+if __name__ == '__main__':
+    results = {}
+    for arch in ['linux_arm', 'linux_mips', 'linux_x64', 'linux_x86']:
+        results[arch] = gen_syscalls(arch)
+    with open("syscalls.json", 'w') as f:
+        json.dump(results, f)


### PR DESCRIPTION
Also includes an unrelated utility script to convert syscalls2 prototypes into json and a better error handler for pyplugins. Those are each in their own commits though so the history should be clean, despite the fact that I'm including them in this PR