### PR TITLE
CI: test pypanda with flake8 - for now just errors

### DIFF
--- a/.github/workflows/parallel_tests.yml
+++ b/.github/workflows/parallel_tests.yml
@@ -20,6 +20,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2 # Clones to $GITHUB_WORKSPACE. NOTE: this requires git > 2.18 (not on ubuntu 18.04 by default) to get .git directory
+    - name: Lint PyPANDA with flake8
+      run: |
+       python -m pip install --upgrade pip
+       python -m pip install flake8
+       python -m flake8 $GITHUB_WORKSPACE/panda/python/core/pandare/ --count --select=E9,F63,F7,F82 --show-source --statistics
+       # python -m flake8 $GITHUB_WORKSPACE/panda/python/core/pandare/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run install_ubuntu.sh
       run: cd $GITHUB_WORKSPACE && ./panda/scripts/install_ubuntu.sh
 

--- a/panda/python/core/pandare/asyncthread.py
+++ b/panda/python/core/pandare/asyncthread.py
@@ -169,9 +169,9 @@ def test3():
         print("Main slow_func sleeping")
         sleep(10)
         print("Main done")
-    hang_func.__blocking__ = "placeholder" # Hack to pretend it's decorated
+    slow_func.__blocking__ = "placeholder" # Hack to pretend it's decorated
 
-    b.queue(hang_func)
+    b.queue(slow_func)
 
     # Make sure we have time to run both fns
     started.set()

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -1373,7 +1373,7 @@ class Panda():
         Returns:
             DeviceState struct
         '''
-        return self.libpanda.sysbus_create_varargs(name,addr,ffi.NULL)
+        return self.libpanda.sysbus_create_varargs(name,addr, self.ffi.NULL)
 
     def cpu_class_by_name(self, name, cpu_model):
         '''
@@ -1531,7 +1531,7 @@ class Panda():
         Returns:
             struct ObjectProperty pointer
         '''
-        return self.libpanda.object_property_find(obj,name,ffi.NULL)
+        return self.libpanda.object_property_find(obj,name, self.ffi.NULL)
 
     def memory_region_allocate_system_memory(self, mr, obj, name, ram_size):
         '''

--- a/panda/python/core/pandare/volatility_cli_classes.py
+++ b/panda/python/core/pandare/volatility_cli_classes.py
@@ -75,15 +75,15 @@ class CommandLineMoreEfficient(interfaces.plugins.FileConsumerInterface):
 
     def run(self):
         # we aren't really doing logging, but you can change these numbers to get more details
-        vollog = logging.getLogger(__name__)
-        vollog = logging.getLogger()
-       # vollog.setLevel(1000)
+        self.vollog = logging.getLogger(__name__)
+        self.vollog = logging.getLogger()
+       # self.vollog.setLevel(1000)
         console = logging.StreamHandler()
         #console.setLevel(logging.WARNING)
         formatter = logging.Formatter(
             '%(levelname)-8s %(name)-12s: %(message)s')
         console.setFormatter(formatter)
-        vollog.addHandler(console)
+        self.vollog.addHandler(console)
         volatility.framework.require_interface_version(1, 0, 0)
         # also change here for log level
         #console.setLevel(1000)
@@ -127,25 +127,25 @@ class CommandLineRunFullCommand(interfaces.plugins.FileConsumerInterface):
     def run(self, argstring):
         # Make sure we log everything
 
-        vollog = logging.getLogger()
-        #vollog.setLevel(1)
+        self.vollog = logging.getLogger()
+        #self.vollog.setLevel(1)
         # Trim the console down by default
         console = logging.StreamHandler()
         #console.setLevel(logging.FATAL)
         formatter = logging.Formatter(
             '%(levelname)-8s %(name)-12s: %(message)s')
         console.setFormatter(formatter)
-        vollog.addHandler(console)
+        self.vollog.addHandler(console)
         # Make sure we log everything
-        vollog = logging.getLogger()
-        #vollog.setLevel(1)
+        self.vollog = logging.getLogger()
+        #self.vollog.setLevel(1)
         # Trim the console down by default
         console = logging.StreamHandler()
         #console.setLevel(logging.WARNING)
         formatter = logging.Formatter(
             '%(levelname)-8s %(name)-12s: %(message)s')
         console.setFormatter(formatter)
-        vollog.addHandler(console)
+        self.vollog.addHandler(console)
         arg_arr = shlex.split(argstring)
         """Executes the command line module, taking the system arguments,
             determining the plugin to run and then running it."""
@@ -238,17 +238,17 @@ class CommandLineRunFullCommand(interfaces.plugins.FileConsumerInterface):
             file_formatter = logging.Formatter(datefmt='%y-%m-%d %H:%M:%S',
                                                fmt='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
             file_logger.setFormatter(file_formatter)
-            vollog.addHandler(file_logger)
-            vollog.info("Logging started")
+            self.vollog.addHandler(file_logger)
+            self.vollog.info("Logging started")
         if partial_args.verbosity < 3:
             console.setLevel(30 - (partial_args.verbosity * 10))
         else:
             console.setLevel(10 - (partial_args.verbosity - 2))
         #console.setLevel(0)
 
-        vollog.info("Volatility plugins path: {}".format(
+        self.vollog.info("Volatility plugins path: {}".format(
             volatility.plugins.__path__))
-        vollog.info("Volatility symbols path: {}".format(
+        self.vollog.info("Volatility symbols path: {}".format(
             volatility.symbols.__path__))
 
         # Set the PARALLELISM
@@ -266,7 +266,7 @@ class CommandLineRunFullCommand(interfaces.plugins.FileConsumerInterface):
         if failures:
             parser.epilog = "The following plugins could not be loaded (use -vv to see why): " + \
                 ", ".join(sorted(failures))
-            vollog.info(parser.epilog)
+            self.vollog.info(parser.epilog)
         automagics = automagic.available(ctx)
 
         plugin_list = framework.list_plugins()
@@ -302,7 +302,7 @@ class CommandLineRunFullCommand(interfaces.plugins.FileConsumerInterface):
         if args.plugin is None:
             parser.error("Please select a plugin to run")
 
-        vollog.log(constants.LOGLEVEL_VVV,
+        self.vollog.log(constants.LOGLEVEL_VVV,
                    "Cache directory used: {}".format(constants.CACHE_PATH))
 
         plugin = plugin_list[args.plugin]
@@ -357,7 +357,7 @@ class CommandLineRunFullCommand(interfaces.plugins.FileConsumerInterface):
         #	return (ctx, automagics, plugin, base_config_path, progress_callback, self)
 
             if args.write_config:
-                vollog.debug("Writing out configuration data to config.json")
+                self.vollog.debug("Writing out configuration data to config.json")
                 with open("config.json", "w") as f:
                     json.dump(dict(constructed.build_configuration()),
                               f, sort_keys=True, indent=2)
@@ -451,10 +451,10 @@ class CommandLineRunFullCommand(interfaces.plugins.FileConsumerInterface):
         if not os.path.exists(output_filename):
             with open(output_filename, "wb") as current_file:
                 current_file.write(filedata.data.getvalue())
-                vollog.log(
+                self.vollog.log(
                     logging.INFO, "Saved stored plugin file: {}".format(output_filename))
         else:
-            vollog.warning(
+            self.vollog.warning(
                 "Refusing to overwrite an existing file: {}".format(output_filename))
 
     def populate_requirements_argparse(self, parser: Union[argparse.ArgumentParser, argparse._ArgumentGroup],


### PR DESCRIPTION
Combined with the test_installer job so we don't have another job that has to clone the repo. Will raise errors if flake8 detects invalid python syntax in PyPANDA code.

Eventually we could also to turn on the linting line, but that has 54k errors right now:
```
20    C901 'Loop 52' is too complex (18)
6     E101 indentation contains mixed spaces and tabs
3     E111 indentation is not a multiple of 4
1     E114 indentation is not a multiple of 4 (comment)
2     E116 unexpected indentation (comment)
42    E122 continuation line missing indentation or outdented
1     E124 closing bracket does not match visual indentation
1     E125 continuation line with same indent as next logical line
5     E127 continuation line over-indented for visual indent
103   E128 continuation line under-indented for visual indent
2     E201 whitespace after '['
9     E202 whitespace before '}'
53    E203 whitespace before ':'
11    E211 whitespace before '('
25    E221 multiple spaces before operator
4     E222 multiple spaces after operator
16    E225 missing whitespace around operator
53214 E231 missing whitespace after ','
472   E251 unexpected spaces around keyword / parameter equals
164   E261 at least two spaces before inline comment
1     E262 inline comment should start with '# '
59    E265 block comment should start with '# '
12    E266 too many leading '#' for block comment
1     E271 multiple spaces after keyword
1     E272 multiple spaces before keyword
5     E301 expected 1 blank line, found 0
37    E302 expected 2 blank lines, found 0
47    E303 too many blank lines (2)
11    E305 expected 2 blank lines after class or function definition, found 1
5     E306 expected 1 blank line before a nested definition, found 0
1     E401 multiple imports on one line
8     E402 module level import not at top of file
187   E501 line too long (143 > 127 characters)
9     E502 the backslash is redundant between brackets
11    E701 multiple statements on one line (colon)
10    E711 comparison to None should be 'if cond is None:'
3     E712 comparison to True should be 'if cond is True:' or 'if cond:'
2     E713 test for membership should be 'not in'
2     E722 do not use bare 'except'
1     E741 ambiguous variable name 'l'
35    F401 '.panda.blocking' imported but unused
1     F403 'from ctypes import *' used; unable to detect undefined names
3     F541 f-string is missing placeholders
30    F811 redefinition of unused 'sleep' from line 9
13    F841 local variable 'asid' is assigned to but never used
6     W191 indentation contains tabs
11    W291 trailing whitespace
2     W292 no newline at end of file
17    W293 blank line contains whitespace
1     W391 blank line at end of file
1     W605 invalid escape sequence '\>'
54687
```