### PR TITLE
callstack_instr: runtime test for capstone version + fix in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,14 @@ RUN [ -e /tmp/${BASE_IMAGE}_build.txt ] && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $(cat /tmp/${BASE_IMAGE}_build.txt | grep -o '^[^#]*') && \
     apt-get clean && \
     python3 -m pip install --upgrade --no-cache-dir pip && \
-    python3 -m pip install --upgrade --no-cache-dir "cffi>1.14.3" && \
+    python3 -m pip install --upgrade --no-cache-dir "cffi>1.14.3 capstone" && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
 
 # Then install capstone from source
 RUN cd /tmp && \
     curl -o cap.tgz -L https://github.com/aquynh/capstone/archive/4.0.2.tar.gz && \
     tar xvf cap.tgz && cd capstone-4.0.2/ && ./make.sh && make install && cd /tmp && \
-    rm -rf /tmp/capstone-4.0.2
+    rm -rf /tmp/capstone-4.0.2 && ldconfig
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -76,7 +76,7 @@ FROM base as panda
 
 # Copy panda + libcapstone.so*
 COPY --from=installer /usr/local /usr/local
-COPY --from=installer /lib/x86_64-linux-gnu/libcapstone* /lib/x86_64-linux-gnu/
+COPY --from=installer /usr/lib/libcapstone* /usr/lib/
 
 # Workaround issue #901 - ensure LD_LIBRARY_PATH contains the panda plugins directories
 #ARG TARGET_LIST="x86_64-softmmu,i386-softmmu,arm-softmmu,ppc-softmmu,mips-softmmu,mipsel-softmmu"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN [ -e /tmp/${BASE_IMAGE}_build.txt ] && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $(cat /tmp/${BASE_IMAGE}_build.txt | grep -o '^[^#]*') && \
     apt-get clean && \
     python3 -m pip install --upgrade --no-cache-dir pip && \
-    python3 -m pip install --upgrade --no-cache-dir "cffi>1.14.3 capstone" && \
+    python3 -m pip install --upgrade --no-cache-dir "cffi>1.14.3" && \
+    python3 -m pip install --upgrade --no-cache-dir "capstone" && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
 
 # Then install capstone from source

--- a/panda/dependencies/ubuntu:20.04_build.txt
+++ b/panda/dependencies/ubuntu:20.04_build.txt
@@ -7,11 +7,11 @@ lsb-core
 zip
 
 # panda build deps
+# Note libcapstone-dev is required, but we need v4 + which isn't in apt
 build-essential
 chrpath
 clang-11
 gcc
-libcapstone-dev
 libdwarf-dev
 libprotoc-dev
 llvm-11-dev

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -527,10 +527,11 @@ bool init_plugin(void *self) {
     if (cs_open(CS_ARCH_ARM, CS_MODE_ARM, &cs_handle_32) != CS_ERR_OK)
         return false;
 
-#if CS_VERSION_MAJOR < 4
-        printf("\n[ERROR] Capstone versions prior to 4.0.1 are unusable with ARM so callstack instr will fail! Please upgrade your libcapstone install to use this plugin\n\n");
-        return false;
-#endif
+    // Run-time check
+    if (cs_version < CS_MAKE_VERSION(4, 0)) {
+      printf("\n[ERROR] Capstone versions prior to 4.0.1 are unusable with ARM so callstack instr will fail! Please upgrade your libcapstone install and rebuild to use this plugin\n\n");
+      return false;
+    }
 
 
 #elif defined(TARGET_PPC)


### PR DESCRIPTION
The current dockerfile and callstack_instr have a pair of bugs which, together mean callstack_instr fails to provide any useful callbacks with arm guests.

We identified that callstack_instr required newer capstone versions for ARM guests in #641 and in #854 we added a compile-time check which would trigger a run-time error if the dependency wasn't met.

At some point, something changed in our docker file so we were no longer copying the installed-from-source version of capstone into the final container we produced. As such, panda was building with capstone > v4 but running with <v4, not raising any errors, and failing to trigger any callbacks.

This PR changes callstack_instr to raise an error *at runtime* if it's running an arm guest with capstone < v4 and updates the docker container to properly install capstone v4.