### PR TITLE
Add dedicated plugin for hardware-agnostic process ID

### DIFF
--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -15,6 +15,7 @@ forcedexec
 gdb
 hooks
 hooks2
+hw_proc_id
 libfi
 lighthouse_coverage
 loaded

--- a/panda/plugins/hw_proc_id/Makefile
+++ b/panda/plugins/hw_proc_id/Makefile
@@ -1,0 +1,17 @@
+# Don't forget to add your plugin to config.panda!
+
+# If you need custom CFLAGS or LIBS, set them up here
+# CFLAGS+=
+# LIBS+=
+
+# Example: this plugin has runtime symbol dependencies on plugin_x:
+# LIBS+=-L$(PLUGIN_TARGET_DIR) -l:panda_plugin_x.so
+# Also create a plugin_plugin.d file in this directory to ensure plugin_x
+# gets compiled before this plugin, example contents:
+# plugin-this_plugins_name : plugin-plugin_x
+# or if you're using the extra plugins dir:
+# extra-plugin-this_plugins_name : extra-plugin-plugin_x
+
+# The main rule for your plugin. List all object-file dependencies.
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
+	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o

--- a/panda/plugins/hw_proc_id/README.md
+++ b/panda/plugins/hw_proc_id/README.md
@@ -1,0 +1,25 @@
+Plugin: `HW_PROC_ID`
+===========
+
+Summary
+-------
+This plugin aims to provide an architecture-agnostic way to uniquely identify processes through a single API.
+
+For non-MIPS architectures, this plugin is equivalent to using the `panda_current_asid()` function. However, on MIPS guests, the ASID changes frequently for the same process so a different implementation is needed. For these guests, we return the address of the `current` `task_struct` object which will be different for different processes. But, (like with ASIDs) after a process is terminated, another process could end up with it's `task_struct` object in the same location.
+
+
+Arguments
+---------
+None
+
+Dependencies
+------------
+None
+
+APIs and Callbacks
+------------------
+
+`int procid(CPUState*)`: Returns an integer that represents the current process running on the CPU.
+
+Example
+-------

--- a/panda/plugins/hw_proc_id/hw_proc_id.cpp
+++ b/panda/plugins/hw_proc_id/hw_proc_id.cpp
@@ -1,0 +1,63 @@
+/* PANDABEGINCOMMENT
+ * 
+ * Authors:
+ *  Andrew Fasano          fasano@mit.edu
+ * 
+ * This work is licensed under the terms of the GNU GPL, version 2. 
+ * See the COPYING file in the top-level directory. 
+ * 
+PANDAENDCOMMENT */
+
+// Simple plugin to provide an architecture-agnostic, generic capability
+// for uniquely identifying a process withotu OSI.
+//
+// For non-mips architectures, we simply return the ASID. For MIPS
+// we cache the address of the current processes' task_struct and return
+// that.
+
+#include "panda/plugin.h"
+#include "hw_proc_id_int_fns.h"
+
+// These need to be extern "C" so that the ABI is compatible with
+// QEMU/PANDA, which is written in C
+extern "C" {
+bool init_plugin(void *);
+void uninit_plugin(void *);
+unsigned int get_id(CPUState * cpu);
+}
+
+#ifdef TARGET_MIPS
+target_ulong last_r28 = 0;
+
+void r28_cache(CPUState *cpu, TranslationBlock *tb) {
+  // Whenever the kernel changes register 28 (current task struct)
+  // save it - Unless it's <= 0x80000000- then it's not the task struct(?)
+
+  if (panda_in_kernel(cpu) && unlikely(((CPUMIPSState*)cpu->env_ptr)->active_tc.gpr[28] != last_r28)) {
+      target_ulong potential = ((CPUMIPSState*)cpu->env_ptr)->active_tc.gpr[28];
+      // XXX: af: While in kernel mode, r28 may be used to contain non-pointer values
+      // make sure we don't cache one of those
+      if (potential > 0x80000000) {
+        last_r28 = potential;
+      }
+  }
+}
+#endif
+
+unsigned int get_id(CPUState * cpu) {
+#ifdef TARGET_MIPS
+  return last_r28;
+#else
+  return panda_current_asid(cpu);
+#endif
+}
+
+bool init_plugin(void *self) {
+#if defined(TARGET_MIPS)
+    panda_cb pcb = { .before_block_exec = r28_cache };
+    panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+#endif
+    return true;
+}
+
+void uninit_plugin(void *self) { }

--- a/panda/plugins/hw_proc_id/hw_proc_id.cpp
+++ b/panda/plugins/hw_proc_id/hw_proc_id.cpp
@@ -16,15 +16,15 @@ PANDAENDCOMMENT */
 // that.
 
 #include "panda/plugin.h"
-#include "hw_proc_id_int_fns.h"
 
 // These need to be extern "C" so that the ABI is compatible with
 // QEMU/PANDA, which is written in C
 extern "C" {
 bool init_plugin(void *);
 void uninit_plugin(void *);
-unsigned int get_id(CPUState * cpu);
+#include "hw_proc_id_int_fns.h"
 }
+
 
 #ifdef TARGET_MIPS
 target_ulong last_r28 = 0;

--- a/panda/plugins/hw_proc_id/hw_proc_id_int.h
+++ b/panda/plugins/hw_proc_id/hw_proc_id_int.h
@@ -1,0 +1,3 @@
+// Need this for PPP calls to get_id()
+typedef void CPUState;
+#include "hw_proc_id_int_fns.h"

--- a/panda/plugins/hw_proc_id/hw_proc_id_int_fns.h
+++ b/panda/plugins/hw_proc_id/hw_proc_id_int_fns.h
@@ -1,6 +1,5 @@
 #pragma once
 
-extern "C" {
 // BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
 // api autogen needs it.  And don't put any compiler directives
 // between this and END_PYPANDA_NEEDS_THIS except includes of other
@@ -9,5 +8,4 @@ extern "C" {
 unsigned int get_id(CPUState *cpu);
 
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
-}
 /* vim:set tabstop=4 softtabstop=4 expandtab: */

--- a/panda/plugins/hw_proc_id/hw_proc_id_int_fns.h
+++ b/panda/plugins/hw_proc_id/hw_proc_id_int_fns.h
@@ -1,0 +1,13 @@
+#pragma once
+
+extern "C" {
+// BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
+// api autogen needs it.  And don't put any compiler directives
+// between this and END_PYPANDA_NEEDS_THIS except includes of other
+// files in this directory that contain subsections like this one.
+
+unsigned int get_id(CPUState *cpu);
+
+// END_PYPANDA_NEEDS_THIS -- do not delete this comment!
+}
+/* vim:set tabstop=4 softtabstop=4 expandtab: */

--- a/panda/plugins/osi_linux/default_profile.cpp
+++ b/panda/plugins/osi_linux/default_profile.cpp
@@ -1,10 +1,6 @@
 #include "osi_linux.h"
 #include "default_profile.h"
 
-#ifdef TARGET_MIPS
-#include "hw_proc_id/hw_proc_id_int_fns.h"
-#endif
-
 
 /**
  * @brief Retrieves the task_struct address using per cpu information.

--- a/panda/plugins/osi_linux/default_profile.cpp
+++ b/panda/plugins/osi_linux/default_profile.cpp
@@ -2,7 +2,7 @@
 #include "default_profile.h"
 
 #ifdef TARGET_MIPS
-extern target_ulong last_r28;
+#include "hw_proc_id/hw_proc_id_int_fns.h"
 #endif
 
 
@@ -53,7 +53,7 @@ target_ptr_t default_get_current_task_struct(CPUState *cpu)
     // __current_thread_info is stored in KERNEL r28
     // userspace clobbers it but kernel restores (somewhow?)
     // First field of struct is task - no offset needed
-    current_task_addr=last_r28;
+    current_task_addr = get_id(cpu); // HWID returned by hw_proc_id is the cached r28 value
 
 #else // x86/64
     current_task_addr = ki.task.current_task_addr;

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -31,6 +31,10 @@
 
 #define KERNEL_CONF "/" TARGET_NAME "-softmmu/panda/plugins/osi_linux/kernelinfo.conf"
 
+#ifdef TARGET_MIPS
+#include "hw_proc_id/hw_proc_id_ext.h"
+#endif
+
 /*
  * Functions interfacing with QEMU/PANDA should be linked as C.
  * C++ function name mangling breaks linkage.
@@ -762,6 +766,7 @@ bool init_plugin(void *self) {
 
 #if defined(TARGET_MIPS)
         panda_require("hw_proc_id");
+        assert(init_hw_proc_id_api());
 #endif
 
 #if defined(OSI_LINUX_TEST)

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -688,27 +688,6 @@ void restore_after_snapshot(CPUState* cpu) {
     PPP_REG_CB("syscalls2", on_all_sys_enter, on_first_syscall);
 }
 
-
-/**
- * @brief Cache the last R28 observed while in kernel for MIPS
- */
-
-#ifdef TARGET_MIPS
-target_ulong last_r28 = 0;
-
-void r28_cache(CPUState *cpu, TranslationBlock *tb) {
-
-  if (unlikely(((CPUMIPSState*)cpu->env_ptr)->active_tc.gpr[28] != last_r28) && panda_in_kernel(cpu)) {
-
-      target_ulong potential = ((CPUMIPSState*)cpu->env_ptr)->active_tc.gpr[28];
-      // XXX: af: We need this filter but I have no idea why
-      if (potential > 0x80000000) {
-        last_r28 = potential;
-      }
-  }
-}
-#endif
-
 #if defined(TARGET_I386) || defined(TARGET_ARM) || (defined(TARGET_MIPS) && !defined(TARGET_MIPS64))
 
 // Keep track of which tasks have entered execve. Note that we simply track
@@ -782,8 +761,7 @@ bool init_plugin(void *self) {
     }
 
 #if defined(TARGET_MIPS)
-        panda_cb pcb2 = { .before_block_exec = r28_cache };
-        panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb2);
+        panda_require("hw_proc_id");
 #endif
 
 #if defined(OSI_LINUX_TEST)

--- a/panda/plugins/osi_linux/osi_linux.h
+++ b/panda/plugins/osi_linux/osi_linux.h
@@ -28,6 +28,10 @@
 #include "kernel_profile.h"
 #include "endian_helpers.h"
 
+#ifdef TARGET_MIPS
+#include "hw_proc_id/hw_proc_id_ext.h"
+#endif
+
 extern struct kernelinfo ki;
 extern struct KernelProfile const *kernel_profile;
 

--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -457,7 +457,7 @@ class MipsArch(PandaArch):
         self.reg_retaddr = regnames.index("ra")
         # Default syscall/args are for mips o32
         self.call_conventions = {"mips":          ["A0", "A1", "A2", "A3"],
-                                 "syscall": ["V0", "A0", "A1", "A2", "A3", "stack_1", "stack_2", "stack_3", "stack_4"]}
+                "syscall": ["V0", "A0", "A1", "A2", "A3", "stack_3", "stack_4", "stack_5", "stack_6"]} # XXX: Note it's not 0-indexed for stack args, I guess the syscall pushes stuff too
         self.call_conventions['default'] = self.call_conventions['mips']
 
         self.reg_retval =  {"default":    "V0",

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -2447,7 +2447,7 @@ class Panda():
 
         if isfile(pjoin(copy_directory, setup_script)):
             setup_result = self.run_serial_cmd(f"{mount_dir}/{setup_script}", timeout=timeout)
-            progress("[Setup command]: {setup_result}")
+            progress(f"[Setup command]: {setup_result}")
 
     @blocking
     def record_cmd(self, guest_command, copy_directory=None, iso_name=None, setup_command=None, recording_name="recording", snap_name="root", ignore_errors=False):

--- a/panda/python/core/pandare/qcows.py
+++ b/panda/python/core/pandare/qcows.py
@@ -343,7 +343,11 @@ class Qcows():
 
         panda_args.extend(['-loadvm', q.snapshot])
 
-        return " ".join(panda_args)
+        ret = " ".join(panda_args)
+
+        if "-display none" in ret:
+            ret = ret.replace("-display none", "-nographic")
+        return ret
 
 if __name__ == "__main__":
     from sys import argv, stdout


### PR DESCRIPTION
panda_current_asid provides a unique, per-process ID for x86, arm, and PPC guests - but not MIPS!

This PR adds a simple plugin, `hw_proc_id` which provides one ppp-function: `int get_id(CPUState*)`  which returns a unique process ID for any of our supported architectures.

For non mips architectures, this is just the asid.
For MIPS, we cache the address of the current_task saved in `r28` whenever we're in kernel mode.