### PR TITLE
Change Before Handle Exception

### DIFF
--- a/cpu-exec.c
+++ b/cpu-exec.c
@@ -523,8 +523,13 @@ static inline bool cpu_handle_exception(CPUState *cpu, int *ret)
             cpu->exception_index = -1;
             return true;
         } else {
+            int32_t exception = cpu->exception_index;
 
             cpu->exception_index = panda_callbacks_before_handle_exception(cpu, cpu->exception_index);
+
+            if (exception != cpu->exception_index){
+                return cpu_handle_exception(cpu, ret);
+            }
 
 #if defined(CONFIG_USER_ONLY)
             /* if user mode only, we simulate a fake exception


### PR DESCRIPTION
This PR changes before_handle_exception so that exceptions are generally cancellable. Previously, only i386 had handled that case. This PR makes it such that if a callback changes the exception we re-call cpu_handle_exception (as though a new exception occurred). If a valid exception is changed into another valid exception another callback will be generated.