### PR TITLE
double return for syscalls2

### DIFF
--- a/panda/plugins/syscalls2/generated-in/context_target.json
+++ b/panda/plugins/syscalls2/generated-in/context_target.json
@@ -1,14 +1,22 @@
 {
 	"linux:x86": {
-		"panda_noreturn": ["sys_execve", "sys_exit_group", "sys_sigreturn"]
+		"panda_noreturn": ["sys_execve", "sys_exit_group", "sys_sigreturn"],
+		"panda_doublereturn": ["sys_fork"]
 	},
 	"linux:arm": {
-		"panda_noreturn": ["sys_execve", "sys_exit_group", "sys_sigreturn"]
+		"panda_noreturn": ["sys_execve", "sys_exit_group", "sys_sigreturn"],
+		"panda_doublereturn": ["sys_fork"]
 	},
 	"linux:x64": {
-		"panda_noreturn": ["sys_exit_group"]
+		"panda_noreturn": ["sys_exit_group"],
+		"panda_doublereturn": ["sys_fork"]
+	},
+	"linux:mips": {
+		"panda_noreturn": ["sys_exit_group"],
+		"panda_doublereturn": ["sys_fork"]
 	},
 	"freebsd:x64": {
-		"panda_noreturn": ["execve", "fexecve", "__mac_execve", "sys_exit", "thr_exit"]
+		"panda_noreturn": ["execve", "fexecve", "__mac_execve", "sys_exit", "thr_exit"],
+		"panda_doublereturn": ["fork"]
 	}
 }

--- a/panda/plugins/syscalls2/generated-tpl/syscall_switch_enter.tpl
+++ b/panda/plugins/syscalls2/generated-tpl/syscall_switch_enter.tpl
@@ -33,6 +33,7 @@ void syscall_enter_switch_{{os}}_{{arch}}(CPUState *cpu, target_ptr_t pc, int st
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -49,6 +50,7 @@ void syscall_enter_switch_{{os}}_{{arch}}(CPUState *cpu, target_ptr_t pc, int st
 	// {{syscall.no}} {{syscall.rettype}} {{syscall.name}} {{syscall.args_raw}}
 	case {{syscall.no}}: {
 		panda_noreturn = {{ 'true' if syscall.panda_noreturn else 'false' }};
+		ctx.double_return = {{ 'true' if syscall.panda_double_return else 'false' }};
 		{%- if syscall.args|length > 0 %}
 		{%- for arg in syscall.args %}
 		{{arg.emit_temp_assignment()}}

--- a/panda/plugins/syscalls2/generated-tpl/syscalls_ext_typedefs.tpl
+++ b/panda/plugins/syscalls2/generated-tpl/syscalls_ext_typedefs.tpl
@@ -43,6 +43,7 @@ struct syscall_ctx {
     target_ptr_t retaddr; /**< return address */
     uint8_t args[GLOBAL_MAX_SYSCALL_ARGS]
                 [GLOBAL_MAX_SYSCALL_ARG_SIZE]; /**< arguments */
+    bool double_return;
 };
 typedef struct syscall_ctx syscall_ctx_t;
 

--- a/panda/plugins/syscalls2/generated/dso_info_linux_mips.c
+++ b/panda/plugins/syscalls2/generated/dso_info_linux_mips.c
@@ -3882,7 +3882,7 @@ syscall_info_t __syscall_info_a[] = {
 		.argsz = argsz_4246,
 		.argn = argn_4246,
 		.argtn = argtn_4246,
-		.noreturn = false
+		.noreturn = true
 	},
 	[4247] = {
 		.no = 4247,

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_freebsd_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_freebsd_x64.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -48,11 +49,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 0 int nosys ['void']
 	case 0: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_nosys_enter, cpu, pc);
 	}; break;
 	// 1 void sys_exit ['int rval']
 	case 1: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -64,11 +67,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 2 int fork ['void']
 	case 2: {
 		panda_noreturn = false;
+		ctx.double_return = true;
 		PPP_RUN_CB(on_fork_enter, cpu, pc);
 	}; break;
 	// 3 ssize_t read ['int fd', 'void *buf', 'size_t nbyte']
 	case 3: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -84,6 +89,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 4 ssize_t write ['int fd', 'const void *buf', 'size_t nbyte']
 	case 4: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -99,6 +105,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 5 int open ['const char *path', 'int flags', 'mode_t mode']
 	case 5: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -114,6 +121,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 6 int close ['int fd']
 	case 6: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -125,6 +133,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 7 int wait4 ['int pid', 'int *status', 'int options', 'struct rusage *rusage']
 	case 7: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -142,6 +151,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 8 int creat ['const char *path', 'int mode']
 	case 8: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -155,6 +165,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 9 int link ['const char *path', 'const char *link']
 	case 9: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -168,6 +179,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 10 int unlink ['const char *path']
 	case 10: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -179,6 +191,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 12 int chdir ['const char *path']
 	case 12: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -190,6 +203,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 13 int fchdir ['int fd']
 	case 13: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -201,6 +215,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 14 int mknod ['const char *path', 'int mode', 'uint32_t dev']
 	case 14: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -216,6 +231,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 15 int chmod ['const char *path', 'mode_t mode']
 	case 15: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -229,6 +245,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 16 int chown ['const char *path', 'int uid', 'int gid']
 	case 16: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -244,6 +261,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 18 int getfsstat ['struct ostatfs *buf', 'long bufsize', 'int mode']
 	case 18: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -259,11 +277,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 20 pid_t getpid ['void']
 	case 20: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_getpid_enter, cpu, pc);
 	}; break;
 	// 21 int mount ['const char *type', 'const char *path', 'int flags', 'void *data']
 	case 21: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -281,6 +301,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 22 int unmount ['const char *path', 'int flags']
 	case 22: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -294,6 +315,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 23 int setuid ['uid_t uid']
 	case 23: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -305,16 +327,19 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 24 uid_t getuid ['void']
 	case 24: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_getuid_enter, cpu, pc);
 	}; break;
 	// 25 uid_t geteuid ['void']
 	case 25: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_geteuid_enter, cpu, pc);
 	}; break;
 	// 26 int ptrace ['int req', 'pid_t pid', 'caddr_t addr', 'int data']
 	case 26: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -332,6 +357,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 27 int recvmsg ['int s', 'struct msghdr *msg', 'int flags']
 	case 27: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -347,6 +373,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 28 int sendmsg ['int s', 'struct msghdr *msg', 'int flags']
 	case 28: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -362,6 +389,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 29 int recvfrom ['int s', 'void *buf', 'size_t len', 'int flags', 'struct sockaddr *from', '__socklen_t *fromlenaddr']
 	case 29: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -383,6 +411,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 30 int accept ['int s', 'struct sockaddr *name', '__socklen_t *anamelen']
 	case 30: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -398,6 +427,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 31 int getpeername ['int fdes', 'struct sockaddr *asa', '__socklen_t *alen']
 	case 31: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -413,6 +443,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 32 int getsockname ['int fdes', 'struct sockaddr *asa', '__socklen_t *alen']
 	case 32: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -428,6 +459,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 33 int access ['const char *path', 'int amode']
 	case 33: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -441,6 +473,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 34 int chflags ['const char *path', 'u_long flags']
 	case 34: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -454,6 +487,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 35 int fchflags ['int fd', 'u_long flags']
 	case 35: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -467,11 +501,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 36 int sync ['void']
 	case 36: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sync_enter, cpu, pc);
 	}; break;
 	// 37 int kill ['int pid', 'int signum']
 	case 37: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -485,6 +521,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 38 int stat ['const char *path', 'struct ostat *ub']
 	case 38: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -498,11 +535,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 39 pid_t getppid ['void']
 	case 39: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_getppid_enter, cpu, pc);
 	}; break;
 	// 40 int lstat ['const char *path', 'struct ostat *ub']
 	case 40: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -516,6 +555,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 41 int dup ['unsigned fd']
 	case 41: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -527,16 +567,19 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 42 int pipe ['void']
 	case 42: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_pipe_enter, cpu, pc);
 	}; break;
 	// 43 gid_t getegid ['void']
 	case 43: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_getegid_enter, cpu, pc);
 	}; break;
 	// 44 int profil ['char *samples', 'size_t size', 'size_t offset', 'unsigned scale']
 	case 44: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -554,6 +597,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 45 int ktrace ['const char *fname', 'int ops', 'int facs', 'int pid']
 	case 45: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -571,6 +615,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 46 int sigaction ['int signum', 'struct osigaction *nsa', 'struct osigaction *osa']
 	case 46: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -586,11 +631,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 47 gid_t getgid ['void']
 	case 47: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_getgid_enter, cpu, pc);
 	}; break;
 	// 49 int getlogin ['char *namebuf', 'unsigned namelen']
 	case 49: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -604,6 +651,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 50 int setlogin ['const char *namebuf']
 	case 50: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -615,6 +663,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 51 int acct ['const char *path']
 	case 51: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -626,6 +675,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 53 int sigaltstack ['stack_t *ss', 'stack_t *oss']
 	case 53: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -639,6 +689,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 54 int ioctl ['int fd', 'u_long com', 'char *data']
 	case 54: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -654,6 +705,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 55 int reboot ['int opt']
 	case 55: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -665,6 +717,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 56 int revoke ['const char *path']
 	case 56: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -676,6 +729,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 57 int symlink ['const char *path', 'const char *link']
 	case 57: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -689,6 +743,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 58 ssize_t readlink ['const char *path', 'char *buf', 'size_t count']
 	case 58: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -704,6 +759,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 59 int execve ['const char *fname', 'char **argv', 'char **envv']
 	case 59: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -719,6 +775,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 60 int umask ['mode_t newmask']
 	case 60: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -730,6 +787,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 61 int chroot ['const char *path']
 	case 61: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -741,6 +799,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 62 int fstat ['int fd', 'struct ostat *sb']
 	case 62: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -754,6 +813,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 63 int getkerninfo ['int op', 'char *where', 'size_t *size', 'int arg']
 	case 63: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -771,11 +831,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 64 int getpagesize ['void']
 	case 64: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_getpagesize_enter, cpu, pc);
 	}; break;
 	// 65 int msync ['void *addr', 'size_t len', 'int flags']
 	case 65: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -791,11 +853,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 66 int vfork ['void']
 	case 66: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_vfork_enter, cpu, pc);
 	}; break;
 	// 69 int sbrk ['int incr']
 	case 69: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -807,6 +871,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 70 int sstk ['int incr']
 	case 70: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -818,6 +883,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 72 int vadvise ['int anom']
 	case 72: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -829,6 +895,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 73 int munmap ['void *addr', 'size_t len']
 	case 73: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -842,6 +909,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 74 int mprotect ['void *addr', 'size_t len', 'int prot']
 	case 74: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -857,6 +925,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 75 int madvise ['void *addr', 'size_t len', 'int behav']
 	case 75: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -872,6 +941,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 78 int mincore ['const void *addr', 'size_t len', 'char *vec']
 	case 78: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -887,6 +957,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 79 int getgroups ['unsigned gidsetsize', 'gid_t *gidset']
 	case 79: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -900,6 +971,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 80 int setgroups ['unsigned gidsetsize', 'gid_t *gidset']
 	case 80: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -913,11 +985,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 81 int getpgrp ['void']
 	case 81: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_getpgrp_enter, cpu, pc);
 	}; break;
 	// 82 int setpgid ['int pid', 'int pgid']
 	case 82: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -931,6 +1005,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 83 int setitimer ['unsigned which', 'struct itimerval *itv', 'struct itimerval *oitv']
 	case 83: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -946,11 +1021,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 84 int wait ['void']
 	case 84: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_wait_enter, cpu, pc);
 	}; break;
 	// 85 int swapon ['const char *name']
 	case 85: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -962,6 +1039,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 86 int getitimer ['unsigned which', 'struct itimerval *itv']
 	case 86: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -975,6 +1053,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 87 int gethostname ['char *hostname', 'unsigned len']
 	case 87: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -988,6 +1067,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 88 int sethostname ['char *hostname', 'unsigned len']
 	case 88: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1001,11 +1081,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 89 int getdtablesize ['void']
 	case 89: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_getdtablesize_enter, cpu, pc);
 	}; break;
 	// 90 int dup2 ['unsigned from', 'unsigned to']
 	case 90: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1019,6 +1101,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 92 int fcntl ['int fd', 'int cmd', 'long arg']
 	case 92: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int64_t arg2 = get_s64(cpu, 2);
@@ -1034,6 +1117,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 93 int select ['int nd', 'fd_set *in', 'fd_set *ou', 'fd_set *ex', 'struct timeval *tv']
 	case 93: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1053,6 +1137,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 95 int fsync ['int fd']
 	case 95: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1064,6 +1149,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 96 int setpriority ['int which', 'int who', 'int prio']
 	case 96: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1079,6 +1165,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 97 int socket ['int domain', 'int type', 'int protocol']
 	case 97: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1094,6 +1181,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 98 int connect ['int s', 'const struct sockaddr *name', 'int namelen']
 	case 98: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1109,6 +1197,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 99 int accept ['int s', 'struct sockaddr *name', 'int *anamelen']
 	case 99: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1124,6 +1213,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 100 int getpriority ['int which', 'int who']
 	case 100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1137,6 +1227,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 101 int send ['int s', 'const void *buf', 'int len', 'int flags']
 	case 101: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1154,6 +1245,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 102 int recv ['int s', 'void *buf', 'int len', 'int flags']
 	case 102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1171,6 +1263,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 103 int sigreturn ['struct osigcontext *sigcntxp']
 	case 103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1182,6 +1275,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 104 int bind ['int s', 'const struct sockaddr *name', 'int namelen']
 	case 104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1197,6 +1291,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 105 int setsockopt ['int s', 'int level', 'int name', 'const void *val', 'int valsize']
 	case 105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1216,6 +1311,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 106 int listen ['int s', 'int backlog']
 	case 106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1229,6 +1325,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 108 int sigvec ['int signum', 'struct sigvec *nsv', 'struct sigvec *osv']
 	case 108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1244,6 +1341,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 109 int sigblock ['int mask']
 	case 109: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1255,6 +1353,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 110 int sigsetmask ['int mask']
 	case 110: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1266,6 +1365,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 111 int sigsuspend ['osigset_t mask']
 	case 111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1277,6 +1377,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 112 int sigstack ['struct sigstack *nss', 'struct sigstack *oss']
 	case 112: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1290,6 +1391,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 113 int recvmsg ['int s', 'struct omsghdr *msg', 'int flags']
 	case 113: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1305,6 +1407,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 114 int sendmsg ['int s', 'const void *msg', 'int flags']
 	case 114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1320,6 +1423,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 116 int gettimeofday ['struct timeval *tp', 'struct timezone *tzp']
 	case 116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1333,6 +1437,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 117 int getrusage ['int who', 'struct rusage *rusage']
 	case 117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1346,6 +1451,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 118 int getsockopt ['int s', 'int level', 'int name', 'void *val', 'int *avalsize']
 	case 118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1365,6 +1471,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 120 int readv ['int fd', 'struct iovec *iovp', 'unsigned iovcnt']
 	case 120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1380,6 +1487,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 121 int writev ['int fd', 'struct iovec *iovp', 'unsigned iovcnt']
 	case 121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1395,6 +1503,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 122 int settimeofday ['struct timeval *tv', 'struct timezone *tzp']
 	case 122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1408,6 +1517,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 123 int fchown ['int fd', 'int uid', 'int gid']
 	case 123: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1423,6 +1533,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 124 int fchmod ['int fd', 'mode_t mode']
 	case 124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1436,6 +1547,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 125 int recvfrom ['int s', 'void *buf', 'size_t len', 'int flags', 'struct sockaddr *from', 'int *fromlenaddr']
 	case 125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1457,6 +1569,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 126 int setreuid ['int ruid', 'int euid']
 	case 126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1470,6 +1583,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 127 int setregid ['int rgid', 'int egid']
 	case 127: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1483,6 +1597,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 128 int rename ['const char *from', 'const char *to']
 	case 128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1496,6 +1611,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 131 int flock ['int fd', 'int how']
 	case 131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1509,6 +1625,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 132 int mkfifo ['const char *path', 'mode_t mode']
 	case 132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1522,6 +1639,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 133 int sendto ['int s', 'const void *buf', 'size_t len', 'int flags', 'const struct sockaddr *to', 'int tolen']
 	case 133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1543,6 +1661,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 134 int shutdown ['int s', 'int how']
 	case 134: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1556,6 +1675,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 135 int socketpair ['int domain', 'int type', 'int protocol', 'int *rsv']
 	case 135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1573,6 +1693,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 136 int mkdir ['const char *path', 'mode_t mode']
 	case 136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1586,6 +1707,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 137 int rmdir ['const char *path']
 	case 137: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1597,6 +1719,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 138 int utimes ['const char *path', 'struct timeval *tptr']
 	case 138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1610,6 +1733,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 140 int adjtime ['struct timeval *delta', 'struct timeval *olddelta']
 	case 140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1623,6 +1747,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 141 int getpeername ['int fdes', 'struct sockaddr *asa', 'int *alen']
 	case 141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1638,11 +1763,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 142 long gethostid ['void']
 	case 142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_gethostid_enter, cpu, pc);
 	}; break;
 	// 143 int sethostid ['long hostid']
 	case 143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int64_t arg0 = get_s64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1654,6 +1781,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 144 int getrlimit ['unsigned which', 'struct orlimit *rlp']
 	case 144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1667,6 +1795,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 145 int setrlimit ['unsigned which', 'struct orlimit *rlp']
 	case 145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1680,6 +1809,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 146 int killpg ['int pgid', 'int signum']
 	case 146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1693,11 +1823,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 147 int setsid ['void']
 	case 147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_setsid_enter, cpu, pc);
 	}; break;
 	// 148 int quotactl ['const char *path', 'int cmd', 'int uid', 'void *arg']
 	case 148: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1715,11 +1847,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 149 int quota ['void']
 	case 149: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_quota_enter, cpu, pc);
 	}; break;
 	// 150 int getsockname ['int fdec', 'struct sockaddr *asa', 'int *alen']
 	case 150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1735,6 +1869,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 154 int nlm_syscall ['int debug_level', 'int grace_period', 'int addr_count', 'char **addrs']
 	case 154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1752,6 +1887,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 155 int nfssvc ['int flag', 'void *argp']
 	case 155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1765,6 +1901,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 156 int getdirentries ['int fd', 'char *buf', 'unsigned count', 'long *basep']
 	case 156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1782,6 +1919,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 157 int statfs ['const char *path', 'struct ostatfs *buf']
 	case 157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1795,6 +1933,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 158 int fstatfs ['int fd', 'struct ostatfs *buf']
 	case 158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1808,6 +1947,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 160 int lgetfh ['const char *fname', 'struct fhandle *fhp']
 	case 160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1821,6 +1961,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 161 int getfh ['const char *fname', 'struct fhandle *fhp']
 	case 161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1834,6 +1975,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 162 int getdomainname ['char *domainname', 'int len']
 	case 162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1847,6 +1989,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 163 int setdomainname ['char *domainname', 'int len']
 	case 163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1860,6 +2003,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 164 int uname ['struct utsname *name']
 	case 164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1871,6 +2015,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 165 int sysarch ['int op', 'char *parms']
 	case 165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1884,6 +2029,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 166 int rtprio ['int function', 'pid_t pid', 'struct rtprio *rtp']
 	case 166: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1899,6 +2045,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 169 int semsys ['int which', 'int a2', 'int a3', 'int a4', 'int a5']
 	case 169: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1918,6 +2065,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 175 int setfib ['int fibnum']
 	case 175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1929,6 +2077,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 176 int ntp_adjtime ['struct timex *tp']
 	case 176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1940,6 +2089,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 181 int setgid ['gid_t gid']
 	case 181: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1951,6 +2101,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 182 int setegid ['gid_t egid']
 	case 182: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1962,6 +2113,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 183 int seteuid ['uid_t euid']
 	case 183: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1973,6 +2125,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 188 int stat ['const char *path', 'struct freebsd11_stat *ub']
 	case 188: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1986,6 +2139,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 189 int fstat ['int fd', 'struct freebsd11_stat *sb']
 	case 189: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1999,6 +2153,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 190 int lstat ['const char *path', 'struct freebsd11_stat *ub']
 	case 190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2012,6 +2167,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 191 int pathconf ['const char *path', 'int name']
 	case 191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2025,6 +2181,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 192 int fpathconf ['int fd', 'int name']
 	case 192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2038,6 +2195,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 194 int getrlimit ['unsigned which', 'struct rlimit *rlp']
 	case 194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2051,6 +2209,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 195 int setrlimit ['unsigned which', 'struct rlimit *rlp']
 	case 195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2064,6 +2223,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 196 int getdirentries ['int fd', 'char *buf', 'unsigned count', 'long *basep']
 	case 196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2081,11 +2241,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 198 int nosys ['void']
 	case 198: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_nosys_enter, cpu, pc);
 	}; break;
 	// 202 int __sysctl ['int *name', 'unsigned namelen', 'void *old', 'size_t *oldlenp', 'const void *new', 'size_t newlen']
 	case 202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2107,6 +2269,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 203 int mlock ['const void *addr', 'size_t len']
 	case 203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2120,6 +2283,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 204 int munlock ['const void *addr', 'size_t len']
 	case 204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2133,6 +2297,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 205 int undelete ['const char *path']
 	case 205: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2144,6 +2309,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 206 int futimes ['int fd', 'struct timeval *tptr']
 	case 206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2157,6 +2323,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 207 int getpgid ['pid_t pid']
 	case 207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2168,6 +2335,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 209 int poll ['struct pollfd *fds', 'unsigned nfds', 'int timeout']
 	case 209: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2183,6 +2351,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 220 int __semctl ['int semid', 'int semnum', 'int cmd', 'union semun_old *arg']
 	case 220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2200,6 +2369,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 221 int semget ['key_t key', 'int nsems', 'int semflg']
 	case 221: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2215,6 +2385,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 222 int semop ['int semid', 'struct sembuf *sops', 'size_t nsops']
 	case 222: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2230,6 +2401,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 224 int msgctl ['int msqid', 'int cmd', 'struct msqid_ds_old *buf']
 	case 224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2245,6 +2417,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 225 int msgget ['key_t key', 'int msgflg']
 	case 225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2258,6 +2431,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 226 int msgsnd ['int msqid', 'const void *msgp', 'size_t msgsz', 'int msgflg']
 	case 226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2275,6 +2449,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 227 ssize_t msgrcv ['int msqid', 'void *msgp', 'size_t msgsz', 'long msgtyp', 'int msgflg']
 	case 227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2294,6 +2469,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 229 int shmctl ['int shmid', 'int cmd', 'struct shmid_ds_old *buf']
 	case 229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2309,6 +2485,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 230 int shmdt ['const void *shmaddr']
 	case 230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2320,6 +2497,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 231 int shmget ['key_t key', 'size_t size', 'int shmflg']
 	case 231: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2335,6 +2513,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 232 int clock_gettime ['clockid_t clock_id', 'struct timespec *tp']
 	case 232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2348,6 +2527,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 233 int clock_settime ['clockid_t clock_id', 'const struct timespec *tp']
 	case 233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2361,6 +2541,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 234 int clock_getres ['clockid_t clock_id', 'struct timespec *tp']
 	case 234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2374,6 +2555,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 235 int ktimer_create ['clockid_t clock_id', 'struct sigevent *evp', 'int *timerid']
 	case 235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2389,6 +2571,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 236 int ktimer_delete ['int timerid']
 	case 236: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2400,6 +2583,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 237 int ktimer_settime ['int timerid', 'int flags', 'const struct itimerspec *value', 'struct itimerspec *ovalue']
 	case 237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2417,6 +2601,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 238 int ktimer_gettime ['int timerid', 'struct itimerspec *value']
 	case 238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2430,6 +2615,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 239 int ktimer_getoverrun ['int timerid']
 	case 239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2441,6 +2627,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 240 int nanosleep ['const struct timespec *rqtp', 'struct timespec *rmtp']
 	case 240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2454,6 +2641,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 241 int ffclock_getcounter ['ffcounter *ffcount']
 	case 241: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2465,6 +2653,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 242 int ffclock_setestimate ['struct ffclock_estimate *cest']
 	case 242: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2476,6 +2665,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 243 int ffclock_getestimate ['struct ffclock_estimate *cest']
 	case 243: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2487,6 +2677,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 244 int clock_nanosleep ['clockid_t clock_id', 'int flags', 'const struct timespec *rqtp', 'struct timespec *rmtp']
 	case 244: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2504,6 +2695,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 247 int clock_getcpuclockid2 ['id_t id', 'int which', 'clockid_t *clock_id']
 	case 247: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2519,6 +2711,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 248 int ntp_gettime ['struct ntptimeval *ntvp']
 	case 248: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2530,6 +2723,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 250 int minherit ['void *addr', 'size_t len', 'int inherit']
 	case 250: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2545,6 +2739,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 251 int rfork ['int flags']
 	case 251: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2556,11 +2751,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 253 int issetugid ['void']
 	case 253: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_issetugid_enter, cpu, pc);
 	}; break;
 	// 254 int lchown ['const char *path', 'int uid', 'int gid']
 	case 254: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2576,6 +2773,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 255 int aio_read ['struct aiocb *aiocbp']
 	case 255: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2587,6 +2785,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 256 int aio_write ['struct aiocb *aiocbp']
 	case 256: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2598,6 +2797,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 257 int lio_listio ['int mode', 'struct aiocb * const *acb_list', 'int nent', 'struct sigevent *sig']
 	case 257: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2615,6 +2815,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 272 int getdents ['int fd', 'char *buf', 'size_t count']
 	case 272: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2630,6 +2831,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 274 int lchmod ['const char *path', 'mode_t mode']
 	case 274: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2643,6 +2845,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 276 int lutimes ['const char *path', 'struct timeval *tptr']
 	case 276: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2656,6 +2859,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 278 int nstat ['const char *path', 'struct nstat *ub']
 	case 278: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2669,6 +2873,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 279 int nfstat ['int fd', 'struct nstat *sb']
 	case 279: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2682,6 +2887,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 280 int nlstat ['const char *path', 'struct nstat *ub']
 	case 280: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2695,6 +2901,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 289 ssize_t preadv ['int fd', 'struct iovec *iovp', 'unsigned iovcnt', 'off_t offset']
 	case 289: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2712,6 +2919,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 290 ssize_t pwritev ['int fd', 'struct iovec *iovp', 'unsigned iovcnt', 'off_t offset']
 	case 290: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2729,6 +2937,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 297 int fhstatfs ['const struct fhandle *u_fhp', 'struct ostatfs *buf']
 	case 297: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2742,6 +2951,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 298 int fhopen ['const struct fhandle *u_fhp', 'int flags']
 	case 298: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2755,6 +2965,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 299 int fhstat ['const struct fhandle *u_fhp', 'struct freebsd11_stat *sb']
 	case 299: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2768,6 +2979,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 300 int modnext ['int modid']
 	case 300: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2779,6 +2991,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 301 int modstat ['int modid', 'struct module_stat *stat']
 	case 301: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2792,6 +3005,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 302 int modfnext ['int modid']
 	case 302: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2803,6 +3017,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 303 int modfind ['const char *name']
 	case 303: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2814,6 +3029,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 304 int kldload ['const char *file']
 	case 304: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2825,6 +3041,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 305 int kldunload ['int fileid']
 	case 305: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2836,6 +3053,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 306 int kldfind ['const char *file']
 	case 306: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2847,6 +3065,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 307 int kldnext ['int fileid']
 	case 307: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2858,6 +3077,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 308 int kldstat ['int fileid', 'struct kld_file_stat *stat']
 	case 308: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2871,6 +3091,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 309 int kldfirstmod ['int fileid']
 	case 309: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2882,6 +3103,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 310 int getsid ['pid_t pid']
 	case 310: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2893,6 +3115,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 311 int setresuid ['uid_t ruid', 'uid_t euid', 'uid_t suid']
 	case 311: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2908,6 +3131,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 312 int setresgid ['gid_t rgid', 'gid_t egid', 'gid_t sgid']
 	case 312: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2923,6 +3147,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 314 ssize_t aio_return ['struct aiocb *aiocbp']
 	case 314: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2934,6 +3159,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 315 int aio_suspend ['struct aiocb * const * aiocbp', 'int nent', 'const struct timespec *timeout']
 	case 315: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2949,6 +3175,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 316 int aio_cancel ['int fd', 'struct aiocb *aiocbp']
 	case 316: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2962,6 +3189,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 317 int aio_error ['struct aiocb *aiocbp']
 	case 317: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2973,6 +3201,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 318 int aio_read ['struct oaiocb *aiocbp']
 	case 318: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2984,6 +3213,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 319 int aio_write ['struct oaiocb *aiocbp']
 	case 319: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2995,6 +3225,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 320 int lio_listio ['int mode', 'struct oaiocb * const *acb_list', 'int nent', 'struct osigevent *sig']
 	case 320: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3012,11 +3243,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 321 int yield ['void']
 	case 321: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_yield_enter, cpu, pc);
 	}; break;
 	// 324 int mlockall ['int how']
 	case 324: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3028,6 +3261,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 325 int munlockall(void); 326 int __getcwd ['char *buf', 'size_t buflen']
 	case 325: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3041,6 +3275,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 327 int sched_setparam ['pid_t pid', 'const struct sched_param *param']
 	case 327: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3054,6 +3289,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 328 int sched_getparam ['pid_t pid', 'struct sched_param *param']
 	case 328: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3067,6 +3303,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 329 int sched_setscheduler ['pid_t pid', 'int policy', 'const struct sched_param *param']
 	case 329: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3082,6 +3319,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 330 int sched_getscheduler ['pid_t pid']
 	case 330: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3093,11 +3331,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 331 int sched_yield ['void']
 	case 331: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sched_yield_enter, cpu, pc);
 	}; break;
 	// 332 int sched_get_priority_max ['int policy']
 	case 332: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3109,6 +3349,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 333 int sched_get_priority_min ['int policy']
 	case 333: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3120,6 +3361,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 334 int sched_rr_get_interval ['pid_t pid', 'struct timespec *interval']
 	case 334: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3133,6 +3375,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 335 int utrace ['const void *addr', 'size_t len']
 	case 335: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3146,6 +3389,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 336 int sendfile ['int fd', 'int s', 'off_t offset', 'size_t nbytes', 'struct sf_hdtr *hdtr', 'off_t *sbytes', 'int flags']
 	case 336: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3169,6 +3413,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 337 int kldsym ['int fileid', 'int cmd', 'void *data']
 	case 337: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3184,6 +3429,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 338 int jail ['struct jail *jail']
 	case 338: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3195,6 +3441,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 339 int nnpfs_syscall ['int operation', 'char *a_pathP', 'int a_opcode', 'void *a_paramsP', 'int a_followSymlinks']
 	case 339: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3214,6 +3461,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 340 int sigprocmask ['int how', 'const sigset_t *set', 'sigset_t *oset']
 	case 340: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3229,6 +3477,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 341 int sigsuspend ['const sigset_t *sigmask']
 	case 341: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3240,6 +3489,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 342 int sigaction ['int sig', 'const struct sigaction *act', 'struct sigaction *oact']
 	case 342: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3255,6 +3505,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 343 int sigpending ['sigset_t *set']
 	case 343: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3266,6 +3517,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 344 int sigreturn ['const struct ucontext4 *sigcntxp']
 	case 344: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3277,6 +3529,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 345 int sigtimedwait ['const sigset_t *set', 'siginfo_t *info', 'const struct timespec *timeout']
 	case 345: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3292,6 +3545,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 346 int sigwaitinfo ['const sigset_t *set', 'siginfo_t *info']
 	case 346: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3305,6 +3559,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 347 int __acl_get_file ['const char *path', 'acl_type_t type', 'struct acl *aclp']
 	case 347: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3320,6 +3575,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 348 int __acl_set_file ['const char *path', 'acl_type_t type', 'struct acl *aclp']
 	case 348: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3335,6 +3591,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 349 int __acl_get_fd ['int filedes', 'acl_type_t type', 'struct acl *aclp']
 	case 349: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3350,6 +3607,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 350 int __acl_set_fd ['int filedes', 'acl_type_t type', 'struct acl *aclp']
 	case 350: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3365,6 +3623,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 351 int __acl_delete_file ['const char *path', 'acl_type_t type']
 	case 351: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3378,6 +3637,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 352 int __acl_delete_fd ['int filedes', 'acl_type_t type']
 	case 352: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3391,6 +3651,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 353 int __acl_aclcheck_file ['const char *path', 'acl_type_t type', 'struct acl *aclp']
 	case 353: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3406,6 +3667,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 354 int __acl_aclcheck_fd ['int filedes', 'acl_type_t type', 'struct acl *aclp']
 	case 354: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3421,6 +3683,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 355 int extattrctl ['const char *path', 'int cmd', 'const char *filename', 'int attrnamespace', 'const char *attrname']
 	case 355: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3440,6 +3703,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 356 ssize_t extattr_set_file ['const char *path', 'int attrnamespace', 'const char *attrname', 'void *data', 'size_t nbytes']
 	case 356: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3459,6 +3723,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 357 ssize_t extattr_get_file ['const char *path', 'int attrnamespace', 'const char *attrname', 'void *data', 'size_t nbytes']
 	case 357: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3478,6 +3743,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 358 int extattr_delete_file ['const char *path', 'int attrnamespace', 'const char *attrname']
 	case 358: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3493,6 +3759,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 359 ssize_t aio_waitcomplete ['struct aiocb **aiocbp', 'struct timespec *timeout']
 	case 359: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3506,6 +3773,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 360 int getresuid ['uid_t *ruid', 'uid_t *euid', 'uid_t *suid']
 	case 360: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3521,6 +3789,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 361 int getresgid ['gid_t *rgid', 'gid_t *egid', 'gid_t *sgid']
 	case 361: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3536,11 +3805,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 362 int kqueue ['void']
 	case 362: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_kqueue_enter, cpu, pc);
 	}; break;
 	// 363 int kevent ['int fd', 'struct kevent_freebsd11 *changelist', 'int nchanges', 'struct kevent_freebsd11 *eventlist', 'int nevents', 'const struct timespec *timeout']
 	case 363: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3562,6 +3833,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 371 ssize_t extattr_set_fd ['int fd', 'int attrnamespace', 'const char *attrname', 'void *data', 'size_t nbytes']
 	case 371: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3581,6 +3853,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 372 ssize_t extattr_get_fd ['int fd', 'int attrnamespace', 'const char *attrname', 'void *data', 'size_t nbytes']
 	case 372: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3600,6 +3873,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 373 int extattr_delete_fd ['int fd', 'int attrnamespace', 'const char *attrname']
 	case 373: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3615,6 +3889,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 374 int __setugid ['int flag']
 	case 374: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3626,6 +3901,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 376 int eaccess ['const char *path', 'int amode']
 	case 376: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3639,6 +3915,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 377 int afs3_syscall ['long syscall', 'long parm1', 'long parm2', 'long parm3', 'long parm4', 'long parm5', 'long parm6']
 	case 377: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int64_t arg0 = get_s64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		int64_t arg2 = get_s64(cpu, 2);
@@ -3662,6 +3939,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 378 int nmount ['struct iovec *iovp', 'unsigned int iovcnt', 'int flags']
 	case 378: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3677,6 +3955,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 384 int __mac_get_proc ['struct mac *mac_p']
 	case 384: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3688,6 +3967,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 385 int __mac_set_proc ['struct mac *mac_p']
 	case 385: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3699,6 +3979,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 386 int __mac_get_fd ['int fd', 'struct mac *mac_p']
 	case 386: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3712,6 +3993,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 387 int __mac_get_file ['const char *path_p', 'struct mac *mac_p']
 	case 387: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3725,6 +4007,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 388 int __mac_set_fd ['int fd', 'struct mac *mac_p']
 	case 388: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3738,6 +4021,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 389 int __mac_set_file ['const char *path_p', 'struct mac *mac_p']
 	case 389: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3751,6 +4035,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 390 int kenv ['int what', 'const char *name', 'char *value', 'int len']
 	case 390: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3768,6 +4053,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 391 int lchflags ['const char *path', 'u_long flags']
 	case 391: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3781,6 +4067,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 392 int uuidgen ['struct uuid *store', 'int count']
 	case 392: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3794,6 +4081,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 393 int sendfile ['int fd', 'int s', 'off_t offset', 'size_t nbytes', 'struct sf_hdtr *hdtr', 'off_t *sbytes', 'int flags']
 	case 393: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3817,6 +4105,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 394 int mac_syscall ['const char *policy', 'int call', 'void *arg']
 	case 394: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3832,6 +4121,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 395 int getfsstat ['struct freebsd11_statfs *buf', 'long bufsize', 'int mode']
 	case 395: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3847,6 +4137,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 396 int statfs ['const char *path', 'struct freebsd11_statfs *buf']
 	case 396: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3860,6 +4151,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 397 int fstatfs ['int fd', 'struct freebsd11_statfs *buf']
 	case 397: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3873,6 +4165,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 398 int fhstatfs ['const struct fhandle *u_fhp', 'struct freebsd11_statfs *buf']
 	case 398: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3886,6 +4179,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 400 int ksem_close ['semid_t id']
 	case 400: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3897,6 +4191,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 401 int ksem_post ['semid_t id']
 	case 401: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3908,6 +4203,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 402 int ksem_wait ['semid_t id']
 	case 402: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3919,6 +4215,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 403 int ksem_trywait ['semid_t id']
 	case 403: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3930,6 +4227,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 404 int ksem_init ['semid_t *idp', 'unsigned int value']
 	case 404: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3943,6 +4241,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 405 int ksem_open ['semid_t *idp', 'const char *name', 'int oflag', 'mode_t mode', 'unsigned int value']
 	case 405: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3962,6 +4261,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 406 int ksem_unlink ['const char *name']
 	case 406: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3973,6 +4273,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 407 int ksem_getvalue ['semid_t id', 'int *val']
 	case 407: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3986,6 +4287,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 408 int ksem_destroy ['semid_t id']
 	case 408: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3997,6 +4299,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 409 int __mac_get_pid ['pid_t pid', 'struct mac *mac_p']
 	case 409: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4010,6 +4313,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 410 int __mac_get_link ['const char *path_p', 'struct mac *mac_p']
 	case 410: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4023,6 +4327,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 411 int __mac_set_link ['const char *path_p', 'struct mac *mac_p']
 	case 411: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4036,6 +4341,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 412 ssize_t extattr_set_link ['const char *path', 'int attrnamespace', 'const char *attrname', 'void *data', 'size_t nbytes']
 	case 412: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4055,6 +4361,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 413 ssize_t extattr_get_link ['const char *path', 'int attrnamespace', 'const char *attrname', 'void *data', 'size_t nbytes']
 	case 413: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4074,6 +4381,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 414 int extattr_delete_link ['const char *path', 'int attrnamespace', 'const char *attrname']
 	case 414: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4089,6 +4397,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 415 int __mac_execve ['const char *fname', 'char **argv', 'char **envv', 'struct mac *mac_p']
 	case 415: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4106,6 +4415,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 416 int sigaction ['int sig', 'const struct sigaction *act', 'struct sigaction *oact']
 	case 416: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4121,6 +4431,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 417 int sigreturn ['const struct __ucontext *sigcntxp']
 	case 417: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4132,6 +4443,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 421 int getcontext ['struct __ucontext *ucp']
 	case 421: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4143,6 +4455,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 422 int setcontext ['const struct __ucontext *ucp']
 	case 422: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4154,6 +4467,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 423 int swapcontext ['struct __ucontext *oucp', 'const struct __ucontext *ucp']
 	case 423: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4167,6 +4481,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 424 int swapoff ['const char *name']
 	case 424: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4178,6 +4493,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 425 int __acl_get_link ['const char *path', 'acl_type_t type', 'struct acl *aclp']
 	case 425: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4193,6 +4509,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 426 int __acl_set_link ['const char *path', 'acl_type_t type', 'struct acl *aclp']
 	case 426: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4208,6 +4525,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 427 int __acl_delete_link ['const char *path', 'acl_type_t type']
 	case 427: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4221,6 +4539,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 428 int __acl_aclcheck_link ['const char *path', 'acl_type_t type', 'struct acl *aclp']
 	case 428: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4236,6 +4555,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 429 int sigwait ['const sigset_t *set', 'int *sig']
 	case 429: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4249,6 +4569,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 430 int thr_create ['ucontext_t *ctx', 'long *id', 'int flags']
 	case 430: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4264,6 +4585,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 431 void thr_exit ['long *state']
 	case 431: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4275,6 +4597,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 432 int thr_self ['long *id']
 	case 432: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4286,6 +4609,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 433 int thr_kill ['long id', 'int sig']
 	case 433: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int64_t arg0 = get_s64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4299,6 +4623,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 436 int jail_attach ['int jid']
 	case 436: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4310,6 +4635,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 437 ssize_t extattr_list_fd ['int fd', 'int attrnamespace', 'void *data', 'size_t nbytes']
 	case 437: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4327,6 +4653,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 438 ssize_t extattr_list_file ['const char *path', 'int attrnamespace', 'void *data', 'size_t nbytes']
 	case 438: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4344,6 +4671,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 439 ssize_t extattr_list_link ['const char *path', 'int attrnamespace', 'void *data', 'size_t nbytes']
 	case 439: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4361,6 +4689,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 441 int ksem_timedwait ['semid_t id', 'const struct timespec *abstime']
 	case 441: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4374,6 +4703,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 442 int thr_suspend ['const struct timespec *timeout']
 	case 442: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4385,6 +4715,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 443 int thr_wake ['long id']
 	case 443: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int64_t arg0 = get_s64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4396,6 +4727,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 444 int kldunloadf ['int fileid', 'int flags']
 	case 444: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4409,6 +4741,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 445 int audit ['const void *record', 'unsigned length']
 	case 445: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4422,6 +4755,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 446 int auditon ['int cmd', 'void *data', 'unsigned length']
 	case 446: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4437,6 +4771,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 447 int getauid ['uid_t *auid']
 	case 447: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4448,6 +4783,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 448 int setauid ['uid_t *auid']
 	case 448: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4459,6 +4795,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 449 int getaudit ['struct auditinfo *auditinfo']
 	case 449: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4470,6 +4807,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 450 int setaudit ['struct auditinfo *auditinfo']
 	case 450: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4481,6 +4819,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 451 int getaudit_addr ['struct auditinfo_addr *auditinfo_addr', 'unsigned length']
 	case 451: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4494,6 +4833,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 452 int setaudit_addr ['struct auditinfo_addr *auditinfo_addr', 'unsigned length']
 	case 452: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4507,6 +4847,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 453 int auditctl ['const char *path']
 	case 453: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4518,6 +4859,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 454 int _umtx_op ['void *obj', 'int op', 'u_long val', 'void *uaddr1', 'void *uaddr2']
 	case 454: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int64_t arg2 = get_s64(cpu, 2);
@@ -4537,6 +4879,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 455 int thr_new ['struct thr_param *param', 'int param_size']
 	case 455: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4550,6 +4893,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 456 int sigqueue ['pid_t pid', 'int signum', 'void *value']
 	case 456: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4565,6 +4909,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 457 int kmq_open ['const char *path', 'int flags', 'mode_t mode', 'const struct mq_attr *attr']
 	case 457: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4582,6 +4927,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 458 int kmq_setattr ['int mqd', 'const struct mq_attr *attr', 'struct mq_attr *oattr']
 	case 458: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4597,6 +4943,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 459 int kmq_timedreceive ['int mqd', 'char *msg_ptr', 'size_t msg_len', 'unsigned *msg_prio', 'const struct timespec *abs_timeout']
 	case 459: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4616,6 +4963,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 460 int kmq_timedsend ['int mqd', 'const char *msg_ptr', 'size_t msg_len', 'unsigned msg_prio', 'const struct timespec *abs_timeout']
 	case 460: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4635,6 +4983,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 461 int kmq_notify ['int mqd', 'const struct sigevent *sigev']
 	case 461: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4648,6 +4997,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 462 int kmq_unlink ['const char *path']
 	case 462: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4659,6 +5009,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 463 int abort2 ['const char *why', 'int nargs', 'void **args']
 	case 463: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4674,6 +5025,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 464 int thr_set_name ['long id', 'const char *name']
 	case 464: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int64_t arg0 = get_s64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4687,6 +5039,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 465 int aio_fsync ['int op', 'struct aiocb *aiocbp']
 	case 465: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4700,6 +5053,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 466 int rtprio_thread ['int function', 'lwpid_t lwpid', 'struct rtprio *rtp']
 	case 466: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4715,6 +5069,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 471 int sctp_peeloff ['int sd', 'uint32_t name']
 	case 471: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4728,6 +5083,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 472 int sctp_generic_sendmsg ['int sd', 'void *msg', 'int mlen', 'struct sockaddr *to', '__socklen_t tolen', 'struct sctp_sndrcvinfo *sinfo', 'int flags']
 	case 472: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4751,6 +5107,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 473 int sctp_generic_sendmsg_iov ['int sd', 'struct iovec *iov', 'int iovlen', 'struct sockaddr *to', '__socklen_t tolen', 'struct sctp_sndrcvinfo *sinfo', 'int flags']
 	case 473: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4774,6 +5131,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 474 int sctp_generic_recvmsg ['int sd', 'struct iovec *iov', 'int iovlen', 'struct sockaddr *from', '__socklen_t *fromlenaddr', 'struct sctp_sndrcvinfo *sinfo', 'int *msg_flags']
 	case 474: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4797,6 +5155,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 475 ssize_t pread ['int fd', 'void *buf', 'size_t nbyte', 'off_t offset']
 	case 475: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4814,6 +5173,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 476 ssize_t pwrite ['int fd', 'const void *buf', 'size_t nbyte', 'off_t offset']
 	case 476: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4831,6 +5191,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 478 off_t lseek ['int fd', 'off_t offset', 'int whence']
 	case 478: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4846,6 +5207,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 479 int truncate ['const char *path', 'off_t length']
 	case 479: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4859,6 +5221,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 480 int ftruncate ['int fd', 'off_t length']
 	case 480: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4872,6 +5235,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 481 int thr_kill2 ['pid_t pid', 'long id', 'int sig']
 	case 481: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4887,6 +5251,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 482 int shm_open ['const char *path', 'int flags', 'mode_t mode']
 	case 482: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4902,6 +5267,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 483 int shm_unlink ['const char *path']
 	case 483: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4913,6 +5279,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 484 int cpuset ['cpusetid_t *setid']
 	case 484: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4924,6 +5291,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 485 int cpuset_setid ['cpuwhich_t which', 'id_t id', 'cpusetid_t setid']
 	case 485: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4939,6 +5307,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 486 int cpuset_getid ['cpulevel_t level', 'cpuwhich_t which', 'id_t id', 'cpusetid_t *setid']
 	case 486: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4956,6 +5325,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 487 int cpuset_getaffinity ['cpulevel_t level', 'cpuwhich_t which', 'id_t id', 'size_t cpusetsize', 'cpuset_t *mask']
 	case 487: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4975,6 +5345,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 488 int cpuset_setaffinity ['cpulevel_t level', 'cpuwhich_t which', 'id_t id', 'size_t cpusetsize', 'const cpuset_t *mask']
 	case 488: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4994,6 +5365,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 489 int faccessat ['int fd', 'const char *path', 'int amode', 'int flag']
 	case 489: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5011,6 +5383,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 490 int fchmodat ['int fd', 'const char *path', 'mode_t mode', 'int flag']
 	case 490: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5028,6 +5401,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 491 int fchownat ['int fd', 'const char *path', 'uid_t uid', 'gid_t gid', 'int flag']
 	case 491: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5047,6 +5421,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 492 int fexecve ['int fd', 'char **argv', 'char **envv']
 	case 492: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5062,6 +5437,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 493 int fstatat ['int fd', 'const char *path', 'struct freebsd11_stat *buf', 'int flag']
 	case 493: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5079,6 +5455,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 494 int futimesat ['int fd', 'const char *path', 'struct timeval *times']
 	case 494: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5094,6 +5471,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 495 int linkat ['int fd1', 'const char *path1', 'int fd2', 'const char *path2', 'int flag']
 	case 495: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5113,6 +5491,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 496 int mkdirat ['int fd', 'const char *path', 'mode_t mode']
 	case 496: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5128,6 +5507,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 497 int mkfifoat ['int fd', 'const char *path', 'mode_t mode']
 	case 497: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5143,6 +5523,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 498 int mknodat ['int fd', 'const char *path', 'mode_t mode', 'uint32_t dev']
 	case 498: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5160,6 +5541,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 499 int openat ['int fd', 'const char *path', 'int flag', 'mode_t mode']
 	case 499: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5177,6 +5559,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 500 ssize_t readlinkat ['int fd', 'const char *path', 'char *buf', 'size_t bufsize']
 	case 500: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5194,6 +5577,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 501 int renameat ['int oldfd', 'const char *old', 'int newfd', 'const char *new']
 	case 501: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5211,6 +5595,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 502 int symlinkat ['const char *path1', 'int fd', 'const char *path2']
 	case 502: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5226,6 +5611,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 503 int unlinkat ['int fd', 'const char *path', 'int flag']
 	case 503: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5241,6 +5627,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 504 int posix_openpt ['int flags']
 	case 504: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5252,6 +5639,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 505 int gssd_syscall ['const char *path']
 	case 505: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5263,6 +5651,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 506 int jail_get ['struct iovec *iovp', 'unsigned int iovcnt', 'int flags']
 	case 506: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5278,6 +5667,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 507 int jail_set ['struct iovec *iovp', 'unsigned int iovcnt', 'int flags']
 	case 507: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5293,6 +5683,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 508 int jail_remove ['int jid']
 	case 508: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5304,6 +5695,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 509 int closefrom ['int lowfd']
 	case 509: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5315,6 +5707,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 510 int __semctl ['int semid', 'int semnum', 'int cmd', 'union semun *arg']
 	case 510: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5332,6 +5725,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 511 int msgctl ['int msqid', 'int cmd', 'struct msqid_ds *buf']
 	case 511: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5347,6 +5741,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 512 int shmctl ['int shmid', 'int cmd', 'struct shmid_ds *buf']
 	case 512: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5362,6 +5757,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 513 int lpathconf ['const char *path', 'int name']
 	case 513: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5375,6 +5771,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 515 int __cap_rights_get ['int version', 'int fd', 'cap_rights_t *rightsp']
 	case 515: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5390,11 +5787,13 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 516 int cap_enter ['void']
 	case 516: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_cap_enter_enter, cpu, pc);
 	}; break;
 	// 517 int cap_getmode ['unsigned *modep']
 	case 517: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5406,6 +5805,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 518 int pdfork ['int *fdp', 'int flags']
 	case 518: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5419,6 +5819,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 519 int pdkill ['int fd', 'int signum']
 	case 519: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5432,6 +5833,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 520 int pdgetpid ['int fd', 'pid_t *pidp']
 	case 520: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5445,6 +5847,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 522 int pselect ['int nd', 'fd_set *in', 'fd_set *ou', 'fd_set *ex', 'const struct timespec *ts', 'const sigset_t *sm']
 	case 522: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5466,6 +5869,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 523 int getloginclass ['char *namebuf', 'size_t namelen']
 	case 523: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5479,6 +5883,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 524 int setloginclass ['const char *namebuf']
 	case 524: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5490,6 +5895,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 525 int rctl_get_racct ['const void *inbufp', 'size_t inbuflen', 'void *outbufp', 'size_t outbuflen']
 	case 525: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5507,6 +5913,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 526 int rctl_get_rules ['const void *inbufp', 'size_t inbuflen', 'void *outbufp', 'size_t outbuflen']
 	case 526: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5524,6 +5931,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 527 int rctl_get_limits ['const void *inbufp', 'size_t inbuflen', 'void *outbufp', 'size_t outbuflen']
 	case 527: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5541,6 +5949,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 528 int rctl_add_rule ['const void *inbufp', 'size_t inbuflen', 'void *outbufp', 'size_t outbuflen']
 	case 528: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5558,6 +5967,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 529 int rctl_remove_rule ['const void *inbufp', 'size_t inbuflen', 'void *outbufp', 'size_t outbuflen']
 	case 529: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5575,6 +5985,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 530 int posix_fallocate ['int fd', 'off_t offset', 'off_t len']
 	case 530: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5590,6 +6001,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 531 int posix_fadvise ['int fd', 'off_t offset', 'off_t len', 'int advice']
 	case 531: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5607,6 +6019,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 532 int wait6 ['idtype_t idtype', 'id_t id', 'int *status', 'int options', 'struct __wrusage *wrusage', 'siginfo_t *info']
 	case 532: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5628,6 +6041,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 533 int cap_rights_limit ['int fd', 'cap_rights_t *rightsp']
 	case 533: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5641,6 +6055,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 534 int cap_ioctls_limit ['int fd', 'const u_long *cmds', 'size_t ncmds']
 	case 534: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5656,6 +6071,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 535 ssize_t cap_ioctls_get ['int fd', 'u_long *cmds', 'size_t maxcmds']
 	case 535: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5671,6 +6087,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 536 int cap_fcntls_limit ['int fd', 'uint32_t fcntlrights']
 	case 536: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5684,6 +6101,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 537 int cap_fcntls_get ['int fd', 'uint32_t *fcntlrightsp']
 	case 537: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5697,6 +6115,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 538 int bindat ['int fd', 'int s', 'const struct sockaddr *name', 'int namelen']
 	case 538: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5714,6 +6133,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 539 int connectat ['int fd', 'int s', 'const struct sockaddr *name', 'int namelen']
 	case 539: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5731,6 +6151,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 540 int chflagsat ['int fd', 'const char *path', 'u_long flags', 'int atflag']
 	case 540: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int64_t arg2 = get_s64(cpu, 2);
@@ -5748,6 +6169,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 541 int accept4 ['int s', 'struct sockaddr *name', '__socklen_t *anamelen', 'int flags']
 	case 541: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5765,6 +6187,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 542 int pipe2 ['int *fildes', 'int flags']
 	case 542: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5778,6 +6201,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 543 int aio_mlock ['struct aiocb *aiocbp']
 	case 543: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5789,6 +6213,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 544 int procctl ['idtype_t idtype', 'id_t id', 'int com', 'void *data']
 	case 544: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5806,6 +6231,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 545 int ppoll ['struct pollfd *fds', 'unsigned nfds', 'const struct timespec *ts', 'const sigset_t *set']
 	case 545: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5823,6 +6249,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 546 int futimens ['int fd', 'struct timespec *times']
 	case 546: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5836,6 +6263,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 547 int utimensat ['int fd', 'const char *path', 'struct timespec *times', 'int flag']
 	case 547: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5853,6 +6281,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 550 int fdatasync ['int fd']
 	case 550: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5864,6 +6293,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 551 int fstat ['int fd', 'struct stat *sb']
 	case 551: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5877,6 +6307,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 552 int fstatat ['int fd', 'const char *path', 'struct stat *buf', 'int flag']
 	case 552: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -5894,6 +6325,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 553 int fhstat ['const struct fhandle *u_fhp', 'struct stat *sb']
 	case 553: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5907,6 +6339,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 554 ssize_t getdirentries ['int fd', 'char *buf', 'size_t count', 'off_t *basep']
 	case 554: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5924,6 +6357,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 555 int statfs ['const char *path', 'struct statfs *buf']
 	case 555: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5937,6 +6371,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 556 int fstatfs ['int fd', 'struct statfs *buf']
 	case 556: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5950,6 +6385,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 557 int getfsstat ['struct statfs *buf', 'long bufsize', 'int mode']
 	case 557: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5965,6 +6401,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 558 int fhstatfs ['const struct fhandle *u_fhp', 'struct statfs *buf']
 	case 558: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5978,6 +6415,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 559 int mknodat ['int fd', 'const char *path', 'mode_t mode', 'dev_t dev']
 	case 559: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5995,6 +6433,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 560 int kevent ['int fd', 'struct kevent *changelist', 'int nchanges', 'struct kevent *eventlist', 'int nevents', 'const struct timespec *timeout']
 	case 560: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -6016,6 +6455,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 561 int cpuset_getdomain ['cpulevel_t level', 'cpuwhich_t which', 'id_t id', 'size_t domainsetsize', 'domainset_t *mask', 'int *policy']
 	case 561: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6037,6 +6477,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 562 int cpuset_setdomain ['cpulevel_t level', 'cpuwhich_t which', 'id_t id', 'size_t domainsetsize', 'domainset_t *mask', 'int policy']
 	case 562: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6058,6 +6499,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 563 int getrandom ['void *buf', 'size_t buflen', 'unsigned int flags']
 	case 563: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6073,6 +6515,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 564 int getfhat ['int fd', 'char *path', 'struct fhandle *fhp', 'int flags']
 	case 564: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -6090,6 +6533,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 565 int fhlink ['struct fhandle *fhp', 'const char *to']
 	case 565: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6103,6 +6547,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 566 int fhlinkat ['struct fhandle *fhp', 'int tofd', 'const char *to', '']
 	case 566: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -6118,6 +6563,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 567 int fhreadlink ['struct fhandle *fhp', 'char *buf', 'size_t bufsize']
 	case 567: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6133,6 +6579,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 568 int funlinkat ['int dfd', 'const char *path', 'int fd', 'int flag']
 	case 568: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -6150,6 +6597,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 569 ssize_t copy_file_range ['int infd', 'off_t *inoffp', 'int outfd', 'off_t *outoffp', 'size_t len', 'unsigned int flags']
 	case 569: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -6171,6 +6619,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 570 int __sysctlbyname ['const char *name', 'size_t namelen', 'void *old', 'size_t *oldlenp', 'void *new', 'size_t newlen']
 	case 570: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -6192,6 +6641,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 571 int shm_open2 ['const char *path', 'int flags', 'mode_t mode', 'int shmflags', 'const char *name']
 	case 571: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6211,6 +6661,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 572 int shm_rename ['const char *path_from', 'const char *path_to', 'int flags']
 	case 572: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -6226,6 +6677,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 573 int sigfastblock ['int cmd', 'uint32_t *ptr']
 	case 573: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6239,6 +6691,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 574 int __realpathat ['int fd', 'const char *path', 'char *buf', 'size_t size', 'int flags']
 	case 574: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -6258,6 +6711,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 575 int close_range ['unsigned lowfd', 'unsigned highfd', 'int flags']
 	case 575: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -6273,6 +6727,7 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 	// 576 int rpctls_syscall ['int op', 'const char *path']
 	case 576: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -48,11 +49,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 0 long sys_restart_syscall ['void']
 	case 0: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_restart_syscall_enter, cpu, pc);
 	}; break;
 	// 1 long sys_exit ['int error_code']
 	case 1: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -64,11 +67,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 2 long sys_fork ['void']
 	case 2: {
 		panda_noreturn = false;
+		ctx.double_return = true;
 		PPP_RUN_CB(on_sys_fork_enter, cpu, pc);
 	}; break;
 	// 3 long sys_read ['unsigned int fd', 'char __user *buf', 'size_t count']
 	case 3: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -84,6 +89,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 4 long sys_write ['unsigned int fd', 'const char __user *buf', 'size_t count']
 	case 4: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -99,6 +105,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 5 long sys_open ['const char __user *filename', 'int flags', 'umode_t mode']
 	case 5: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -114,6 +121,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 6 long sys_close ['unsigned int fd']
 	case 6: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -125,6 +133,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 8 long sys_creat ['const char __user *pathname', 'umode_t mode']
 	case 8: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -138,6 +147,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 9 long sys_link ['const char __user *oldname', 'const char __user *newname']
 	case 9: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -151,6 +161,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 10 long sys_unlink ['const char __user *pathname']
 	case 10: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -162,6 +173,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 11 long sys_execve ['const char __user *filename', 'const char __user *const __user *argv', 'const char __user *const __user *envp']
 	case 11: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -177,6 +189,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 12 long sys_chdir ['const char __user *filename']
 	case 12: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -188,6 +201,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 13 long sys_time ['time_t __user *tloc']
 	case 13: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -199,6 +213,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 14 long sys_mknod ['const char __user *filename', 'umode_t mode', 'unsigned dev']
 	case 14: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -214,6 +229,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 15 long sys_chmod ['const char __user *filename', 'umode_t mode']
 	case 15: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -227,6 +243,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 16 long sys_lchown16 ['const char __user *filename', 'old_uid_t user', 'old_gid_t group']
 	case 16: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -242,6 +259,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 19 long sys_lseek ['unsigned int fd', 'off_t offset', 'unsigned int whence']
 	case 19: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -257,11 +275,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 20 long sys_getpid ['void']
 	case 20: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getpid_enter, cpu, pc);
 	}; break;
 	// 21 long sys_mount ['char __user *dev_name', 'char __user *dir_name', 'char __user *type', 'unsigned long flags', 'void __user *data']
 	case 21: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -281,6 +301,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 23 long sys_setuid16 ['old_uid_t uid']
 	case 23: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -292,11 +313,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 24 long sys_getuid16 ['void']
 	case 24: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getuid16_enter, cpu, pc);
 	}; break;
 	// 25 long sys_stime ['time_t __user *tptr']
 	case 25: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -308,6 +331,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 26 long sys_ptrace ['long request', 'long pid', 'unsigned long addr', 'unsigned long data']
 	case 26: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -325,6 +349,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 27 long sys_alarm ['unsigned int seconds']
 	case 27: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -336,11 +361,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 29 long sys_pause ['void']
 	case 29: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_pause_enter, cpu, pc);
 	}; break;
 	// 30 long sys_utime ['char __user *filename', 'struct utimbuf __user *times']
 	case 30: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -354,6 +381,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 33 long sys_access ['const char __user *filename', 'int mode']
 	case 33: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -367,6 +395,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 34 long sys_nice ['int increment']
 	case 34: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -378,11 +407,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 36 long sys_sync ['void']
 	case 36: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sync_enter, cpu, pc);
 	}; break;
 	// 37 long sys_kill ['int pid', 'int sig']
 	case 37: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -396,6 +427,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 38 long sys_rename ['const char __user *oldname', 'const char __user *newname']
 	case 38: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -409,6 +441,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 39 long sys_mkdir ['const char __user *pathname', 'umode_t mode']
 	case 39: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -422,6 +455,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 40 long sys_rmdir ['const char __user *pathname']
 	case 40: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -433,6 +467,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 41 long sys_dup ['unsigned int fildes']
 	case 41: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -444,6 +479,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 42 long sys_pipe ['int __user *fildes']
 	case 42: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -455,6 +491,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 43 long sys_times ['struct tms __user *tbuf']
 	case 43: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -466,6 +503,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 45 long sys_brk ['unsigned long brk']
 	case 45: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -477,6 +515,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 46 long sys_setgid16 ['old_gid_t gid']
 	case 46: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -488,21 +527,25 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 47 long sys_getgid16 ['void']
 	case 47: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getgid16_enter, cpu, pc);
 	}; break;
 	// 49 long sys_geteuid16 ['void']
 	case 49: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_geteuid16_enter, cpu, pc);
 	}; break;
 	// 50 long sys_getegid16 ['void']
 	case 50: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getegid16_enter, cpu, pc);
 	}; break;
 	// 51 long sys_acct ['const char __user *name']
 	case 51: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -514,6 +557,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 52 long sys_umount ['char __user *name', 'int flags']
 	case 52: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -527,6 +571,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 54 long sys_ioctl ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 54: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -542,6 +587,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 55 long sys_fcntl ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 55: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -557,6 +603,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 57 long sys_setpgid ['pid_t pid', 'pid_t pgid']
 	case 57: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -570,6 +617,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 60 long sys_umask ['int mask']
 	case 60: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -581,6 +629,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 61 long sys_chroot ['const char __user *filename']
 	case 61: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -592,6 +641,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 62 long sys_ustat ['unsigned dev', 'struct ustat __user *ubuf']
 	case 62: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -605,6 +655,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 63 long sys_dup2 ['unsigned int oldfd', 'unsigned int newfd']
 	case 63: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -618,21 +669,25 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 64 long sys_getppid ['void']
 	case 64: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getppid_enter, cpu, pc);
 	}; break;
 	// 65 long sys_getpgrp ['void']
 	case 65: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getpgrp_enter, cpu, pc);
 	}; break;
 	// 66 long sys_setsid ['void']
 	case 66: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_setsid_enter, cpu, pc);
 	}; break;
 	// 67 long sys_sigaction ['int', 'const struct old_sigaction __user *', 'struct old_sigaction __user *']
 	case 67: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -648,6 +703,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 70 long sys_setreuid16 ['old_uid_t ruid', 'old_uid_t euid']
 	case 70: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -661,6 +717,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 71 long sys_setregid16 ['old_gid_t rgid', 'old_gid_t egid']
 	case 71: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -674,6 +731,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 72 long sys_sigsuspend ['int unused1', 'int unused2', 'old_sigset_t mask']
 	case 72: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -689,6 +747,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 73 long sys_sigpending ['old_sigset_t __user *set']
 	case 73: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -700,6 +759,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 74 long sys_sethostname ['char __user *name', 'int len']
 	case 74: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -713,6 +773,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 75 long sys_setrlimit ['unsigned int resource', 'struct rlimit __user *rlim']
 	case 75: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -726,6 +787,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 77 long sys_getrusage ['int who', 'struct rusage __user *ru']
 	case 77: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -739,6 +801,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 78 long sys_gettimeofday ['struct timeval __user *tv', 'struct timezone __user *tz']
 	case 78: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -752,6 +815,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 79 long sys_settimeofday ['struct timeval __user *tv', 'struct timezone __user *tz']
 	case 79: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -765,6 +829,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 80 long sys_getgroups16 ['int gidsetsize', 'old_gid_t __user *grouplist']
 	case 80: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -778,6 +843,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 81 long sys_setgroups16 ['int gidsetsize', 'old_gid_t __user *grouplist']
 	case 81: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -791,6 +857,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 83 long sys_symlink ['const char __user *old', 'const char __user *new']
 	case 83: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -804,6 +871,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 85 long sys_readlink ['const char __user *path', 'char __user *buf', 'int bufsiz']
 	case 85: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -819,6 +887,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 86 long sys_uselib ['const char __user *library']
 	case 86: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -830,6 +899,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 87 long sys_swapon ['const char __user *specialfile', 'int swap_flags']
 	case 87: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -843,6 +913,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 88 long sys_reboot ['int magic1', 'int magic2', 'unsigned int cmd', 'void __user *arg']
 	case 88: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -860,6 +931,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 91 long sys_munmap ['unsigned long addr', 'size_t len']
 	case 91: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -873,6 +945,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 92 long sys_truncate ['const char __user *path', 'long length']
 	case 92: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -886,6 +959,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 93 long sys_ftruncate ['unsigned int fd', 'unsigned long length']
 	case 93: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -899,6 +973,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 94 long sys_fchmod ['unsigned int fd', 'umode_t mode']
 	case 94: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -912,6 +987,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 95 long sys_fchown16 ['unsigned int fd', 'old_uid_t user', 'old_gid_t group']
 	case 95: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -927,6 +1003,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 96 long sys_getpriority ['int which', 'int who']
 	case 96: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -940,6 +1017,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 97 long sys_setpriority ['int which', 'int who', 'int niceval']
 	case 97: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -955,6 +1033,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 99 long sys_statfs ['const char __user *path', 'struct statfs __user *buf']
 	case 99: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -968,6 +1047,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 100 long sys_fstatfs ['unsigned int fd', 'struct statfs __user *buf']
 	case 100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -981,6 +1061,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 102 long sys_socketcall ['int call', 'unsigned long __user *args']
 	case 102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -994,6 +1075,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 103 long sys_syslog ['int type', 'char __user *buf', 'int len']
 	case 103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1009,6 +1091,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 104 long sys_setitimer ['int which', 'struct itimerval __user *value', 'struct itimerval __user *ovalue']
 	case 104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1024,6 +1107,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 105 long sys_getitimer ['int which', 'struct itimerval __user *value']
 	case 105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1037,6 +1121,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 106 long sys_newstat ['const char __user *filename', 'struct stat __user *statbuf']
 	case 106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1050,6 +1135,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 107 long sys_newlstat ['const char __user *filename', 'struct stat __user *statbuf']
 	case 107: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1063,6 +1149,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 108 long sys_newfstat ['unsigned int fd', 'struct stat __user *statbuf']
 	case 108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1076,11 +1163,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 111 long sys_vhangup ['void']
 	case 111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_vhangup_enter, cpu, pc);
 	}; break;
 	// 114 long sys_wait4 ['pid_t pid', 'int __user *stat_addr', 'int options', 'struct rusage __user *ru']
 	case 114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1098,6 +1187,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 115 long sys_swapoff ['const char __user *specialfile']
 	case 115: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1109,6 +1199,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 116 long sys_sysinfo ['struct sysinfo __user *info']
 	case 116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1120,6 +1211,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 117 long sys_ipc ['unsigned int call', 'int first', 'unsigned long second', 'unsigned long third', 'void __user *ptr', 'long fifth']
 	case 117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1141,6 +1233,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 118 long sys_fsync ['unsigned int fd']
 	case 118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1152,6 +1245,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 119 int sys_sigreturn ['struct pt_regs *regs']
 	case 119: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1163,6 +1257,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 120 long sys_clone ['unsigned long', 'unsigned long', 'int __user *', 'int __user *', 'unsigned long']
 	case 120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1182,6 +1277,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 121 long sys_setdomainname ['char __user *name', 'int len']
 	case 121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1195,6 +1291,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 122 long sys_newuname ['struct new_utsname __user *name']
 	case 122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1206,6 +1303,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 124 long sys_adjtimex ['struct timex __user *txc_p']
 	case 124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1217,6 +1315,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 125 long sys_mprotect ['unsigned long start', 'size_t len', 'unsigned long prot']
 	case 125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1232,6 +1331,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 126 long sys_sigprocmask ['int how', 'old_sigset_t __user *set', 'old_sigset_t __user *oset']
 	case 126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1247,6 +1347,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 128 long sys_init_module ['void __user *umod', 'unsigned long len', 'const char __user *uargs']
 	case 128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1262,6 +1363,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 129 long sys_delete_module ['const char __user *name_user', 'unsigned int flags']
 	case 129: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1275,6 +1377,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 131 long sys_quotactl ['unsigned int cmd', 'const char __user *special', 'qid_t id', 'void __user *addr']
 	case 131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1292,6 +1395,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 132 long sys_getpgid ['pid_t pid']
 	case 132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1303,6 +1407,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 133 long sys_fchdir ['unsigned int fd']
 	case 133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1314,6 +1419,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 134 long sys_bdflush ['int func', 'long data']
 	case 134: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1327,6 +1433,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 135 long sys_sysfs ['int option', 'unsigned long arg1', 'unsigned long arg2']
 	case 135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1342,6 +1449,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 136 long sys_personality ['unsigned int personality']
 	case 136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1353,6 +1461,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 138 long sys_setfsuid16 ['old_uid_t uid']
 	case 138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1364,6 +1473,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 139 long sys_setfsgid16 ['old_gid_t gid']
 	case 139: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1375,6 +1485,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 140 long sys_llseek ['unsigned int fd', 'unsigned long offset_high', 'unsigned long offset_low', 'loff_t __user *result', 'unsigned int whence']
 	case 140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1394,6 +1505,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 141 long sys_getdents ['unsigned int fd', 'struct linux_dirent __user *dirent', 'unsigned int count']
 	case 141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1409,6 +1521,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 142 long sys_select ['int n', 'fd_set __user *inp', 'fd_set __user *outp', 'fd_set __user *exp', 'struct timeval __user *tvp']
 	case 142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1428,6 +1541,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 143 long sys_flock ['unsigned int fd', 'unsigned int cmd']
 	case 143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1441,6 +1555,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 144 long sys_msync ['unsigned long start', 'size_t len', 'int flags']
 	case 144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1456,6 +1571,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 145 long sys_readv ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen']
 	case 145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1471,6 +1587,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 146 long sys_writev ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen']
 	case 146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1486,6 +1603,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 147 long sys_getsid ['pid_t pid']
 	case 147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1497,6 +1615,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 148 long sys_fdatasync ['unsigned int fd']
 	case 148: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1508,6 +1627,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 149 long sys_sysctl ['struct __sysctl_args __user *args']
 	case 149: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1519,6 +1639,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 150 long sys_mlock ['unsigned long start', 'size_t len']
 	case 150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1532,6 +1653,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 151 long sys_munlock ['unsigned long start', 'size_t len']
 	case 151: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1545,6 +1667,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 152 long sys_mlockall ['int flags']
 	case 152: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1556,11 +1679,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 153 long sys_munlockall ['void']
 	case 153: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_munlockall_enter, cpu, pc);
 	}; break;
 	// 154 long sys_sched_setparam ['pid_t pid', 'struct sched_param __user *param']
 	case 154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1574,6 +1699,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 155 long sys_sched_getparam ['pid_t pid', 'struct sched_param __user *param']
 	case 155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1587,6 +1713,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 156 long sys_sched_setscheduler ['pid_t pid', 'int policy', 'struct sched_param __user *param']
 	case 156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1602,6 +1729,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 157 long sys_sched_getscheduler ['pid_t pid']
 	case 157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1613,11 +1741,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 158 long sys_sched_yield ['void']
 	case 158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sched_yield_enter, cpu, pc);
 	}; break;
 	// 159 long sys_sched_get_priority_max ['int policy']
 	case 159: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1629,6 +1759,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 160 long sys_sched_get_priority_min ['int policy']
 	case 160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1640,6 +1771,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 161 long sys_sched_rr_get_interval ['pid_t pid', 'struct timespec __user *interval']
 	case 161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1653,6 +1785,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 162 long sys_nanosleep ['struct timespec __user *rqtp', 'struct timespec __user *rmtp']
 	case 162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1666,6 +1799,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 163 long sys_mremap ['unsigned long addr', 'unsigned long old_len', 'unsigned long new_len', 'unsigned long flags', 'unsigned long new_addr']
 	case 163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1685,6 +1819,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 164 long sys_setresuid16 ['old_uid_t ruid', 'old_uid_t euid', 'old_uid_t suid']
 	case 164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1700,6 +1835,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 165 long sys_getresuid16 ['old_uid_t __user *ruid', 'old_uid_t __user *euid', 'old_uid_t __user *suid']
 	case 165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1715,6 +1851,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 168 long sys_poll ['struct pollfd __user *ufds', 'unsigned int nfds', 'int timeout']
 	case 168: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1730,6 +1867,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 170 long sys_setresgid16 ['old_gid_t rgid', 'old_gid_t egid', 'old_gid_t sgid']
 	case 170: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1745,6 +1883,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 171 long sys_getresgid16 ['old_gid_t __user *rgid', 'old_gid_t __user *egid', 'old_gid_t __user *sgid']
 	case 171: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1760,6 +1899,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 172 long sys_prctl ['int option', 'unsigned long arg2', 'unsigned long arg3', 'unsigned long arg4', 'unsigned long arg5']
 	case 172: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1779,6 +1919,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 173 int sys_rt_sigreturn ['struct pt_regs *regs']
 	case 173: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1790,6 +1931,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 174 long sys_rt_sigaction ['int', 'const struct sigaction __user *', 'struct sigaction __user *', 'size_t']
 	case 174: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1807,6 +1949,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 175 long sys_rt_sigprocmask ['int how', 'sigset_t __user *set', 'sigset_t __user *oset', 'size_t sigsetsize']
 	case 175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1824,6 +1967,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 176 long sys_rt_sigpending ['sigset_t __user *set', 'size_t sigsetsize']
 	case 176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1837,6 +1981,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 177 long sys_rt_sigtimedwait ['const sigset_t __user *uthese', 'siginfo_t __user *uinfo', 'const struct timespec __user *uts', 'size_t sigsetsize']
 	case 177: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1854,6 +1999,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 178 long sys_rt_sigqueueinfo ['int pid', 'int sig', 'siginfo_t __user *uinfo']
 	case 178: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1869,6 +2015,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 179 long sys_rt_sigsuspend ['sigset_t __user *unewset', 'size_t sigsetsize']
 	case 179: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1882,6 +2029,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 180 long sys_pread64 ['unsigned int fd', 'char __user *buf', 'size_t count', 'loff_t pos']
 	case 180: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1899,6 +2047,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 181 long sys_pwrite64 ['unsigned int fd', 'const char __user *buf', 'size_t count', 'loff_t pos']
 	case 181: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1916,6 +2065,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 182 long sys_chown16 ['const char __user *filename', 'old_uid_t user', 'old_gid_t group']
 	case 182: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1931,6 +2081,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 183 long sys_getcwd ['char __user *buf', 'unsigned long size']
 	case 183: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1944,6 +2095,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 184 long sys_capget ['cap_user_header_t header', 'cap_user_data_t dataptr']
 	case 184: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1957,6 +2109,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 185 long sys_capset ['cap_user_header_t header', 'const cap_user_data_t data']
 	case 185: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1970,6 +2123,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 186 long sys_sigaltstack ['const struct sigaltstack __user *uss', 'struct sigaltstack __user *uoss']
 	case 186: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1983,6 +2137,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 187 long sys_sendfile ['int out_fd', 'int in_fd', 'off_t __user *offset', 'size_t count']
 	case 187: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2000,11 +2155,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 190 long sys_vfork ['void']
 	case 190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_vfork_enter, cpu, pc);
 	}; break;
 	// 191 long sys_getrlimit ['unsigned int resource', 'struct rlimit __user *rlim']
 	case 191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2018,6 +2175,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 192 long do_mmap2 ['unsigned long addr', 'unsigned long len', 'unsigned long prot', 'unsigned long flags', 'unsigned long fd', 'unsigned long pgoff']
 	case 192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2039,6 +2197,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 193 long sys_truncate64 ['const char __user *path', 'loff_t length']
 	case 193: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2052,6 +2211,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 194 long sys_ftruncate64 ['unsigned int fd', 'loff_t length']
 	case 194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2065,6 +2225,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 195 long sys_stat64 ['const char __user *filename', 'struct stat64 __user *statbuf']
 	case 195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2078,6 +2239,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 196 long sys_lstat64 ['const char __user *filename', 'struct stat64 __user *statbuf']
 	case 196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2091,6 +2253,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 197 long sys_fstat64 ['unsigned long fd', 'struct stat64 __user *statbuf']
 	case 197: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2104,6 +2267,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 198 long sys_lchown ['const char __user *filename', 'uid_t user', 'gid_t group']
 	case 198: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2119,26 +2283,31 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 199 long sys_getuid ['void']
 	case 199: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getuid_enter, cpu, pc);
 	}; break;
 	// 200 long sys_getgid ['void']
 	case 200: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getgid_enter, cpu, pc);
 	}; break;
 	// 201 long sys_geteuid ['void']
 	case 201: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_geteuid_enter, cpu, pc);
 	}; break;
 	// 202 long sys_getegid ['void']
 	case 202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getegid_enter, cpu, pc);
 	}; break;
 	// 203 long sys_setreuid ['uid_t ruid', 'uid_t euid']
 	case 203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2152,6 +2321,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 204 long sys_setregid ['gid_t rgid', 'gid_t egid']
 	case 204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2165,6 +2335,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 205 long sys_getgroups ['int gidsetsize', 'gid_t __user *grouplist']
 	case 205: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2178,6 +2349,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 206 long sys_setgroups ['int gidsetsize', 'gid_t __user *grouplist']
 	case 206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2191,6 +2363,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 207 long sys_fchown ['unsigned int fd', 'uid_t user', 'gid_t group']
 	case 207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2206,6 +2379,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 208 long sys_setresuid ['uid_t ruid', 'uid_t euid', 'uid_t suid']
 	case 208: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2221,6 +2395,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 209 long sys_getresuid ['uid_t __user *ruid', 'uid_t __user *euid', 'uid_t __user *suid']
 	case 209: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2236,6 +2411,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 210 long sys_setresgid ['gid_t rgid', 'gid_t egid', 'gid_t sgid']
 	case 210: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2251,6 +2427,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 211 long sys_getresgid ['gid_t __user *rgid', 'gid_t __user *egid', 'gid_t __user *sgid']
 	case 211: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2266,6 +2443,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 212 long sys_chown ['const char __user *filename', 'uid_t user', 'gid_t group']
 	case 212: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2281,6 +2459,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 213 long sys_setuid ['uid_t uid']
 	case 213: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2292,6 +2471,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 214 long sys_setgid ['gid_t gid']
 	case 214: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2303,6 +2483,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 215 long sys_setfsuid ['uid_t uid']
 	case 215: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2314,6 +2495,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 216 long sys_setfsgid ['gid_t gid']
 	case 216: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2325,6 +2507,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 217 long sys_getdents64 ['unsigned int fd', 'struct linux_dirent64 __user *dirent', 'unsigned int count']
 	case 217: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2340,6 +2523,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 218 long sys_pivot_root ['const char __user *new_root', 'const char __user *put_old']
 	case 218: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2353,6 +2537,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 219 long sys_mincore ['unsigned long start', 'size_t len', 'unsigned char __user *vec']
 	case 219: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2368,6 +2553,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 220 long sys_madvise ['unsigned long start', 'size_t len', 'int behavior']
 	case 220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2383,6 +2569,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 221 long sys_fcntl64 ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 221: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2398,11 +2585,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 224 long sys_gettid ['void']
 	case 224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_gettid_enter, cpu, pc);
 	}; break;
 	// 225 long sys_readahead ['int fd', 'loff_t offset', 'size_t count']
 	case 225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2418,6 +2607,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 226 long sys_setxattr ['const char __user *path', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2437,6 +2627,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 227 long sys_lsetxattr ['const char __user *path', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2456,6 +2647,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 228 long sys_fsetxattr ['int fd', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 228: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2475,6 +2667,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 229 long sys_getxattr ['const char __user *path', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2492,6 +2685,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 230 long sys_lgetxattr ['const char __user *path', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2509,6 +2703,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 231 long sys_fgetxattr ['int fd', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 231: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2526,6 +2721,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 232 long sys_listxattr ['const char __user *path', 'char __user *list', 'size_t size']
 	case 232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2541,6 +2737,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 233 long sys_llistxattr ['const char __user *path', 'char __user *list', 'size_t size']
 	case 233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2556,6 +2753,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 234 long sys_flistxattr ['int fd', 'char __user *list', 'size_t size']
 	case 234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2571,6 +2769,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 235 long sys_removexattr ['const char __user *path', 'const char __user *name']
 	case 235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2584,6 +2783,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 236 long sys_lremovexattr ['const char __user *path', 'const char __user *name']
 	case 236: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2597,6 +2797,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 237 long sys_fremovexattr ['int fd', 'const char __user *name']
 	case 237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2610,6 +2811,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 238 long sys_tkill ['int pid', 'int sig']
 	case 238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2623,6 +2825,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 239 long sys_sendfile64 ['int out_fd', 'int in_fd', 'loff_t __user *offset', 'size_t count']
 	case 239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2640,6 +2843,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 240 long sys_futex ['u32 __user *uaddr', 'int op', 'u32 val', 'struct timespec __user *utime', 'u32 __user *uaddr2', 'u32 val3']
 	case 240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2661,6 +2865,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 241 long sys_sched_setaffinity ['pid_t pid', 'unsigned int len', 'unsigned long __user *user_mask_ptr']
 	case 241: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2676,6 +2881,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 242 long sys_sched_getaffinity ['pid_t pid', 'unsigned int len', 'unsigned long __user *user_mask_ptr']
 	case 242: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2691,6 +2897,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 243 long sys_io_setup ['unsigned nr_reqs', 'aio_context_t __user *ctx']
 	case 243: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2704,6 +2911,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 244 long sys_io_destroy ['aio_context_t ctx']
 	case 244: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2715,6 +2923,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 245 long sys_io_getevents ['aio_context_t ctx_id', 'long min_nr', 'long nr', 'struct io_event __user *events', 'struct timespec __user *timeout']
 	case 245: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2734,6 +2943,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 246 long sys_io_submit ['aio_context_t', 'long', 'struct iocb __user * __user *']
 	case 246: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2749,6 +2959,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 247 long sys_io_cancel ['aio_context_t ctx_id', 'struct iocb __user *iocb', 'struct io_event __user *result']
 	case 247: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2764,6 +2975,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 248 long sys_exit_group ['int error_code']
 	case 248: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2775,6 +2987,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 249 long sys_lookup_dcookie ['u64 cookie64', 'char __user *buf', 'size_t len']
 	case 249: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2790,6 +3003,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 250 long sys_epoll_create ['int size']
 	case 250: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2801,6 +3015,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 251 long sys_epoll_ctl ['int epfd', 'int op', 'int fd', 'struct epoll_event __user *event']
 	case 251: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2818,6 +3033,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 252 long sys_epoll_wait ['int epfd', 'struct epoll_event __user *events', 'int maxevents', 'int timeout']
 	case 252: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2835,6 +3051,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 253 long sys_remap_file_pages ['unsigned long start', 'unsigned long size', 'unsigned long prot', 'unsigned long pgoff', 'unsigned long flags']
 	case 253: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2854,6 +3071,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 256 long sys_set_tid_address ['int __user *tidptr']
 	case 256: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2865,6 +3083,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 257 long sys_timer_create ['clockid_t which_clock', 'struct sigevent __user *timer_event_spec', 'timer_t __user *created_timer_id']
 	case 257: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2880,6 +3099,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 258 long sys_timer_settime ['timer_t timer_id', 'int flags', 'const struct itimerspec __user *new_setting', 'struct itimerspec __user *old_setting']
 	case 258: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2897,6 +3117,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 259 long sys_timer_gettime ['timer_t timer_id', 'struct itimerspec __user *setting']
 	case 259: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2910,6 +3131,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 260 long sys_timer_getoverrun ['timer_t timer_id']
 	case 260: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2921,6 +3143,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 261 long sys_timer_delete ['timer_t timer_id']
 	case 261: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2932,6 +3155,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 262 long sys_clock_settime ['clockid_t which_clock', 'const struct timespec __user *tp']
 	case 262: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2945,6 +3169,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 263 long sys_clock_gettime ['clockid_t which_clock', 'struct timespec __user *tp']
 	case 263: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2958,6 +3183,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 264 long sys_clock_getres ['clockid_t which_clock', 'struct timespec __user *tp']
 	case 264: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2971,6 +3197,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 265 long sys_clock_nanosleep ['clockid_t which_clock', 'int flags', 'const struct timespec __user *rqtp', 'struct timespec __user *rmtp']
 	case 265: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2988,6 +3215,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 266 long sys_statfs64 ['const char __user *path', 'size_t sz', 'struct statfs64 __user *buf']
 	case 266: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3003,6 +3231,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 267 long sys_fstatfs64 ['unsigned int fd', 'size_t sz', 'struct statfs64 __user *buf']
 	case 267: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3018,6 +3247,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 268 long sys_tgkill ['int tgid', 'int pid', 'int sig']
 	case 268: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3033,6 +3263,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 269 long sys_utimes ['char __user *filename', 'struct timeval __user *utimes']
 	case 269: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3046,6 +3277,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 270 long sys_arm_fadvise64_64 ['int fd', 'int advice', 'loff_t offset', 'loff_t len']
 	case 270: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3063,6 +3295,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 271 long sys_pciconfig_iobase ['long which', 'unsigned long bus', 'unsigned long devfn']
 	case 271: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3078,6 +3311,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 272 long sys_pciconfig_read ['unsigned long bus', 'unsigned long dfn', 'unsigned long off', 'unsigned long len', 'void __user *buf']
 	case 272: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3097,6 +3331,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 273 long sys_pciconfig_write ['unsigned long bus', 'unsigned long dfn', 'unsigned long off', 'unsigned long len', 'void __user *buf']
 	case 273: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3116,6 +3351,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 274 long sys_mq_open ['const char __user *name', 'int oflag', 'umode_t mode', 'struct mq_attr __user *attr']
 	case 274: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3133,6 +3369,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 275 long sys_mq_unlink ['const char __user *name']
 	case 275: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3144,6 +3381,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 276 long sys_mq_timedsend ['mqd_t mqdes', 'const char __user *msg_ptr', 'size_t msg_len', 'unsigned int msg_prio', 'const struct timespec __user *abs_timeout']
 	case 276: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3163,6 +3401,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 277 long sys_mq_timedreceive ['mqd_t mqdes', 'char __user *msg_ptr', 'size_t msg_len', 'unsigned int __user *msg_prio', 'const struct timespec __user *abs_timeout']
 	case 277: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3182,6 +3421,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 278 long sys_mq_notify ['mqd_t mqdes', 'const struct sigevent __user *notification']
 	case 278: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3195,6 +3435,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 279 long sys_mq_getsetattr ['mqd_t mqdes', 'const struct mq_attr __user *mqstat', 'struct mq_attr __user *omqstat']
 	case 279: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3210,6 +3451,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 280 long sys_waitid ['int which', 'pid_t pid', 'struct siginfo __user *infop', 'int options', 'struct rusage __user *ru']
 	case 280: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3229,6 +3471,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 281 long sys_socket ['int', 'int', 'int']
 	case 281: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3244,6 +3487,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 282 long sys_bind ['int', 'struct sockaddr __user *', 'int']
 	case 282: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3259,6 +3503,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 283 long sys_connect ['int', 'struct sockaddr __user *', 'int']
 	case 283: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3274,6 +3519,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 284 long sys_listen ['int', 'int']
 	case 284: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3287,6 +3533,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 285 long sys_accept ['int', 'struct sockaddr __user *', 'int __user *']
 	case 285: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3302,6 +3549,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 286 long sys_getsockname ['int', 'struct sockaddr __user *', 'int __user *']
 	case 286: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3317,6 +3565,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 287 long sys_getpeername ['int', 'struct sockaddr __user *', 'int __user *']
 	case 287: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3332,6 +3581,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 288 long sys_socketpair ['int', 'int', 'int', 'int __user *']
 	case 288: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3349,6 +3599,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 289 long sys_send ['int', 'void __user *', 'size_t', 'unsigned']
 	case 289: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3366,6 +3617,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 290 long sys_sendto ['int', 'void __user *', 'size_t', 'unsigned', 'struct sockaddr __user *', 'int']
 	case 290: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3387,6 +3639,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 291 long sys_recv ['int', 'void __user *', 'size_t', 'unsigned']
 	case 291: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3404,6 +3657,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 292 long sys_recvfrom ['int', 'void __user *', 'size_t', 'unsigned', 'struct sockaddr __user *', 'int __user *']
 	case 292: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3425,6 +3679,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 293 long sys_shutdown ['int', 'int']
 	case 293: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3438,6 +3693,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 294 long sys_setsockopt ['int fd', 'int level', 'int optname', 'char __user *optval', 'int optlen']
 	case 294: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3457,6 +3713,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 295 long sys_getsockopt ['int fd', 'int level', 'int optname', 'char __user *optval', 'int __user *optlen']
 	case 295: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3476,6 +3733,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 296 long sys_sendmsg ['int fd', 'struct user_msghdr __user *msg', 'unsigned flags']
 	case 296: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3491,6 +3749,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 297 long sys_recvmsg ['int fd', 'struct user_msghdr __user *msg', 'unsigned flags']
 	case 297: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3506,6 +3765,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 298 long sys_semop ['int semid', 'struct sembuf __user *sops', 'unsigned nsops']
 	case 298: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3521,6 +3781,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 299 long sys_semget ['key_t key', 'int nsems', 'int semflg']
 	case 299: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3536,6 +3797,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 300 long sys_semctl ['int semid', 'int semnum', 'int cmd', 'unsigned long arg']
 	case 300: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3553,6 +3815,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 301 long sys_msgsnd ['int msqid', 'struct msgbuf __user *msgp', 'size_t msgsz', 'int msgflg']
 	case 301: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3570,6 +3833,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 302 long sys_msgrcv ['int msqid', 'struct msgbuf __user *msgp', 'size_t msgsz', 'long msgtyp', 'int msgflg']
 	case 302: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3589,6 +3853,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 303 long sys_msgget ['key_t key', 'int msgflg']
 	case 303: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3602,6 +3867,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 304 long sys_msgctl ['int msqid', 'int cmd', 'struct msqid_ds __user *buf']
 	case 304: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3617,6 +3883,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 305 long sys_shmat ['int shmid', 'char __user *shmaddr', 'int shmflg']
 	case 305: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3632,6 +3899,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 306 long sys_shmdt ['char __user *shmaddr']
 	case 306: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3643,6 +3911,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 307 long sys_shmget ['key_t key', 'size_t size', 'int flag']
 	case 307: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3658,6 +3927,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 308 long sys_shmctl ['int shmid', 'int cmd', 'struct shmid_ds __user *buf']
 	case 308: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3673,6 +3943,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 309 long sys_add_key ['const char __user *_type', 'const char __user *_description', 'const void __user *_payload', 'size_t plen', 'key_serial_t destringid']
 	case 309: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3692,6 +3963,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 310 long sys_request_key ['const char __user *_type', 'const char __user *_description', 'const char __user *_callout_info', 'key_serial_t destringid']
 	case 310: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3709,6 +3981,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 311 long sys_keyctl ['int cmd', 'unsigned long arg2', 'unsigned long arg3', 'unsigned long arg4', 'unsigned long arg5']
 	case 311: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3728,6 +4001,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 312 long sys_semtimedop ['int semid', 'struct sembuf __user *sops', 'unsigned nsops', 'const struct timespec __user *timeout']
 	case 312: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3745,6 +4019,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 314 long sys_ioprio_set ['int which', 'int who', 'int ioprio']
 	case 314: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3760,6 +4035,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 315 long sys_ioprio_get ['int which', 'int who']
 	case 315: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3773,11 +4049,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 316 long sys_inotify_init ['void']
 	case 316: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_inotify_init_enter, cpu, pc);
 	}; break;
 	// 317 long sys_inotify_add_watch ['int fd', 'const char __user *path', 'u32 mask']
 	case 317: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3793,6 +4071,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 318 long sys_inotify_rm_watch ['int fd', '__s32 wd']
 	case 318: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3806,6 +4085,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 319 long sys_mbind ['unsigned long start', 'unsigned long len', 'unsigned long mode', 'const unsigned long __user *nmask', 'unsigned long maxnode', 'unsigned flags']
 	case 319: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3827,6 +4107,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 320 long sys_get_mempolicy ['int __user *policy', 'unsigned long __user *nmask', 'unsigned long maxnode', 'unsigned long addr', 'unsigned long flags']
 	case 320: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3846,6 +4127,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 321 long sys_set_mempolicy ['int mode', 'const unsigned long __user *nmask', 'unsigned long maxnode']
 	case 321: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3861,6 +4143,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 322 long sys_openat ['int dfd', 'const char __user *filename', 'int flags', 'umode_t mode']
 	case 322: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3878,6 +4161,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 323 long sys_mkdirat ['int dfd', 'const char __user *pathname', 'umode_t mode']
 	case 323: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3893,6 +4177,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 324 long sys_mknodat ['int dfd', 'const char __user *filename', 'umode_t mode', 'unsigned dev']
 	case 324: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3910,6 +4195,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 325 long sys_fchownat ['int dfd', 'const char __user *filename', 'uid_t user', 'gid_t group', 'int flag']
 	case 325: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3929,6 +4215,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 326 long sys_futimesat ['int dfd', 'const char __user *filename', 'struct timeval __user *utimes']
 	case 326: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3944,6 +4231,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 327 long sys_fstatat64 ['int dfd', 'const char __user *filename', 'struct stat64 __user *statbuf', 'int flag']
 	case 327: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3961,6 +4249,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 328 long sys_unlinkat ['int dfd', 'const char __user *pathname', 'int flag']
 	case 328: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3976,6 +4265,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 329 long sys_renameat ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname']
 	case 329: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3993,6 +4283,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 330 long sys_linkat ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname', 'int flags']
 	case 330: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4012,6 +4303,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 331 long sys_symlinkat ['const char __user *oldname', 'int newdfd', 'const char __user *newname']
 	case 331: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4027,6 +4319,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 332 long sys_readlinkat ['int dfd', 'const char __user *path', 'char __user *buf', 'int bufsiz']
 	case 332: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4044,6 +4337,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 333 long sys_fchmodat ['int dfd', 'const char __user *filename', 'umode_t mode']
 	case 333: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4059,6 +4353,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 334 long sys_faccessat ['int dfd', 'const char __user *filename', 'int mode']
 	case 334: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4074,6 +4369,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 335 long sys_pselect6 ['int', 'fd_set __user *', 'fd_set __user *', 'fd_set __user *', 'struct timespec __user *', 'void __user *']
 	case 335: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4095,6 +4391,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 336 long sys_ppoll ['struct pollfd __user *', 'unsigned int', 'struct timespec __user *', 'const sigset_t __user *', 'size_t']
 	case 336: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4114,6 +4411,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 337 long sys_unshare ['unsigned long unshare_flags']
 	case 337: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4125,6 +4423,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 338 long sys_set_robust_list ['struct robust_list_head __user *head', 'size_t len']
 	case 338: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4138,6 +4437,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 339 long sys_get_robust_list ['int pid', 'struct robust_list_head __user * __user *head_ptr', 'size_t __user *len_ptr']
 	case 339: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4153,6 +4453,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 340 long sys_splice ['int fd_in', 'loff_t __user *off_in', 'int fd_out', 'loff_t __user *off_out', 'size_t len', 'unsigned int flags']
 	case 340: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4174,6 +4475,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 341 long sys_sync_file_range2 ['int fd', 'unsigned int flags', 'loff_t offset', 'loff_t nbytes']
 	case 341: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4191,6 +4493,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 342 long sys_tee ['int fdin', 'int fdout', 'size_t len', 'unsigned int flags']
 	case 342: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4208,6 +4511,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 343 long sys_vmsplice ['int fd', 'const struct iovec __user *iov', 'unsigned long nr_segs', 'unsigned int flags']
 	case 343: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4225,6 +4529,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 344 long sys_move_pages ['pid_t pid', 'unsigned long nr_pages', 'const void __user * __user *pages', 'const int __user *nodes', 'int __user *status', 'int flags']
 	case 344: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4246,6 +4551,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 345 long sys_getcpu ['unsigned __user *cpu', 'unsigned __user *node', 'struct getcpu_cache __user *cache']
 	case 345: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4261,6 +4567,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 346 long sys_epoll_pwait ['int epfd', 'struct epoll_event __user *events', 'int maxevents', 'int timeout', 'const sigset_t __user *sigmask', 'size_t sigsetsize']
 	case 346: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4282,6 +4589,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 347 long sys_kexec_load ['unsigned long entry', 'unsigned long nr_segments', 'struct kexec_segment __user *segments', 'unsigned long flags']
 	case 347: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4299,6 +4607,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 348 long sys_utimensat ['int dfd', 'const char __user *filename', 'struct timespec __user *utimes', 'int flags']
 	case 348: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4316,6 +4625,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 349 long sys_signalfd ['int ufd', 'sigset_t __user *user_mask', 'size_t sizemask']
 	case 349: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4331,6 +4641,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 350 long sys_timerfd_create ['int clockid', 'int flags']
 	case 350: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4344,6 +4655,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 351 long sys_eventfd ['unsigned int count']
 	case 351: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4355,6 +4667,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 352 long sys_fallocate ['int fd', 'int mode', 'loff_t offset', 'loff_t len']
 	case 352: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4372,6 +4685,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 353 long sys_timerfd_settime ['int ufd', 'int flags', 'const struct itimerspec __user *utmr', 'struct itimerspec __user *otmr']
 	case 353: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4389,6 +4703,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 354 long sys_timerfd_gettime ['int ufd', 'struct itimerspec __user *otmr']
 	case 354: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4402,6 +4717,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 355 long sys_signalfd4 ['int ufd', 'sigset_t __user *user_mask', 'size_t sizemask', 'int flags']
 	case 355: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4419,6 +4735,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 356 long sys_eventfd2 ['unsigned int count', 'int flags']
 	case 356: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4432,6 +4749,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 357 long sys_epoll_create1 ['int flags']
 	case 357: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4443,6 +4761,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 358 long sys_dup3 ['unsigned int oldfd', 'unsigned int newfd', 'int flags']
 	case 358: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4458,6 +4777,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 359 long sys_pipe2 ['int __user *fildes', 'int flags']
 	case 359: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4471,6 +4791,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 360 long sys_inotify_init1 ['int flags']
 	case 360: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4482,6 +4803,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 361 long sys_preadv ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h']
 	case 361: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4501,6 +4823,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 362 long sys_pwritev ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h']
 	case 362: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4520,6 +4843,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 363 long sys_rt_tgsigqueueinfo ['pid_t tgid', 'pid_t pid', 'int sig', 'siginfo_t __user *uinfo']
 	case 363: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4537,6 +4861,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 364 long sys_perf_event_open ['struct perf_event_attr __user *attr_uptr', 'pid_t pid', 'int cpu', 'int group_fd', 'unsigned long flags']
 	case 364: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4556,6 +4881,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 365 long sys_recvmmsg ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags', 'struct timespec __user *timeout']
 	case 365: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4575,6 +4901,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 366 long sys_accept4 ['int', 'struct sockaddr __user *', 'int __user *', 'int']
 	case 366: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4592,6 +4919,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 367 long sys_fanotify_init ['unsigned int flags', 'unsigned int event_f_flags']
 	case 367: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4605,6 +4933,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 368 long sys_fanotify_mark ['int fanotify_fd', 'unsigned int flags', 'u64 mask', 'int fd', 'const char __user *pathname']
 	case 368: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4624,6 +4953,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 369 long sys_prlimit64 ['pid_t pid', 'unsigned int resource', 'const struct rlimit64 __user *new_rlim', 'struct rlimit64 __user *old_rlim']
 	case 369: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4641,6 +4971,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 370 long sys_name_to_handle_at ['int dfd', 'const char __user *name', 'struct file_handle __user *handle', 'int __user *mnt_id', 'int flag']
 	case 370: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4660,6 +4991,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 371 long sys_open_by_handle_at ['int mountdirfd', 'struct file_handle __user *handle', 'int flags']
 	case 371: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4675,6 +5007,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 372 long sys_clock_adjtime ['clockid_t which_clock', 'struct timex __user *tx']
 	case 372: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4688,6 +5021,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 373 long sys_syncfs ['int fd']
 	case 373: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4699,6 +5033,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 374 long sys_sendmmsg ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags']
 	case 374: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4716,6 +5051,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 375 long sys_setns ['int fd', 'int nstype']
 	case 375: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4729,6 +5065,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 376 long sys_process_vm_readv ['pid_t pid', 'const struct iovec __user *lvec', 'unsigned long liovcnt', 'const struct iovec __user *rvec', 'unsigned long riovcnt', 'unsigned long flags']
 	case 376: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4750,6 +5087,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 377 long sys_process_vm_writev ['pid_t pid', 'const struct iovec __user *lvec', 'unsigned long liovcnt', 'const struct iovec __user *rvec', 'unsigned long riovcnt', 'unsigned long flags']
 	case 377: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4771,6 +5109,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 378 long sys_kcmp ['pid_t pid1', 'pid_t pid2', 'int type', 'unsigned long idx1', 'unsigned long idx2']
 	case 378: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4790,6 +5129,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 379 long sys_finit_module ['int fd', 'const char __user *uargs', 'int flags']
 	case 379: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4805,6 +5145,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 380 long sys_sched_setattr ['pid_t pid', 'struct sched_attr __user *attr', 'unsigned int flags']
 	case 380: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4820,6 +5161,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 381 long sys_sched_getattr ['pid_t pid', 'struct sched_attr __user *attr', 'unsigned int size', 'unsigned int flags']
 	case 381: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4837,6 +5179,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 382 long sys_renameat2 ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname', 'unsigned int flags']
 	case 382: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4856,6 +5199,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 383 long sys_seccomp ['unsigned int op', 'unsigned int flags', 'const char __user *uargs']
 	case 383: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4871,6 +5215,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 384 long sys_getrandom ['char __user *buf', 'size_t count', 'unsigned int flags']
 	case 384: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4886,6 +5231,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 385 long sys_memfd_create ['const char __user *uname_ptr', 'unsigned int flags']
 	case 385: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4899,6 +5245,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 386 long sys_bpf ['int cmd', 'union bpf_attr *attr', 'unsigned int size']
 	case 386: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4914,6 +5261,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 387 long sys_execveat ['int dfd', 'const char __user *filename', 'const char __user *const __user *argv', 'const char __user *const __user *envp', 'int flags']
 	case 387: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4933,6 +5281,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 388 long sys_userfaultfd ['int flags']
 	case 388: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4944,6 +5293,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 389 long sys_membarrier ['int cmd', 'int flags']
 	case 389: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4957,6 +5307,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 390 long sys_mlock2 ['unsigned long start', 'size_t len', 'int flags']
 	case 390: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4972,11 +5323,13 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 983041 long ARM_breakpoint ['void']
 	case 983041: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_ARM_breakpoint_enter, cpu, pc);
 	}; break;
 	// 983042 long ARM_cacheflush ['unsigned long start', 'unsigned long end', 'unsigned long flags']
 	case 983042: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4992,16 +5345,19 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	// 983043 long ARM_user26_mode ['void']
 	case 983043: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_ARM_user26_mode_enter, cpu, pc);
 	}; break;
 	// 983044 long ARM_usr32_mode ['void']
 	case 983044: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_ARM_usr32_mode_enter, cpu, pc);
 	}; break;
 	// 983045 long ARM_set_tls ['unsigned long arg']
 	case 983045: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm64.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -48,6 +49,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 0 long sys_io_setup ['unsigned nr_reqs', 'aio_context_t __user *ctx']
 	case 0: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -61,6 +63,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 1 long sys_io_destroy ['aio_context_t ctx']
 	case 1: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -72,6 +75,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 2 long sys_io_submit ['aio_context_t', 'long', 'struct iocb __user * __user *']
 	case 2: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -87,6 +91,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 3 long sys_io_cancel ['aio_context_t ctx_id', 'struct iocb __user *iocb', 'struct io_event __user *result']
 	case 3: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -102,6 +107,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 4 long sys_io_getevents ['aio_context_t ctx_id', 'long min_nr', 'long nr', 'struct io_event __user *events', 'struct timespec __user *timeout']
 	case 4: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		int64_t arg2 = get_s64(cpu, 2);
@@ -121,6 +127,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 5 long sys_setxattr ['const char __user *path', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 5: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -140,6 +147,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 6 long sys_lsetxattr ['const char __user *path', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 6: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -159,6 +167,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 7 long sys_fsetxattr ['int fd', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 7: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -178,6 +187,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 8 long sys_getxattr ['const char __user *path', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 8: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -195,6 +205,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 9 long sys_lgetxattr ['const char __user *path', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 9: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -212,6 +223,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 10 long sys_fgetxattr ['int fd', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 10: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -229,6 +241,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 11 long sys_listxattr ['const char __user *path', 'char __user *list', 'size_t size']
 	case 11: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -244,6 +257,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 12 long sys_llistxattr ['const char __user *path', 'char __user *list', 'size_t size']
 	case 12: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -259,6 +273,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 13 long sys_flistxattr ['int fd', 'char __user *list', 'size_t size']
 	case 13: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -274,6 +289,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 14 long sys_removexattr ['const char __user *path', 'const char __user *name']
 	case 14: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -287,6 +303,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 15 long sys_lremovexattr ['const char __user *path', 'const char __user *name']
 	case 15: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -300,6 +317,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 16 long sys_fremovexattr ['int fd', 'const char __user *name']
 	case 16: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -313,6 +331,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 17 long sys_getcwd ['char __user *buf', 'unsigned long size']
 	case 17: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -326,6 +345,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 18 long sys_lookup_dcookie ['u64 cookie64', 'char __user *buf', 'size_t len']
 	case 18: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -341,6 +361,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 19 long sys_eventfd2 ['unsigned int count', 'int flags']
 	case 19: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -354,6 +375,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 20 long sys_epoll_create1 ['int flags']
 	case 20: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -365,6 +387,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 21 long sys_epoll_ctl ['int epfd', 'int op', 'int fd', 'struct epoll_event __user *event']
 	case 21: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -382,6 +405,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 22 long sys_epoll_pwait ['int epfd', 'struct epoll_event __user *events', 'int maxevents', 'int timeout', 'const sigset_t __user *sigmask', 'size_t sigsetsize']
 	case 22: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -403,6 +427,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 23 long sys_dup ['unsigned int fildes']
 	case 23: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -414,6 +439,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 24 long sys_dup3 ['unsigned int oldfd', 'unsigned int newfd', 'int flags']
 	case 24: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -429,6 +455,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 25 long sys_fcntl ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 25: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -444,6 +471,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 26 long sys_inotify_init1 ['int flags']
 	case 26: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -455,6 +483,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 27 long sys_inotify_add_watch ['int fd', 'const char __user *path', 'u32 mask']
 	case 27: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -470,6 +499,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 28 long sys_inotify_rm_watch ['int fd', '__s32 wd']
 	case 28: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -483,6 +513,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 29 long sys_ioctl ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 29: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -498,6 +529,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 30 long sys_ioprio_set ['int which', 'int who', 'int ioprio']
 	case 30: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -513,6 +545,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 31 long sys_ioprio_get ['int which', 'int who']
 	case 31: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -526,6 +559,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 32 long sys_flock ['unsigned int fd', 'unsigned int cmd']
 	case 32: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -539,6 +573,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 33 long sys_mknodat ['int dfd', 'const char __user *filename', 'umode_t mode', 'unsigned dev']
 	case 33: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -556,6 +591,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 34 long sys_mkdirat ['int dfd', 'const char __user *pathname', 'umode_t mode']
 	case 34: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -571,6 +607,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 35 long sys_unlinkat ['int dfd', 'const char __user *pathname', 'int flag']
 	case 35: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -586,6 +623,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 36 long sys_symlinkat ['const char __user *oldname', 'int newdfd', 'const char __user *newname']
 	case 36: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -601,6 +639,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 37 long sys_linkat ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname', 'int flags']
 	case 37: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -620,6 +659,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 38 long sys_renameat ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname']
 	case 38: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -637,6 +677,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 39 long sys_umount2 ['const char* target', 'int flags']
 	case 39: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -650,6 +691,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 40 long sys_mount ['char __user *dev_name', 'char __user *dir_name', 'char __user *type', 'unsigned long flags', 'void __user *data']
 	case 40: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -669,6 +711,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 41 long sys_pivot_root ['const char __user *new_root', 'const char __user *put_old']
 	case 41: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -682,6 +725,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 42 long sys_nfsservctl ['int cmd', 'struct nfsctl_arg *argp', 'union nfsctl_res *resp']
 	case 42: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -697,6 +741,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 43 long sys_statfs ['const char * path', 'struct statfs *buf']
 	case 43: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -710,6 +755,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 44 long sys_fstatfs ['unsigned int fd', 'struct statfs *buf']
 	case 44: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -723,6 +769,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 45 long sys_truncate ['const char *path', 'long length']
 	case 45: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -736,6 +783,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 46 long sys_ftruncate ['unsigned int fd', 'unsigned long length']
 	case 46: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -749,6 +797,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 47 long sys_fallocate ['int fd', 'int mode', 'loff_t offset', 'loff_t len']
 	case 47: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -766,6 +815,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 48 long sys_faccessat ['int dfd', 'const char __user *filename', 'int mode']
 	case 48: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -781,6 +831,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 49 long sys_chdir ['const char __user *filename']
 	case 49: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -792,6 +843,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 50 long sys_fchdir ['unsigned int fd']
 	case 50: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -803,6 +855,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 51 long sys_chroot ['const char __user *filename']
 	case 51: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -814,6 +867,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 52 long sys_fchmod ['unsigned int fd', 'umode_t mode']
 	case 52: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -827,6 +881,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 53 long sys_fchmodat ['int dfd', 'const char __user *filename', 'umode_t mode']
 	case 53: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -842,6 +897,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 54 long sys_fchownat ['int dfd', 'const char __user *filename', 'uid_t user', 'gid_t group', 'int flag']
 	case 54: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -861,6 +917,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 55 long sys_fchown ['unsigned int fd', 'uid_t user', 'gid_t group']
 	case 55: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -876,6 +933,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 56 long sys_openat ['int dfd', 'const char __user *filename', 'int flags', 'umode_t mode']
 	case 56: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -893,6 +951,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 57 long sys_close ['unsigned int fd']
 	case 57: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -904,11 +963,13 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 58 long sys_vhangup ['void']
 	case 58: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_vhangup_enter, cpu, pc);
 	}; break;
 	// 59 long sys_pipe2 ['int *fildes', 'int flags']
 	case 59: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -922,6 +983,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 60 long sys_quotactl ['unsigned int cmd', 'const char __user *special', 'qid_t id', 'void __user *addr']
 	case 60: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -939,6 +1001,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 61 long sys_getdents64 ['unsigned int fd', 'struct linux_dirent64 *dirent', 'unsigned int count']
 	case 61: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -954,6 +1017,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 62 long sys_lseek ['unsigned int fd', 'off_t offset', 'unsigned int whence']
 	case 62: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -969,6 +1033,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 63 long sys_read ['unsigned int fd', 'char __user *buf', 'size_t count']
 	case 63: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -984,6 +1049,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 64 long sys_write ['unsigned int fd', 'const char __user *buf', 'size_t count']
 	case 64: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -999,6 +1065,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 65 long sys_readv ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen']
 	case 65: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1014,6 +1081,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 66 long sys_writev ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen']
 	case 66: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1029,6 +1097,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 67 long sys_pread64 ['unsigned int fd', 'char *buf', 'size_t count', 'loff_t pos']
 	case 67: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1046,6 +1115,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 68 long sys_pwrite64 ['unsigned int fd', 'const char *buf', 'size_t count', 'loff_t pos']
 	case 68: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1063,6 +1133,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 69 long sys_preadv ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h']
 	case 69: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1082,6 +1153,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 70 long sys_pwritev ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h']
 	case 70: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1101,6 +1173,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 71 long sys_sendfile ['int out_fd', 'int in_fd', 'off_t *offset', 'size_t count']
 	case 71: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1118,6 +1191,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 72 long sys_pselect6 ['int', 'fd_set *', 'fd_set *', 'fd_set *', 'struct __kernel_timespec *', 'void *']
 	case 72: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1139,6 +1213,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 73 long sys_ppoll ['struct pollfd __user *', 'unsigned int', 'struct timespec __user *', 'const sigset_t __user *', 'size_t']
 	case 73: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1158,6 +1233,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 74 long sys_signalfd4 ['int ufd', 'sigset_t *user_mask', 'size_t sizemask', 'int flags']
 	case 74: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1175,6 +1251,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 75 long sys_vmsplice ['int fd', 'const struct iovec __user *iov', 'unsigned long nr_segs', 'unsigned int flags']
 	case 75: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1192,6 +1269,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 76 long sys_splice ['int fd_in', 'loff_t __user *off_in', 'int fd_out', 'loff_t __user *off_out', 'size_t len', 'unsigned int flags']
 	case 76: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1213,6 +1291,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 77 long sys_tee ['int fdin', 'int fdout', 'size_t len', 'unsigned int flags']
 	case 77: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1230,6 +1309,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 78 long sys_readlinkat ['int dfd', 'const char __user *path', 'char __user *buf', 'int bufsiz']
 	case 78: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1247,6 +1327,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 79 long sys_newfstatat ['int dfd', 'const char *filename', 'struct stat *statbuf', 'int flag']
 	case 79: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1264,6 +1345,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 80 long sys_fstat ['unsigned int fd', 'struct __old_kernel_stat *statbuf']
 	case 80: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1277,11 +1359,13 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 81 long sys_sync ['void']
 	case 81: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sync_enter, cpu, pc);
 	}; break;
 	// 82 long sys_fsync ['unsigned int fd']
 	case 82: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1293,6 +1377,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 83 long sys_fdatasync ['unsigned int fd']
 	case 83: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1304,6 +1389,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 84 long sys_sync_file_range ['int fd', 'loff_t offset', 'loff_t nbytes', 'unsigned int flags']
 	case 84: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1321,6 +1407,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 85 long sys_timerfd_create ['int clockid', 'int flags']
 	case 85: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1334,6 +1421,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 86 long sys_timerfd_settime ['int ufd', 'int flags', 'const struct itimerspec __user *utmr', 'struct itimerspec __user *otmr']
 	case 86: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1351,6 +1439,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 87 long sys_timerfd_gettime ['int ufd', 'struct itimerspec __user *otmr']
 	case 87: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1364,6 +1453,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 88 long sys_utimensat ['int dfd', 'const char __user *filename', 'struct timespec __user *utimes', 'int flags']
 	case 88: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1381,6 +1471,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 89 long sys_acct ['const char __user *name']
 	case 89: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1392,6 +1483,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 90 long sys_capget ['cap_user_header_t header', 'cap_user_data_t dataptr']
 	case 90: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1405,6 +1497,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 91 long sys_capset ['cap_user_header_t header', 'const cap_user_data_t data']
 	case 91: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1418,6 +1511,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 92 long sys_personality ['unsigned int personality']
 	case 92: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1429,6 +1523,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 93 long sys_exit ['int error_code']
 	case 93: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1440,6 +1535,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 94 long sys_exit_group ['int error_code']
 	case 94: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1451,6 +1547,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 95 long sys_waitid ['int which', 'pid_t pid', 'struct siginfo __user *infop', 'int options', 'struct rusage __user *ru']
 	case 95: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1470,6 +1567,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 96 long sys_set_tid_address ['int __user *tidptr']
 	case 96: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1481,6 +1579,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 97 long sys_unshare ['unsigned long unshare_flags']
 	case 97: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1492,6 +1591,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 98 long sys_futex ['u32 __user *uaddr', 'int op', 'u32 val', 'struct timespec __user *utime', 'u32 __user *uaddr2', 'u32 val3']
 	case 98: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1513,6 +1613,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 99 long sys_set_robust_list ['struct robust_list_head __user *head', 'size_t len']
 	case 99: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1526,6 +1627,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 100 long sys_get_robust_list ['int pid', 'struct robust_list_head __user * __user *head_ptr', 'size_t __user *len_ptr']
 	case 100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1541,6 +1643,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 101 long sys_nanosleep ['struct timespec __user *rqtp', 'struct timespec __user *rmtp']
 	case 101: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1554,6 +1657,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 102 long sys_getitimer ['int which', 'struct itimerval __user *value']
 	case 102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1567,6 +1671,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 103 long sys_setitimer ['int which', 'struct itimerval __user *value', 'struct itimerval __user *ovalue']
 	case 103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1582,6 +1687,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 104 long sys_kexec_load ['unsigned long entry', 'unsigned long nr_segments', 'struct kexec_segment __user *segments', 'unsigned long flags']
 	case 104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1599,6 +1705,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 105 long sys_init_module ['void __user *umod', 'unsigned long len', 'const char __user *uargs']
 	case 105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1614,6 +1721,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 106 long sys_delete_module ['const char __user *name_user', 'unsigned int flags']
 	case 106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1627,6 +1735,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 107 long sys_timer_create ['clockid_t which_clock', 'struct sigevent __user *timer_event_spec', 'timer_t __user *created_timer_id']
 	case 107: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1642,6 +1751,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 108 long sys_timer_gettime ['timer_t timer_id', 'struct itimerspec __user *setting']
 	case 108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1655,6 +1765,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 109 long sys_timer_getoverrun ['timer_t timer_id']
 	case 109: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1666,6 +1777,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 110 long sys_timer_settime ['timer_t timer_id', 'int flags', 'const struct itimerspec __user *new_setting', 'struct itimerspec __user *old_setting']
 	case 110: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1683,6 +1795,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 111 long sys_timer_delete ['timer_t timer_id']
 	case 111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1694,6 +1807,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 112 long sys_clock_settime ['clockid_t which_clock', 'const struct timespec __user *tp']
 	case 112: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1707,6 +1821,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 113 long sys_clock_gettime ['clockid_t which_clock', 'struct timespec __user *tp']
 	case 113: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1720,6 +1835,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 114 long sys_clock_getres ['clockid_t which_clock', 'struct timespec __user *tp']
 	case 114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1733,6 +1849,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 115 long sys_clock_nanosleep ['clockid_t which_clock', 'int flags', 'const struct timespec __user *rqtp', 'struct timespec __user *rmtp']
 	case 115: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1750,6 +1867,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 116 long sys_syslog ['int type', 'char __user *buf', 'int len']
 	case 116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1765,6 +1883,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 117 long sys_ptrace ['long request', 'long pid', 'unsigned long addr', 'unsigned long data']
 	case 117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int64_t arg0 = get_s64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1782,6 +1901,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 118 long sys_sched_setparam ['pid_t pid', 'struct sched_param __user *param']
 	case 118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1795,6 +1915,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 119 long sys_sched_setscheduler ['pid_t pid', 'int policy', 'struct sched_param __user *param']
 	case 119: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1810,6 +1931,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 120 long sys_sched_getscheduler ['pid_t pid']
 	case 120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1821,6 +1943,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 121 long sys_sched_getparam ['pid_t pid', 'struct sched_param __user *param']
 	case 121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1834,6 +1957,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 122 long sys_sched_setaffinity ['pid_t pid', 'unsigned int len', 'unsigned long __user *user_mask_ptr']
 	case 122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1849,6 +1973,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 123 long sys_sched_getaffinity ['pid_t pid', 'unsigned int len', 'unsigned long __user *user_mask_ptr']
 	case 123: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1864,11 +1989,13 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 124 long sys_sched_yield ['void']
 	case 124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sched_yield_enter, cpu, pc);
 	}; break;
 	// 125 long sys_sched_get_priority_max ['int policy']
 	case 125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1880,6 +2007,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 126 long sys_sched_get_priority_min ['int policy']
 	case 126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1891,6 +2019,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 127 long sys_sched_rr_get_interval ['pid_t pid', 'struct timespec __user *interval']
 	case 127: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1904,11 +2033,13 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 128 long sys_restart_syscall ['void']
 	case 128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_restart_syscall_enter, cpu, pc);
 	}; break;
 	// 129 long sys_kill ['pid_t pid', 'int sig']
 	case 129: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1922,6 +2053,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 130 long sys_tkill ['pid_t pid', 'int sig']
 	case 130: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1935,6 +2067,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 131 long sys_tgkill ['pid_t tgid', 'pid_t pid', 'int sig']
 	case 131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1950,6 +2083,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 132 long sys_sigaltstack ['const struct sigaltstack __user *uss', 'struct sigaltstack __user *uoss']
 	case 132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1963,6 +2097,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 133 long sys_rt_sigsuspend ['sigset_t __user *unewset', 'size_t sigsetsize']
 	case 133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1976,6 +2111,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 134 long sys_rt_sigaction ['int', 'const struct sigaction __user *', 'struct sigaction __user *', 'size_t']
 	case 134: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1993,6 +2129,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 135 long sys_rt_sigprocmask ['int how', 'sigset_t __user *set', 'sigset_t __user *oset', 'size_t sigsetsize']
 	case 135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2010,6 +2147,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 136 long sys_rt_sigpending ['sigset_t __user *set', 'size_t sigsetsize']
 	case 136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2023,6 +2161,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 137 long sys_rt_sigtimedwait ['const sigset_t __user *uthese', 'siginfo_t __user *uinfo', 'const struct timespec __user *uts', 'size_t sigsetsize']
 	case 137: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2040,6 +2179,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 138 long sys_rt_sigqueueinfo ['pid_t pid', 'int sig', 'siginfo_t __user *uinfo']
 	case 138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2055,6 +2195,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 139 long sys_rt_sigreturn ['struct pt_regs *regs']
 	case 139: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2066,6 +2207,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 140 long sys_setpriority ['int which', 'int who', 'int niceval']
 	case 140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2081,6 +2223,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 141 long sys_getpriority ['int which', 'int who']
 	case 141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2094,6 +2237,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 142 long sys_reboot ['int magic1', 'int magic2', 'unsigned int cmd', 'void __user *arg']
 	case 142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2111,6 +2255,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 143 long sys_setregid ['gid_t rgid', 'gid_t egid']
 	case 143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2124,6 +2269,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 144 long sys_setgid ['gid_t gid']
 	case 144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2135,6 +2281,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 145 long sys_setreuid ['uid_t ruid', 'uid_t euid']
 	case 145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2148,6 +2295,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 146 long sys_setuid ['uid_t uid']
 	case 146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2159,6 +2307,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 147 long sys_setresuid ['uid_t ruid', 'uid_t euid', 'uid_t suid']
 	case 147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2174,6 +2323,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 148 long sys_getresuid ['uid_t __user *ruid', 'uid_t __user *euid', 'uid_t __user *suid']
 	case 148: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2189,6 +2339,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 149 long sys_setresgid ['gid_t rgid', 'gid_t egid', 'gid_t sgid']
 	case 149: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2204,6 +2355,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 150 long sys_getresgid ['gid_t __user *rgid', 'gid_t __user *egid', 'gid_t __user *sgid']
 	case 150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2219,6 +2371,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 151 long sys_setfsuid ['uid_t uid']
 	case 151: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2230,6 +2383,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 152 long sys_setfsgid ['gid_t gid']
 	case 152: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2241,6 +2395,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 153 long sys_times ['struct tms __user *tbuf']
 	case 153: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2252,6 +2407,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 154 long sys_setpgid ['pid_t pid', 'pid_t pgid']
 	case 154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2265,6 +2421,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 155 long sys_getpgid ['pid_t pid']
 	case 155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2276,6 +2433,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 156 long sys_getsid ['pid_t pid']
 	case 156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2287,11 +2445,13 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 157 long sys_setsid ['void']
 	case 157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_setsid_enter, cpu, pc);
 	}; break;
 	// 158 long sys_getgroups ['int gidsetsize', 'gid_t __user *grouplist']
 	case 158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2305,6 +2465,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 159 long sys_setgroups ['int gidsetsize', 'gid_t __user *grouplist']
 	case 159: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2318,6 +2479,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 160 long sys_uname ['struct new_utsname __user *name']
 	case 160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2329,6 +2491,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 161 long sys_sethostname ['char __user *name', 'int len']
 	case 161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2342,6 +2505,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 162 long sys_setdomainname ['char __user *name', 'int len']
 	case 162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2355,6 +2519,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 163 long sys_getrlimit ['unsigned int resource', 'struct rlimit __user *rlim']
 	case 163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2368,6 +2533,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 164 long sys_setrlimit ['unsigned int resource', 'struct rlimit __user *rlim']
 	case 164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2381,6 +2547,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 165 long sys_getrusage ['int who', 'struct rusage __user *ru']
 	case 165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2394,6 +2561,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 166 long sys_umask ['int mask']
 	case 166: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2405,6 +2573,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 167 long sys_prctl ['int option', 'unsigned long arg2', 'unsigned long arg3', 'unsigned long arg4', 'unsigned long arg5']
 	case 167: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2424,6 +2593,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 168 long sys_getcpu ['unsigned __user *cpu', 'unsigned __user *node', 'struct getcpu_cache __user *cache']
 	case 168: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2439,6 +2609,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 169 long sys_gettimeofday ['struct timeval __user *tv', 'struct timezone __user *tz']
 	case 169: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2452,6 +2623,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 170 long sys_settimeofday ['struct timeval __user *tv', 'struct timezone __user *tz']
 	case 170: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2465,6 +2637,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 171 long sys_adjtimex ['struct timex __user *txc_p']
 	case 171: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2476,41 +2649,49 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 172 long sys_getpid ['void']
 	case 172: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getpid_enter, cpu, pc);
 	}; break;
 	// 173 long sys_getppid ['void']
 	case 173: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getppid_enter, cpu, pc);
 	}; break;
 	// 174 long sys_getuid ['void']
 	case 174: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getuid_enter, cpu, pc);
 	}; break;
 	// 175 long sys_geteuid ['void']
 	case 175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_geteuid_enter, cpu, pc);
 	}; break;
 	// 176 long sys_getgid ['void']
 	case 176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getgid_enter, cpu, pc);
 	}; break;
 	// 177 long sys_getegid ['void']
 	case 177: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getegid_enter, cpu, pc);
 	}; break;
 	// 178 long sys_gettid ['void']
 	case 178: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_gettid_enter, cpu, pc);
 	}; break;
 	// 179 long sys_sysinfo ['struct sysinfo __user *info']
 	case 179: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2522,6 +2703,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 180 long sys_mq_open ['const char __user *name', 'int oflag', 'umode_t mode', 'struct mq_attr __user *attr']
 	case 180: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2539,6 +2721,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 181 long sys_mq_unlink ['const char __user *name']
 	case 181: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2550,6 +2733,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 182 long sys_mq_timedsend ['mqd_t mqdes', 'const char __user *msg_ptr', 'size_t msg_len', 'unsigned int msg_prio', 'const struct timespec __user *abs_timeout']
 	case 182: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2569,6 +2753,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 183 long sys_mq_timedreceive ['mqd_t mqdes', 'char __user *msg_ptr', 'size_t msg_len', 'unsigned int __user *msg_prio', 'const struct timespec __user *abs_timeout']
 	case 183: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2588,6 +2773,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 184 long sys_mq_notify ['mqd_t mqdes', 'const struct sigevent __user *notification']
 	case 184: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2601,6 +2787,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 185 long sys_mq_getsetattr ['mqd_t mqdes', 'const struct mq_attr __user *mqstat', 'struct mq_attr __user *omqstat']
 	case 185: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2616,6 +2803,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 186 long sys_msgget ['key_t key', 'int msgflg']
 	case 186: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2629,6 +2817,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 187 long sys_msgctl ['int msqid', 'int cmd', 'struct msqid_ds __user *buf']
 	case 187: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2644,6 +2833,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 188 long sys_msgrcv ['int msqid', 'struct msgbuf __user *msgp', 'size_t msgsz', 'long msgtyp', 'int msgflg']
 	case 188: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2663,6 +2853,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 189 long sys_msgsnd ['int msqid', 'struct msgbuf __user *msgp', 'size_t msgsz', 'int msgflg']
 	case 189: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2680,6 +2871,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 190 long sys_semget ['key_t key', 'int nsems', 'int semflg']
 	case 190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2695,6 +2887,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 191 long sys_semctl ['int semid', 'int semnum', 'int cmd', 'unsigned long arg']
 	case 191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2712,6 +2905,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 192 long sys_semtimedop ['int semid', 'struct sembuf __user *sops', 'unsigned nsops', 'const struct timespec __user *timeout']
 	case 192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2729,6 +2923,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 193 long sys_semop ['int semid', 'struct sembuf __user *sops', 'unsigned nsops']
 	case 193: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2744,6 +2939,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 194 long sys_shmget ['key_t key', 'size_t size', 'int flag']
 	case 194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2759,6 +2955,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 195 long sys_shmctl ['int shmid', 'int cmd', 'struct shmid_ds __user *buf']
 	case 195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2774,6 +2971,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 196 long sys_shmat ['int shmid', 'char __user *shmaddr', 'int shmflg']
 	case 196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2789,6 +2987,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 197 long sys_shmdt ['char __user *shmaddr']
 	case 197: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2800,6 +2999,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 198 long sys_socket ['int', 'int', 'int']
 	case 198: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2815,6 +3015,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 199 long sys_socketpair ['int', 'int', 'int', 'int __user *']
 	case 199: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2832,6 +3033,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 200 long sys_bind ['int', 'struct sockaddr __user *', 'int']
 	case 200: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2847,6 +3049,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 201 long sys_listen ['int', 'int']
 	case 201: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2860,6 +3063,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 202 long sys_accept ['int', 'struct sockaddr __user *', 'int __user *']
 	case 202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2875,6 +3079,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 203 long sys_connect ['int', 'struct sockaddr __user *', 'int']
 	case 203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2890,6 +3095,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 204 long sys_getsockname ['int', 'struct sockaddr __user *', 'int __user *']
 	case 204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2905,6 +3111,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 205 long sys_getpeername ['int', 'struct sockaddr __user *', 'int __user *']
 	case 205: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2920,6 +3127,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 206 long sys_sendto ['int', 'void __user *', 'size_t', 'unsigned', 'struct sockaddr __user *', 'int']
 	case 206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2941,6 +3149,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 207 long sys_recvfrom ['int', 'void __user *', 'size_t', 'unsigned', 'struct sockaddr __user *', 'int __user *']
 	case 207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2962,6 +3171,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 208 long sys_setsockopt ['int fd', 'int level', 'int optname', 'char __user *optval', 'int optlen']
 	case 208: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2981,6 +3191,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 209 long sys_getsockopt ['int fd', 'int level', 'int optname', 'char __user *optval', 'int __user *optlen']
 	case 209: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3000,6 +3211,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 210 long sys_shutdown ['int', 'int']
 	case 210: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3013,6 +3225,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 211 long sys_sendmsg ['int fd', 'struct user_msghdr __user *msg', 'unsigned flags']
 	case 211: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3028,6 +3241,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 212 long sys_recvmsg ['int fd', 'struct user_msghdr __user *msg', 'unsigned flags']
 	case 212: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3043,6 +3257,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 213 long sys_readahead ['int fd', 'loff_t offset', 'size_t count']
 	case 213: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3058,6 +3273,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 214 long sys_brk ['unsigned long brk']
 	case 214: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3069,6 +3285,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 215 long sys_munmap ['unsigned long addr', 'size_t len']
 	case 215: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3082,6 +3299,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 216 long sys_mremap ['unsigned long addr', 'unsigned long old_len', 'unsigned long new_len', 'unsigned long flags', 'unsigned long new_addr']
 	case 216: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3101,6 +3319,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 217 long sys_add_key ['const char __user *_type', 'const char __user *_description', 'const void __user *_payload', 'size_t plen', 'key_serial_t destringid']
 	case 217: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3120,6 +3339,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 218 long sys_request_key ['const char __user *_type', 'const char __user *_description', 'const char __user *_callout_info', 'key_serial_t destringid']
 	case 218: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3137,6 +3357,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 219 long sys_keyctl ['int cmd', 'unsigned long arg2', 'unsigned long arg3', 'unsigned long arg4', 'unsigned long arg5']
 	case 219: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3156,6 +3377,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 220 long sys_clone ['unsigned long', 'unsigned long', 'int __user *', 'int __user *', 'unsigned long']
 	case 220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3175,6 +3397,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 221 long sys_execve ['const char __user *filename', 'const char __user *const __user *argv', 'const char __user *const __user *envp']
 	case 221: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3190,6 +3413,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 222 long sys_mmap ['void *addr', 'size_t length', 'int prot', 'int flags', 'int fd', 'off_t offset']
 	case 222: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3211,6 +3435,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 223 long sys_fadvise64 ['int fd', 'loff_t offset', 'size_t len', 'int advice']
 	case 223: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3228,6 +3453,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 224 long sys_swapon ['const char __user *specialfile', 'int swap_flags']
 	case 224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3241,6 +3467,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 225 long sys_swapoff ['const char __user *specialfile']
 	case 225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3252,6 +3479,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 226 long sys_mprotect ['unsigned long start', 'size_t len', 'unsigned long prot']
 	case 226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3267,6 +3495,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 227 long sys_msync ['unsigned long start', 'size_t len', 'int flags']
 	case 227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3282,6 +3511,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 228 long sys_mlock ['unsigned long start', 'size_t len']
 	case 228: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3295,6 +3525,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 229 long sys_munlock ['unsigned long start', 'size_t len']
 	case 229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3308,6 +3539,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 230 long sys_mlockall ['int flags']
 	case 230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3319,11 +3551,13 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 231 long sys_munlockall ['void']
 	case 231: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_munlockall_enter, cpu, pc);
 	}; break;
 	// 232 long sys_mincore ['unsigned long start', 'size_t len', 'unsigned char __user *vec']
 	case 232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3339,6 +3573,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 233 long sys_madvise ['unsigned long start', 'size_t len', 'int behavior']
 	case 233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3354,6 +3589,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 234 long sys_remap_file_pages ['unsigned long start', 'unsigned long size', 'unsigned long prot', 'unsigned long pgoff', 'unsigned long flags']
 	case 234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3373,6 +3609,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 235 long sys_mbind ['unsigned long start', 'unsigned long len', 'unsigned long mode', 'const unsigned long __user *nmask', 'unsigned long maxnode', 'unsigned flags']
 	case 235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3394,6 +3631,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 236 long sys_get_mempolicy ['int __user *policy', 'unsigned long __user *nmask', 'unsigned long maxnode', 'unsigned long addr', 'unsigned long flags']
 	case 236: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3413,6 +3651,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 237 long sys_set_mempolicy ['int mode', 'const unsigned long __user *nmask', 'unsigned long maxnode']
 	case 237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3428,6 +3667,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 238 long sys_migrate_pages ['pid_t pid', 'unsigned long maxnode', 'const unsigned long __user *from', 'const unsigned long __user *to']
 	case 238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3445,6 +3685,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 239 long sys_move_pages ['pid_t pid', 'unsigned long nr_pages', 'const void __user * __user *pages', 'const int __user *nodes', 'int __user *status', 'int flags']
 	case 239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3466,6 +3707,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 240 long sys_rt_tgsigqueueinfo ['pid_t tgid', 'pid_t pid', 'int sig', 'siginfo_t __user *uinfo']
 	case 240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3483,6 +3725,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 241 long sys_perf_event_open ['struct perf_event_attr __user *attr_uptr', 'pid_t pid', 'int cpu', 'int group_fd', 'unsigned long flags']
 	case 241: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3502,6 +3745,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 242 long sys_accept4 ['int', 'struct sockaddr *', 'int *', 'int']
 	case 242: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3519,6 +3763,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 243 long sys_recvmmsg ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags', 'struct timespec __user *timeout']
 	case 243: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3538,6 +3783,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 260 long sys_wait4 ['pid_t pid', 'int *stat_addr', 'int options', 'struct rusage *ru']
 	case 260: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3555,6 +3801,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 261 long sys_prlimit64 ['pid_t pid', 'unsigned int resource', 'const struct rlimit64 *new_rlim', 'struct rlimit64 *old_rlim']
 	case 261: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3572,6 +3819,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 262 long sys_fanotify_init ['unsigned int flags', 'unsigned int event_f_flags']
 	case 262: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3585,6 +3833,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 263 long sys_fanotify_mark ['int fanotify_fd', 'unsigned int flags', 'u64 mask', 'int fd', 'const char __user *pathname']
 	case 263: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3604,6 +3853,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 264 long sys_name_to_handle_at ['int dfd', 'const char __user *name', 'struct file_handle __user *handle', 'int __user *mnt_id', 'int flag']
 	case 264: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3623,6 +3873,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 265 long sys_open_by_handle_at ['int mountdirfd', 'struct file_handle __user *handle', 'int flags']
 	case 265: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3638,6 +3889,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 266 long sys_clock_adjtime ['clockid_t which_clock', 'struct timex __user *tx']
 	case 266: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3651,6 +3903,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 267 long sys_syncfs ['int fd']
 	case 267: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3662,6 +3915,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 268 long sys_setns ['int fd', 'int nstype']
 	case 268: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3675,6 +3929,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 269 long sys_sendmmsg ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags']
 	case 269: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3692,6 +3947,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 270 long sys_process_vm_readv ['pid_t pid', 'const struct iovec __user *lvec', 'unsigned long liovcnt', 'const struct iovec __user *rvec', 'unsigned long riovcnt', 'unsigned long flags']
 	case 270: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3713,6 +3969,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 271 long sys_process_vm_writev ['pid_t pid', 'const struct iovec __user *lvec', 'unsigned long liovcnt', 'const struct iovec __user *rvec', 'unsigned long riovcnt', 'unsigned long flags']
 	case 271: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3734,6 +3991,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 272 long sys_kcmp ['pid_t pid1', 'pid_t pid2', 'int type', 'unsigned long idx1', 'unsigned long idx2']
 	case 272: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3753,6 +4011,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 273 long sys_finit_module ['int fd', 'const char __user *uargs', 'int flags']
 	case 273: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3768,6 +4027,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 274 long sys_sched_setattr ['pid_t pid', 'struct sched_attr __user *attr', 'unsigned int flags']
 	case 274: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3783,6 +4043,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 275 long sys_sched_getattr ['pid_t pid', 'struct sched_attr __user *attr', 'unsigned int size', 'unsigned int flags']
 	case 275: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3800,6 +4061,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 276 long sys_renameat2 ['int olddfd', 'const char *oldname', 'int newdfd', 'const char *newname', 'unsigned int flags']
 	case 276: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3819,6 +4081,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 277 long sys_seccomp ['unsigned int op', 'unsigned int flags', 'const char __user *uargs']
 	case 277: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3834,6 +4097,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 278 long sys_getrandom ['char __user *buf', 'size_t count', 'unsigned int flags']
 	case 278: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3849,6 +4113,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 279 long sys_memfd_create ['const char __user *uname_ptr', 'unsigned int flags']
 	case 279: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3862,6 +4127,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 280 long sys_bpf ['int cmd', 'union bpf_attr *attr', 'unsigned int size']
 	case 280: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3877,6 +4143,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 281 long sys_execveat ['int dfd', 'const char __user *filename', 'const char __user *const __user *argv', 'const char __user *const __user *envp', 'int flags']
 	case 281: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3896,6 +4163,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 282 long sys_userfaultfd ['int flags']
 	case 282: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3907,6 +4175,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 283 long sys_membarrier ['int cmd', 'int flags']
 	case 283: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3920,6 +4189,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 284 long sys_mlock2 ['unsigned long start', 'size_t len', 'int flags']
 	case 284: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3935,6 +4205,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 285 long sys_copy_file_range ['int fd_in', 'loff_t __user *off_in', 'int fd_out', 'loff_t __user *off_out', 'size_t len', 'unsigned int flags']
 	case 285: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3956,6 +4227,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 286 long sys_preadv2 ['unsigned long fd', 'const struct iovec *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h', 'rwf_t flags']
 	case 286: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3977,6 +4249,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 287 long sys_pwritev2 ['unsigned long fd', 'const struct iovec *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h', 'rwf_t flags']
 	case 287: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3998,6 +4271,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 288 long sys_pkey_mprotect ['unsigned long start', 'size_t len', 'unsigned long prot', 'int pkey']
 	case 288: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4015,6 +4289,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 289 long sys_pkey_alloc ['unsigned long flags', 'unsigned long init_val']
 	case 289: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4028,6 +4303,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 290 long sys_pkey_free ['int pkey']
 	case 290: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4039,6 +4315,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 291 long sys_statx ['int dfd', 'const char *path', 'unsigned flags', 'unsigned mask', 'struct statx *buffer']
 	case 291: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4058,6 +4335,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 294 long sys_kexec_file_load ['int kernel_fd', 'int initrd_fd', 'unsigned long cmdline_len', 'const char *cmdline', 'unsigned long flags']
 	case 294: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4077,6 +4355,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 424 long sys_pidfd_send_signal ['int pidfd', 'int sig', 'siginfo_t *info', 'unsigned int flags']
 	case 424: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4094,6 +4373,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 434 long sys_pidfd_open ['pid_t pid', 'unsigned int flags']
 	case 434: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4107,6 +4387,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 435 long sys_clone3 ['struct clone_args *cl_args', 'size_t size']
 	case 435: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4120,6 +4401,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 437 long sys_openat2 ['int dirfd', 'const char *pathname', 'struct open_how *how', 'size_t size']
 	case 437: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4137,6 +4419,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 438 long sys_pidfd_getfd ['int pidfd', 'int targetfd', 'unsigned int flags']
 	case 438: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4152,6 +4435,7 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 	// 439 long sys_faccessat2 ['int dirfd', 'const char *pathname', 'int mode', 'int flags']
 	case 439: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_mips.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_mips.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -48,6 +49,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4001 long sys_exit ['int error_code']
 	case 4001: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -59,11 +61,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4002 pid_t sys_fork ['void']
 	case 4002: {
 		panda_noreturn = false;
+		ctx.double_return = true;
 		PPP_RUN_CB(on_sys_fork_enter, cpu, pc);
 	}; break;
 	// 4003 long sys_read ['unsigned int fd', 'char __user *buf', 'size_t count']
 	case 4003: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -79,6 +83,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4004 long sys_write ['unsigned int fd', 'const char __user *buf', 'size_t count']
 	case 4004: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -94,6 +99,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4005 long sys_open ['const char __user *filename', 'int flags', 'umode_t mode']
 	case 4005: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -109,6 +115,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4006 long sys_close ['unsigned int fd']
 	case 4006: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -120,6 +127,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4007 long sys_waitpid ['pid_t pid', 'int __user *stat_addr', 'int options']
 	case 4007: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -135,6 +143,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4008 long sys_creat ['const char __user *pathname', 'umode_t mode']
 	case 4008: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -148,6 +157,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4009 long sys_link ['const char __user *oldname', 'const char __user *newname']
 	case 4009: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -161,6 +171,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4010 long sys_unlink ['const char __user *pathname']
 	case 4010: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -172,6 +183,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4011 long sys_execve ['const char __user *filename', 'const char __user *const __user *argv', 'const char __user *const __user *envp']
 	case 4011: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -187,6 +199,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4012 long sys_chdir ['const char __user *filename']
 	case 4012: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -198,6 +211,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4013 long sys_time32 ['old_time32_t __user *tloc']
 	case 4013: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -209,6 +223,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4014 long sys_mknod ['const char __user *filename', 'umode_t mode', 'unsigned dev']
 	case 4014: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -224,6 +239,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4015 long sys_chmod ['const char __user *filename', 'umode_t mode']
 	case 4015: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -237,6 +253,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4016 long sys_lchown ['const char __user *filename', 'uid_t user', 'gid_t group']
 	case 4016: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -252,6 +269,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4018 long sys_stat ['const char __user *filename', 'struct __old_kernel_stat __user *statbuf']
 	case 4018: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -265,6 +283,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4019 long sys_lseek ['unsigned int fd', 'off_t offset', 'unsigned int whence']
 	case 4019: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -280,11 +299,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4020 long sys_getpid ['void']
 	case 4020: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getpid_enter, cpu, pc);
 	}; break;
 	// 4021 long sys_mount ['char __user *dev_name', 'char __user *dir_name', 'char __user *type', 'unsigned long flags', 'void __user *data']
 	case 4021: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -304,6 +325,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4022 long sys_oldumount ['char __user *name']
 	case 4022: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -315,6 +337,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4023 long sys_setuid ['uid_t uid']
 	case 4023: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -326,11 +349,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4024 long sys_getuid ['void']
 	case 4024: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getuid_enter, cpu, pc);
 	}; break;
 	// 4025 long sys_stime32 ['old_time32_t __user *tptr']
 	case 4025: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -342,6 +367,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4026 long sys_ptrace ['long request', 'long pid', 'unsigned long addr', 'unsigned long data']
 	case 4026: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -359,6 +385,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4027 long sys_alarm ['unsigned int seconds']
 	case 4027: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -370,6 +397,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4028 long sys_fstat ['unsigned int fd', 'struct __old_kernel_stat __user *statbuf']
 	case 4028: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -383,11 +411,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4029 long sys_pause ['void']
 	case 4029: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_pause_enter, cpu, pc);
 	}; break;
 	// 4030 long sys_utime32 ['const char __user *filename', 'struct old_utimbuf32 __user *t']
 	case 4030: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -401,6 +431,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4033 long sys_access ['const char __user *filename', 'int mode']
 	case 4033: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -414,6 +445,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4034 long sys_nice ['int increment']
 	case 4034: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -425,11 +457,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4036 long sys_sync ['void']
 	case 4036: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sync_enter, cpu, pc);
 	}; break;
 	// 4037 long sys_kill ['pid_t pid', 'int sig']
 	case 4037: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -443,6 +477,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4038 long sys_rename ['const char __user *oldname', 'const char __user *newname']
 	case 4038: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -456,6 +491,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4039 long sys_mkdir ['const char __user *pathname', 'umode_t mode']
 	case 4039: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -469,6 +505,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4040 long sys_rmdir ['const char __user *pathname']
 	case 4040: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -480,6 +517,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4041 long sys_dup ['unsigned int fildes']
 	case 4041: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -491,6 +529,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4042 long sys_pipe ['int __user *fildes']
 	case 4042: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -502,6 +541,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4043 long sys_times ['struct tms __user *tbuf']
 	case 4043: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -513,6 +553,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4045 long sys_brk ['unsigned long brk']
 	case 4045: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -524,6 +565,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4046 long sys_setgid ['gid_t gid']
 	case 4046: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -535,11 +577,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4047 long sys_getgid ['void']
 	case 4047: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getgid_enter, cpu, pc);
 	}; break;
 	// 4048 long sys_signal ['int sig', '__sighandler_t handler']
 	case 4048: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -553,16 +597,19 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4049 long sys_geteuid ['void']
 	case 4049: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_geteuid_enter, cpu, pc);
 	}; break;
 	// 4050 long sys_getegid ['void']
 	case 4050: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getegid_enter, cpu, pc);
 	}; break;
 	// 4051 long sys_acct ['const char __user *name']
 	case 4051: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -574,6 +621,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4052 long sys_umount ['char __user *name', 'int flags']
 	case 4052: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -587,6 +635,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4054 long sys_ioctl ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 4054: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -602,6 +651,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4055 long sys_fcntl ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 4055: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -617,6 +667,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4057 long sys_setpgid ['pid_t pid', 'pid_t pgid']
 	case 4057: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -630,6 +681,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4059 long sys_olduname ['struct oldold_utsname __user *']
 	case 4059: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -641,6 +693,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4060 long sys_umask ['int mask']
 	case 4060: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -652,6 +705,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4061 long sys_chroot ['const char __user *filename']
 	case 4061: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -663,6 +717,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4062 long sys_ustat ['unsigned dev', 'struct ustat __user *ubuf']
 	case 4062: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -676,6 +731,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4063 long sys_dup2 ['unsigned int oldfd', 'unsigned int newfd']
 	case 4063: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -689,21 +745,25 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4064 long sys_getppid ['void']
 	case 4064: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getppid_enter, cpu, pc);
 	}; break;
 	// 4065 long sys_getpgrp ['void']
 	case 4065: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getpgrp_enter, cpu, pc);
 	}; break;
 	// 4066 long sys_setsid ['void']
 	case 4066: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_setsid_enter, cpu, pc);
 	}; break;
 	// 4067 long sys_sigaction ['int', 'const struct old_sigaction __user *', 'struct old_sigaction __user *']
 	case 4067: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -719,11 +779,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4068 long sys_sgetmask ['void']
 	case 4068: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sgetmask_enter, cpu, pc);
 	}; break;
 	// 4069 long sys_ssetmask ['int newmask']
 	case 4069: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -735,6 +797,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4070 long sys_setreuid ['uid_t ruid', 'uid_t euid']
 	case 4070: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -748,6 +811,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4071 long sys_setregid ['gid_t rgid', 'gid_t egid']
 	case 4071: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -761,6 +825,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4072 long sys_sigsuspend ['int unused1', 'int unused2', 'old_sigset_t mask']
 	case 4072: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -776,6 +841,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4073 long sys_sigpending ['old_sigset_t __user *uset']
 	case 4073: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -787,6 +853,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4074 long sys_sethostname ['char __user *name', 'int len']
 	case 4074: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -800,6 +867,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4075 long sys_setrlimit ['unsigned int resource', 'struct rlimit __user *rlim']
 	case 4075: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -813,6 +881,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4076 long sys_getrlimit ['unsigned int resource', 'struct rlimit __user *rlim']
 	case 4076: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -826,6 +895,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4077 long sys_getrusage ['int who', 'struct rusage __user *ru']
 	case 4077: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -839,6 +909,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4078 long sys_gettimeofday ['struct __kernel_old_timeval __user *tv', 'struct timezone __user *tz']
 	case 4078: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -852,6 +923,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4079 long sys_settimeofday ['struct __kernel_old_timeval __user *tv', 'struct timezone __user *tz']
 	case 4079: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -865,6 +937,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4080 long sys_getgroups ['int gidsetsize', 'gid_t __user *grouplist']
 	case 4080: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -878,6 +951,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4081 long sys_setgroups ['int gidsetsize', 'gid_t __user *grouplist']
 	case 4081: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -891,6 +965,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4083 long sys_symlink ['const char __user *old', 'const char __user *new']
 	case 4083: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -904,6 +979,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4084 long sys_lstat ['const char __user *filename', 'struct __old_kernel_stat __user *statbuf']
 	case 4084: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -917,6 +993,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4085 long sys_readlink ['const char __user *path', 'char __user *buf', 'int bufsiz']
 	case 4085: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -932,6 +1009,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4086 long sys_uselib ['const char __user *library']
 	case 4086: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -943,6 +1021,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4087 long sys_swapon ['const char __user *specialfile', 'int swap_flags']
 	case 4087: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -956,6 +1035,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4088 long sys_reboot ['int magic1', 'int magic2', 'unsigned int cmd', 'void __user *arg']
 	case 4088: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -973,6 +1053,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4089 long sys_old_readdir ['unsigned int', 'struct old_linux_dirent __user *', 'unsigned int']
 	case 4089: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -988,6 +1069,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4090 long sys_mmap ['unsigned long addr', 'unsigned long len', 'unsigned long prot', 'unsigned long flags', 'unsigned long fd', 'unsigned long pgoff']
 	case 4090: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1009,6 +1091,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4091 long sys_munmap ['unsigned long addr', 'size_t len']
 	case 4091: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1022,6 +1105,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4092 long sys_truncate ['const char __user *path', 'long length']
 	case 4092: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1035,6 +1119,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4093 long sys_ftruncate ['unsigned int fd', 'unsigned long length']
 	case 4093: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1048,6 +1133,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4094 long sys_fchmod ['unsigned int fd', 'umode_t mode']
 	case 4094: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1061,6 +1147,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4095 long sys_fchown ['unsigned int fd', 'uid_t user', 'gid_t group']
 	case 4095: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1076,6 +1163,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4096 long sys_getpriority ['int which', 'int who']
 	case 4096: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1089,6 +1177,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4097 long sys_setpriority ['int which', 'int who', 'int niceval']
 	case 4097: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1104,6 +1193,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4099 long sys_statfs ['const char __user *path', 'struct statfs __user *buf']
 	case 4099: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1117,6 +1207,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4100 long sys_fstatfs ['unsigned int fd', 'struct statfs __user *buf']
 	case 4100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1130,6 +1221,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4101 long sys_ioperm ['unsigned long from', 'unsigned long num', 'int on']
 	case 4101: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1145,6 +1237,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4102 long sys_socketcall ['int call', 'unsigned long __user *args']
 	case 4102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1158,6 +1251,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4103 long sys_syslog ['int type', 'char __user *buf', 'int len']
 	case 4103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1173,6 +1267,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4104 long sys_setitimer ['int which', 'struct __kernel_old_itimerval __user *value', 'struct __kernel_old_itimerval __user *ovalue']
 	case 4104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1188,6 +1283,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4105 long sys_getitimer ['int which', 'struct __kernel_old_itimerval __user *value']
 	case 4105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1201,6 +1297,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4106 long sys_newstat ['const char __user *filename', 'struct stat __user *statbuf']
 	case 4106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1214,6 +1311,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4107 long sys_newlstat ['const char __user *filename', 'struct stat __user *statbuf']
 	case 4107: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1227,6 +1325,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4108 long sys_newfstat ['unsigned int fd', 'struct stat __user *statbuf']
 	case 4108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1240,6 +1339,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4109 long sys_uname ['struct old_utsname __user *']
 	case 4109: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1251,6 +1351,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4110 long sys_iopl ['int level']
 	case 4110: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1262,16 +1363,19 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4111 long sys_vhangup ['void']
 	case 4111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_vhangup_enter, cpu, pc);
 	}; break;
 	// 4112 long sys_idle ['void']
 	case 4112: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_idle_enter, cpu, pc);
 	}; break;
 	// 4114 long sys_wait4 ['pid_t pid', 'int __user *stat_addr', 'int options', 'struct rusage __user *ru']
 	case 4114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1289,6 +1393,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4115 long sys_swapoff ['const char __user *specialfile']
 	case 4115: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1300,6 +1405,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4116 long sys_sysinfo ['struct sysinfo __user *info']
 	case 4116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1311,6 +1417,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4117 long sys_ipc ['unsigned int call', 'int first', 'unsigned long second', 'unsigned long third', 'void __user *ptr', 'long fifth']
 	case 4117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1332,6 +1439,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4118 long sys_fsync ['unsigned int fd']
 	case 4118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1343,11 +1451,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4119 void sys_sigreturn ['void']
 	case 4119: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sigreturn_enter, cpu, pc);
 	}; break;
 	// 4120 long sys_clone ['unsigned long', 'unsigned long', 'int __user *', 'unsigned long', 'int __user *']
 	case 4120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1367,6 +1477,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4121 long sys_setdomainname ['char __user *name', 'int len']
 	case 4121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1380,6 +1491,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4122 long sys_newuname ['struct new_utsname __user *name']
 	case 4122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1391,6 +1503,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4123 long modify_ldt ['int func', 'void *ptr', 'unsigned long bytecount']
 	case 4123: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1406,6 +1519,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4124 long sys_adjtimex_time32 ['struct old_timex32 __user *txc_p']
 	case 4124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1417,6 +1531,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4125 long sys_mprotect ['unsigned long start', 'size_t len', 'unsigned long prot']
 	case 4125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1432,6 +1547,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4126 long sys_sigprocmask ['int how', 'old_sigset_t __user *set', 'old_sigset_t __user *oset']
 	case 4126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1447,6 +1563,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4127 caddr_t create_module ['const char *name', 'size_t size']
 	case 4127: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1460,6 +1577,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4128 long sys_init_module ['void __user *umod', 'unsigned long len', 'const char __user *uargs']
 	case 4128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1475,6 +1593,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4129 long sys_delete_module ['const char __user *name_user', 'unsigned int flags']
 	case 4129: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1488,6 +1607,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4130 long get_kernel_syms ['struct kernel_sym *table']
 	case 4130: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1499,6 +1619,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4131 long sys_quotactl ['unsigned int cmd', 'const char __user *special', 'qid_t id', 'void __user *addr']
 	case 4131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1516,6 +1637,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4132 long sys_getpgid ['pid_t pid']
 	case 4132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1527,6 +1649,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4133 long sys_fchdir ['unsigned int fd']
 	case 4133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1538,6 +1661,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4134 long sys_bdflush ['int func', 'long data']
 	case 4134: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1551,6 +1675,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4135 long sys_sysfs ['int option', 'unsigned long arg1', 'unsigned long arg2']
 	case 4135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1566,6 +1691,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4136 long sys_personality ['unsigned int personality']
 	case 4136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1577,6 +1703,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4138 long sys_setfsuid ['uid_t uid']
 	case 4138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1588,6 +1715,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4139 long sys_setfsgid ['gid_t gid']
 	case 4139: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1599,6 +1727,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4140 long sys_llseek ['unsigned int fd', 'unsigned long offset_high', 'unsigned long offset_low', 'loff_t __user *result', 'unsigned int whence']
 	case 4140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1618,6 +1747,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4141 long sys_getdents ['unsigned int fd', 'struct linux_dirent __user *dirent', 'unsigned int count']
 	case 4141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1633,6 +1763,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4142 long sys_select ['int n', 'fd_set __user *inp', 'fd_set __user *outp', 'fd_set __user *exp', 'struct __kernel_old_timeval __user *tvp']
 	case 4142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1652,6 +1783,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4143 long sys_flock ['unsigned int fd', 'unsigned int cmd']
 	case 4143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1665,6 +1797,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4144 long sys_msync ['unsigned long start', 'size_t len', 'int flags']
 	case 4144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1680,6 +1813,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4145 long sys_readv ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen']
 	case 4145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1695,6 +1829,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4146 long sys_writev ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen']
 	case 4146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1710,6 +1845,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4147 long sys_cacheflush ['char *addr', 'int nbytes', 'int cache']
 	case 4147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1725,11 +1861,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4150 long sys_setup ['void']
 	case 4150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_setup_enter, cpu, pc);
 	}; break;
 	// 4151 long sys_getsid ['pid_t pid']
 	case 4151: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1741,6 +1879,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4152 long sys_fdatasync ['unsigned int fd']
 	case 4152: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1752,6 +1891,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4153 long sys_sysctl ['struct __sysctl_args __user *args']
 	case 4153: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1763,6 +1903,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4154 long sys_mlock ['unsigned long start', 'size_t len']
 	case 4154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1776,6 +1917,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4155 long sys_munlock ['unsigned long start', 'size_t len']
 	case 4155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1789,6 +1931,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4156 long sys_mlockall ['int flags']
 	case 4156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1800,11 +1943,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4157 long sys_munlockall ['void']
 	case 4157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_munlockall_enter, cpu, pc);
 	}; break;
 	// 4158 long sys_sched_setparam ['pid_t pid', 'struct sched_param __user *param']
 	case 4158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1818,6 +1963,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4159 long sys_sched_getparam ['pid_t pid', 'struct sched_param __user *param']
 	case 4159: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1831,6 +1977,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4160 long sys_sched_setscheduler ['pid_t pid', 'int policy', 'struct sched_param __user *param']
 	case 4160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1846,6 +1993,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4161 long sys_sched_getscheduler ['pid_t pid']
 	case 4161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1857,11 +2005,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4162 long sys_sched_yield ['void']
 	case 4162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sched_yield_enter, cpu, pc);
 	}; break;
 	// 4163 long sys_sched_get_priority_max ['int policy']
 	case 4163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1873,6 +2023,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4164 long sys_sched_get_priority_min ['int policy']
 	case 4164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1884,6 +2035,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4165 long sys_sched_rr_get_interval_time32 ['pid_t pid', 'struct old_timespec32 __user *interval']
 	case 4165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1897,6 +2049,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4166 long sys_nanosleep_time32 ['struct old_timespec32 __user *rqtp', 'struct old_timespec32 __user *rmtp']
 	case 4166: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1910,6 +2063,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4167 long sys_mremap ['unsigned long addr', 'unsigned long old_len', 'unsigned long new_len', 'unsigned long flags', 'unsigned long new_addr']
 	case 4167: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1929,6 +2083,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4168 long sys_accept ['int', 'struct sockaddr __user *', 'int __user *']
 	case 4168: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1944,6 +2099,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4169 long sys_bind ['int', 'struct sockaddr __user *', 'int']
 	case 4169: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1959,6 +2115,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4170 long sys_connect ['int', 'struct sockaddr __user *', 'int']
 	case 4170: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1974,6 +2131,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4171 long sys_getpeername ['int', 'struct sockaddr __user *', 'int __user *']
 	case 4171: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1989,6 +2147,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4172 long sys_getsockname ['int', 'struct sockaddr __user *', 'int __user *']
 	case 4172: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2004,6 +2163,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4173 long sys_getsockopt ['int fd', 'int level', 'int optname', 'char __user *optval', 'int __user *optlen']
 	case 4173: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2023,6 +2183,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4174 long sys_listen ['int', 'int']
 	case 4174: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2036,6 +2197,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4175 long sys_recv ['int', 'void __user *', 'size_t', 'unsigned']
 	case 4175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2053,6 +2215,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4176 long sys_recvfrom ['int', 'void __user *', 'size_t', 'unsigned', 'struct sockaddr __user *', 'int __user *']
 	case 4176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2074,6 +2237,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4177 long sys_recvmsg ['int fd', 'struct user_msghdr __user *msg', 'unsigned flags']
 	case 4177: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2089,6 +2253,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4178 long sys_send ['int', 'void __user *', 'size_t', 'unsigned']
 	case 4178: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2106,6 +2271,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4179 long sys_sendmsg ['int fd', 'struct user_msghdr __user *msg', 'unsigned flags']
 	case 4179: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2121,6 +2287,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4180 long sys_sendto ['int', 'void __user *', 'size_t', 'unsigned', 'struct sockaddr __user *', 'int']
 	case 4180: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2142,6 +2309,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4181 long sys_setsockopt ['int fd', 'int level', 'int optname', 'char __user *optval', 'int optlen']
 	case 4181: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2161,6 +2329,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4182 long sys_shutdown ['int', 'int']
 	case 4182: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2174,6 +2343,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4183 long sys_socket ['int', 'int', 'int']
 	case 4183: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2189,6 +2359,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4184 long sys_socketpair ['int', 'int', 'int', 'int __user *']
 	case 4184: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2206,6 +2377,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4185 long sys_setresuid ['uid_t ruid', 'uid_t euid', 'uid_t suid']
 	case 4185: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2221,6 +2393,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4186 long sys_getresuid ['uid_t __user *ruid', 'uid_t __user *euid', 'uid_t __user *suid']
 	case 4186: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2236,6 +2409,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4187 long sys_query_module ['const char *name', 'int which', 'void *buf', 'size_t bufsize', 'size_t *ret']
 	case 4187: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2255,6 +2429,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4188 long sys_poll ['struct pollfd __user *ufds', 'unsigned int nfds', 'int timeout']
 	case 4188: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2270,6 +2445,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4189 long sys_nfsservctl ['int cmd', 'struct nfsctl_arg *argp', 'union nfsctl_res *resp']
 	case 4189: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2285,6 +2461,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4190 long sys_setresgid ['gid_t rgid', 'gid_t egid', 'gid_t sgid']
 	case 4190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2300,6 +2477,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4191 long sys_getresgid ['gid_t __user *rgid', 'gid_t __user *egid', 'gid_t __user *sgid']
 	case 4191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2315,6 +2493,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4192 long sys_prctl ['int option', 'unsigned long arg2', 'unsigned long arg3', 'unsigned long arg4', 'unsigned long arg5']
 	case 4192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2334,11 +2513,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4193 void sys_rt_sigreturn ['void']
 	case 4193: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_rt_sigreturn_enter, cpu, pc);
 	}; break;
 	// 4194 long sys_rt_sigaction ['int', 'const struct sigaction __user *', 'struct sigaction __user *', 'size_t']
 	case 4194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2356,6 +2537,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4195 long sys_rt_sigprocmask ['int how', 'sigset_t __user *set', 'sigset_t __user *oset', 'size_t sigsetsize']
 	case 4195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2373,6 +2555,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4196 long sys_rt_sigpending ['sigset_t __user *set', 'size_t sigsetsize']
 	case 4196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2386,6 +2569,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4197 long sys_rt_sigtimedwait_time32 ['const sigset_t __user *uthese', 'siginfo_t __user *uinfo', 'const struct old_timespec32 __user *uts', 'size_t sigsetsize']
 	case 4197: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2403,6 +2587,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4198 long sys_rt_sigqueueinfo ['pid_t pid', 'int sig', 'siginfo_t __user *uinfo']
 	case 4198: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2418,6 +2603,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4199 long sys_rt_sigsuspend ['sigset_t __user *unewset', 'size_t sigsetsize']
 	case 4199: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2431,6 +2617,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4200 long sys_pread64 ['unsigned int fd', 'char __user *buf', 'size_t count', 'loff_t pos']
 	case 4200: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2448,6 +2635,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4201 long sys_pwrite64 ['unsigned int fd', 'const char __user *buf', 'size_t count', 'loff_t pos']
 	case 4201: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2465,6 +2653,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4202 long sys_chown ['const char __user *filename', 'uid_t user', 'gid_t group']
 	case 4202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2480,6 +2669,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4203 long sys_getcwd ['char __user *buf', 'unsigned long size']
 	case 4203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2493,6 +2683,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4204 long sys_capget ['cap_user_header_t header', 'cap_user_data_t dataptr']
 	case 4204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2506,6 +2697,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4205 long sys_capset ['cap_user_header_t header', 'const cap_user_data_t data']
 	case 4205: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2519,6 +2711,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4206 long sys_sigaltstack ['const struct sigaltstack __user *uss', 'struct sigaltstack __user *uoss']
 	case 4206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2532,6 +2725,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4207 long sys_sendfile ['int out_fd', 'int in_fd', 'off_t __user *offset', 'size_t count']
 	case 4207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2549,6 +2743,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4210 void* mmap2 ['void *addr', 'size_t length', 'int prot', 'int flags', 'int fd', 'off_t pgoffset']
 	case 4210: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2570,6 +2765,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4211 long sys_truncate64 ['const char __user *path', 'loff_t length']
 	case 4211: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2583,6 +2779,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4212 long sys_ftruncate64 ['unsigned int fd', 'loff_t length']
 	case 4212: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2596,6 +2793,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4213 long sys_stat64 ['const char __user *filename', 'struct stat64 __user *statbuf']
 	case 4213: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2609,6 +2807,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4214 long sys_lstat64 ['const char __user *filename', 'struct stat64 __user *statbuf']
 	case 4214: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2622,6 +2821,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4215 long sys_fstat64 ['unsigned long fd', 'struct stat64 __user *statbuf']
 	case 4215: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2635,6 +2835,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4216 long sys_pivot_root ['const char __user *new_root', 'const char __user *put_old']
 	case 4216: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2648,6 +2849,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4217 long sys_mincore ['unsigned long start', 'size_t len', 'unsigned char __user *vec']
 	case 4217: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2663,6 +2865,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4218 long sys_madvise ['unsigned long start', 'size_t len', 'int behavior']
 	case 4218: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2678,6 +2881,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4219 long sys_getdents64 ['unsigned int fd', 'struct linux_dirent64 __user *dirent', 'unsigned int count']
 	case 4219: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2693,6 +2897,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4220 long sys_fcntl64 ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 4220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2708,11 +2913,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4222 long sys_gettid ['void']
 	case 4222: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_gettid_enter, cpu, pc);
 	}; break;
 	// 4223 long sys_readahead ['int fd', 'loff_t offset', 'size_t count']
 	case 4223: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2728,6 +2935,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4224 long sys_setxattr ['const char __user *path', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 4224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2747,6 +2955,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4225 long sys_lsetxattr ['const char __user *path', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 4225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2766,6 +2975,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4226 long sys_fsetxattr ['int fd', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 4226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2785,6 +2995,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4227 long sys_getxattr ['const char __user *path', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 4227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2802,6 +3013,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4228 long sys_lgetxattr ['const char __user *path', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 4228: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2819,6 +3031,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4229 long sys_fgetxattr ['int fd', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 4229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2836,6 +3049,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4230 long sys_listxattr ['const char __user *path', 'char __user *list', 'size_t size']
 	case 4230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2851,6 +3065,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4231 long sys_llistxattr ['const char __user *path', 'char __user *list', 'size_t size']
 	case 4231: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2866,6 +3081,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4232 long sys_flistxattr ['int fd', 'char __user *list', 'size_t size']
 	case 4232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2881,6 +3097,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4233 long sys_removexattr ['const char __user *path', 'const char __user *name']
 	case 4233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2894,6 +3111,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4234 long sys_lremovexattr ['const char __user *path', 'const char __user *name']
 	case 4234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2907,6 +3125,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4235 long sys_fremovexattr ['int fd', 'const char __user *name']
 	case 4235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2920,6 +3139,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4236 long sys_tkill ['pid_t pid', 'int sig']
 	case 4236: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2933,6 +3153,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4237 long sys_sendfile64 ['int out_fd', 'int in_fd', 'loff_t __user *offset', 'size_t count']
 	case 4237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2950,6 +3171,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4238 long sys_futex_time32 ['u32 __user *uaddr', 'int op', 'u32 val', 'struct old_timespec32 __user *utime', 'u32 __user *uaddr2', 'u32 val3']
 	case 4238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2971,6 +3193,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4239 long sys_sched_setaffinity ['pid_t pid', 'unsigned int len', 'unsigned long __user *user_mask_ptr']
 	case 4239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2986,6 +3209,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4240 long sys_sched_getaffinity ['pid_t pid', 'unsigned int len', 'unsigned long __user *user_mask_ptr']
 	case 4240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3001,6 +3225,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4241 long sys_io_setup ['unsigned nr_reqs', 'aio_context_t __user *ctx']
 	case 4241: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3014,6 +3239,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4242 long sys_io_destroy ['aio_context_t ctx']
 	case 4242: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3025,6 +3251,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4243 long sys_io_getevents_time32 ['__u32 ctx_id', '__s32 min_nr', '__s32 nr', 'struct io_event __user *events', 'struct old_timespec32 __user *timeout']
 	case 4243: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3044,6 +3271,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4244 long sys_io_submit ['aio_context_t', 'long', 'struct iocb __user * __user *']
 	case 4244: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3059,6 +3287,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4245 long sys_io_cancel ['aio_context_t ctx_id', 'struct iocb __user *iocb', 'struct io_event __user *result']
 	case 4245: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3073,7 +3302,8 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	}; break;
 	// 4246 long sys_exit_group ['int error_code']
 	case 4246: {
-		panda_noreturn = false;
+		panda_noreturn = true;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3085,6 +3315,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4247 long sys_lookup_dcookie ['u64 cookie64', 'char __user *buf', 'size_t len']
 	case 4247: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3100,6 +3331,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4248 long sys_epoll_create ['int size']
 	case 4248: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3111,6 +3343,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4249 long sys_epoll_ctl ['int epfd', 'int op', 'int fd', 'struct epoll_event __user *event']
 	case 4249: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3128,6 +3361,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4250 long sys_epoll_wait ['int epfd', 'struct epoll_event __user *events', 'int maxevents', 'int timeout']
 	case 4250: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3145,6 +3379,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4251 long sys_remap_file_pages ['unsigned long start', 'unsigned long size', 'unsigned long prot', 'unsigned long pgoff', 'unsigned long flags']
 	case 4251: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3164,6 +3399,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4252 long sys_set_tid_address ['int __user *tidptr']
 	case 4252: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3175,11 +3411,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4253 long sys_restart_syscall ['void']
 	case 4253: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_restart_syscall_enter, cpu, pc);
 	}; break;
 	// 4254 long sys_fadvise64_64 ['int fd', 'loff_t offset', 'loff_t len', 'int advice']
 	case 4254: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3197,6 +3435,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4255 long sys_statfs64 ['const char __user *path', 'size_t sz', 'struct statfs64 __user *buf']
 	case 4255: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3212,6 +3451,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4256 long sys_fstatfs64 ['unsigned int fd', 'size_t sz', 'struct statfs64 __user *buf']
 	case 4256: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3227,6 +3467,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4257 long sys_timer_create ['clockid_t which_clock', 'struct sigevent __user *timer_event_spec', 'timer_t __user *created_timer_id']
 	case 4257: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3242,6 +3483,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4258 long sys_timer_settime32 ['timer_t timer_id', 'int flags', 'struct old_itimerspec32 __user *new', 'struct old_itimerspec32 __user *old']
 	case 4258: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3259,6 +3501,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4259 long sys_timer_gettime32 ['timer_t timer_id', 'struct old_itimerspec32 __user *setting']
 	case 4259: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3272,6 +3515,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4260 long sys_timer_getoverrun ['timer_t timer_id']
 	case 4260: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3283,6 +3527,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4261 long sys_timer_delete ['timer_t timer_id']
 	case 4261: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3294,6 +3539,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4262 long sys_clock_settime32 ['clockid_t which_clock', 'struct old_timespec32 __user *tp']
 	case 4262: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3307,6 +3553,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4263 long sys_clock_gettime32 ['clockid_t which_clock', 'struct old_timespec32 __user *tp']
 	case 4263: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3320,6 +3567,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4264 long sys_clock_getres_time32 ['clockid_t which_clock', 'struct old_timespec32 __user *tp']
 	case 4264: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3333,6 +3581,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4265 long sys_clock_nanosleep_time32 ['clockid_t which_clock', 'int flags', 'struct old_timespec32 __user *rqtp', 'struct old_timespec32 __user *rmtp']
 	case 4265: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3350,6 +3599,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4266 long sys_tgkill ['pid_t tgid', 'pid_t pid', 'int sig']
 	case 4266: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3365,6 +3615,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4267 long sys_utimes_time32 ['const char __user *filename', 'struct old_timeval32 __user *t']
 	case 4267: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3378,6 +3629,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4268 long sys_mbind ['unsigned long start', 'unsigned long len', 'unsigned long mode', 'const unsigned long __user *nmask', 'unsigned long maxnode', 'unsigned flags']
 	case 4268: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3399,6 +3651,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4269 long sys_get_mempolicy ['int __user *policy', 'unsigned long __user *nmask', 'unsigned long maxnode', 'unsigned long addr', 'unsigned long flags']
 	case 4269: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3418,6 +3671,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4270 long sys_set_mempolicy ['int mode', 'const unsigned long __user *nmask', 'unsigned long maxnode']
 	case 4270: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3433,6 +3687,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4271 long sys_mq_open ['const char __user *name', 'int oflag', 'umode_t mode', 'struct mq_attr __user *attr']
 	case 4271: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3450,6 +3705,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4272 long sys_mq_unlink ['const char __user *name']
 	case 4272: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3461,6 +3717,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4273 long sys_mq_timedsend_time32 ['mqd_t mqdes', 'const char __user *u_msg_ptr', 'unsigned int msg_len', 'unsigned int msg_prio', 'const struct old_timespec32 __user *u_abs_timeout']
 	case 4273: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3480,6 +3737,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4274 long sys_mq_timedreceive_time32 ['mqd_t mqdes', 'char __user *u_msg_ptr', 'unsigned int msg_len', 'unsigned int __user *u_msg_prio', 'const struct old_timespec32 __user *u_abs_timeout']
 	case 4274: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3499,6 +3757,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4275 long sys_mq_notify ['mqd_t mqdes', 'const struct sigevent __user *notification']
 	case 4275: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3512,6 +3771,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4276 long sys_mq_getsetattr ['mqd_t mqdes', 'const struct mq_attr __user *mqstat', 'struct mq_attr __user *omqstat']
 	case 4276: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3527,6 +3787,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4278 long sys_waitid ['int which', 'pid_t pid', 'struct siginfo __user *infop', 'int options', 'struct rusage __user *ru']
 	case 4278: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3546,6 +3807,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4280 long sys_add_key ['const char __user *_type', 'const char __user *_description', 'const void __user *_payload', 'size_t plen', 'key_serial_t destringid']
 	case 4280: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3565,6 +3827,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4281 long sys_request_key ['const char __user *_type', 'const char __user *_description', 'const char __user *_callout_info', 'key_serial_t destringid']
 	case 4281: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3582,6 +3845,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4282 long sys_keyctl ['int cmd', 'unsigned long arg2', 'unsigned long arg3', 'unsigned long arg4', 'unsigned long arg5']
 	case 4282: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3601,6 +3865,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4283 long set_thread_area ['unsigned long tp']
 	case 4283: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3612,11 +3877,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4284 long sys_inotify_init ['void']
 	case 4284: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_inotify_init_enter, cpu, pc);
 	}; break;
 	// 4285 long sys_inotify_add_watch ['int fd', 'const char __user *path', 'u32 mask']
 	case 4285: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3632,6 +3899,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4286 long sys_inotify_rm_watch ['int fd', '__s32 wd']
 	case 4286: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3645,6 +3913,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4287 long sys_migrate_pages ['pid_t pid', 'unsigned long maxnode', 'const unsigned long __user *from', 'const unsigned long __user *to']
 	case 4287: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3662,6 +3931,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4288 long sys_openat ['int dfd', 'const char __user *filename', 'int flags', 'umode_t mode']
 	case 4288: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3679,6 +3949,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4289 long sys_mkdirat ['int dfd', 'const char __user *pathname', 'umode_t mode']
 	case 4289: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3694,6 +3965,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4290 long sys_mknodat ['int dfd', 'const char __user *filename', 'umode_t mode', 'unsigned dev']
 	case 4290: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3711,6 +3983,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4291 long sys_fchownat ['int dfd', 'const char __user *filename', 'uid_t user', 'gid_t group', 'int flag']
 	case 4291: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3730,6 +4003,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4292 long sys_futimesat_time32 ['unsigned int dfd', 'const char __user *filename', 'struct old_timeval32 __user *t']
 	case 4292: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3745,6 +4019,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4293 long sys_fstatat64 ['int dfd', 'const char __user *filename', 'struct stat64 __user *statbuf', 'int flag']
 	case 4293: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3762,6 +4037,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4294 long sys_unlinkat ['int dfd', 'const char __user *pathname', 'int flag']
 	case 4294: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3777,6 +4053,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4295 long sys_renameat ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname']
 	case 4295: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3794,6 +4071,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4296 long sys_linkat ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname', 'int flags']
 	case 4296: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3813,6 +4091,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4297 long sys_symlinkat ['const char __user *oldname', 'int newdfd', 'const char __user *newname']
 	case 4297: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3828,6 +4107,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4298 long sys_readlinkat ['int dfd', 'const char __user *path', 'char __user *buf', 'int bufsiz']
 	case 4298: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3845,6 +4125,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4299 long sys_fchmodat ['int dfd', 'const char __user *filename', 'umode_t mode']
 	case 4299: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3860,6 +4141,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4300 long sys_faccessat ['int dfd', 'const char __user *filename', 'int mode']
 	case 4300: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3875,6 +4157,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4301 long sys_pselect6_time32 ['int', 'fd_set __user *', 'fd_set __user *', 'fd_set __user *', 'struct old_timespec32 __user *', 'void __user *']
 	case 4301: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3896,6 +4179,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4302 long sys_ppoll_time32 ['struct pollfd __user *', 'unsigned int', 'struct old_timespec32 __user *', 'const sigset_t __user *', 'size_t']
 	case 4302: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3915,6 +4199,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4303 long sys_unshare ['unsigned long unshare_flags']
 	case 4303: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3926,6 +4211,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4304 long sys_splice ['int fd_in', 'loff_t __user *off_in', 'int fd_out', 'loff_t __user *off_out', 'size_t len', 'unsigned int flags']
 	case 4304: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3947,6 +4233,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4305 long sys_sync_file_range ['int fd', 'loff_t offset', 'loff_t nbytes', 'unsigned int flags']
 	case 4305: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3964,6 +4251,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4306 long sys_tee ['int fdin', 'int fdout', 'size_t len', 'unsigned int flags']
 	case 4306: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3981,6 +4269,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4307 long sys_vmsplice ['int fd', 'const struct iovec __user *iov', 'unsigned long nr_segs', 'unsigned int flags']
 	case 4307: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3998,6 +4287,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4308 long sys_move_pages ['pid_t pid', 'unsigned long nr_pages', 'const void __user * __user *pages', 'const int __user *nodes', 'int __user *status', 'int flags']
 	case 4308: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4019,6 +4309,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4309 long sys_set_robust_list ['struct robust_list_head __user *head', 'size_t len']
 	case 4309: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4032,6 +4323,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4310 long sys_get_robust_list ['int pid', 'struct robust_list_head __user * __user *head_ptr', 'size_t __user *len_ptr']
 	case 4310: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4047,6 +4339,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4311 long sys_kexec_load ['unsigned long entry', 'unsigned long nr_segments', 'struct kexec_segment __user *segments', 'unsigned long flags']
 	case 4311: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4064,6 +4357,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4312 long sys_getcpu ['unsigned __user *cpu', 'unsigned __user *node', 'struct getcpu_cache __user *cache']
 	case 4312: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4079,6 +4373,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4313 long sys_epoll_pwait ['int epfd', 'struct epoll_event __user *events', 'int maxevents', 'int timeout', 'const sigset_t __user *sigmask', 'size_t sigsetsize']
 	case 4313: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4100,6 +4395,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4314 long sys_ioprio_set ['int which', 'int who', 'int ioprio']
 	case 4314: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4115,6 +4411,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4315 long sys_ioprio_get ['int which', 'int who']
 	case 4315: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4128,6 +4425,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4316 long sys_utimensat_time32 ['unsigned int dfd', 'const char __user *filename', 'struct old_timespec32 __user *t', 'int flags']
 	case 4316: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4145,6 +4443,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4317 long sys_signalfd ['int ufd', 'sigset_t __user *user_mask', 'size_t sizemask']
 	case 4317: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4160,11 +4459,13 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4318 long sys_ni_syscall ['void']
 	case 4318: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_ni_syscall_enter, cpu, pc);
 	}; break;
 	// 4319 long sys_eventfd ['unsigned int count']
 	case 4319: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4176,6 +4477,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4320 long sys_fallocate ['int fd', 'int mode', 'loff_t offset', 'loff_t len']
 	case 4320: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4193,6 +4495,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4321 long sys_timerfd_create ['int clockid', 'int flags']
 	case 4321: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4206,6 +4509,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4322 long sys_timerfd_gettime32 ['int ufd', 'struct old_itimerspec32 __user *otmr']
 	case 4322: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4219,6 +4523,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4323 long sys_timerfd_settime32 ['int ufd', 'int flags', 'const struct old_itimerspec32 __user *utmr', 'struct old_itimerspec32 __user *otmr']
 	case 4323: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4236,6 +4541,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4324 long sys_signalfd4 ['int ufd', 'sigset_t __user *user_mask', 'size_t sizemask', 'int flags']
 	case 4324: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4253,6 +4559,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4325 long sys_eventfd2 ['unsigned int count', 'int flags']
 	case 4325: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4266,6 +4573,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4326 long sys_epoll_create1 ['int flags']
 	case 4326: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4277,6 +4585,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4327 long sys_dup3 ['unsigned int oldfd', 'unsigned int newfd', 'int flags']
 	case 4327: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4292,6 +4601,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4328 long sys_pipe2 ['int __user *fildes', 'int flags']
 	case 4328: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4305,6 +4615,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4329 long sys_inotify_init1 ['int flags']
 	case 4329: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4316,6 +4627,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4330 long sys_preadv ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h']
 	case 4330: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4335,6 +4647,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4331 long sys_pwritev ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h']
 	case 4331: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4354,6 +4667,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4332 long sys_rt_tgsigqueueinfo ['pid_t tgid', 'pid_t pid', 'int sig', 'siginfo_t __user *uinfo']
 	case 4332: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4371,6 +4685,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4333 long sys_perf_event_open ['struct perf_event_attr __user *attr_uptr', 'pid_t pid', 'int cpu', 'int group_fd', 'unsigned long flags']
 	case 4333: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4390,6 +4705,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4334 long sys_accept4 ['int', 'struct sockaddr __user *', 'int __user *', 'int']
 	case 4334: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4407,6 +4723,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4335 long sys_recvmmsg_time32 ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags', 'struct old_timespec32 __user *timeout']
 	case 4335: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4426,6 +4743,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4336 long sys_fanotify_init ['unsigned int flags', 'unsigned int event_f_flags']
 	case 4336: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4439,6 +4757,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4337 long sys_fanotify_mark ['int fanotify_fd', 'unsigned int flags', 'u64 mask', 'int fd', 'const char __user *pathname']
 	case 4337: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4458,6 +4777,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4338 long sys_prlimit64 ['pid_t pid', 'unsigned int resource', 'const struct rlimit64 __user *new_rlim', 'struct rlimit64 __user *old_rlim']
 	case 4338: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4475,6 +4795,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4339 long sys_name_to_handle_at ['int dfd', 'const char __user *name', 'struct file_handle __user *handle', 'int __user *mnt_id', 'int flag']
 	case 4339: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4494,6 +4815,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4340 long sys_open_by_handle_at ['int mountdirfd', 'struct file_handle __user *handle', 'int flags']
 	case 4340: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4509,6 +4831,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4341 long sys_clock_adjtime32 ['clockid_t which_clock', 'struct old_timex32 __user *tx']
 	case 4341: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4522,6 +4845,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4342 long sys_syncfs ['int fd']
 	case 4342: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4533,6 +4857,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4343 long sys_sendmmsg ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags']
 	case 4343: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4550,6 +4875,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4344 long sys_setns ['int fd', 'int nstype']
 	case 4344: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4563,6 +4889,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4345 long sys_process_vm_readv ['pid_t pid', 'const struct iovec __user *lvec', 'unsigned long liovcnt', 'const struct iovec __user *rvec', 'unsigned long riovcnt', 'unsigned long flags']
 	case 4345: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4584,6 +4911,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4346 long sys_process_vm_writev ['pid_t pid', 'const struct iovec __user *lvec', 'unsigned long liovcnt', 'const struct iovec __user *rvec', 'unsigned long riovcnt', 'unsigned long flags']
 	case 4346: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4605,6 +4933,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4347 long sys_kcmp ['pid_t pid1', 'pid_t pid2', 'int type', 'unsigned long idx1', 'unsigned long idx2']
 	case 4347: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4624,6 +4953,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4348 long sys_finit_module ['int fd', 'const char __user *uargs', 'int flags']
 	case 4348: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4639,6 +4969,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4349 long sys_sched_setattr ['pid_t pid', 'struct sched_attr __user *attr', 'unsigned int flags']
 	case 4349: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4654,6 +4985,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4350 long sys_sched_getattr ['pid_t pid', 'struct sched_attr __user *attr', 'unsigned int size', 'unsigned int flags']
 	case 4350: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4671,6 +5003,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4351 long sys_renameat2 ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname', 'unsigned int flags']
 	case 4351: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4690,6 +5023,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4352 long sys_seccomp ['unsigned int op', 'unsigned int flags', 'void __user *uargs']
 	case 4352: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4705,6 +5039,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4353 long sys_getrandom ['char __user *buf', 'size_t count', 'unsigned int flags']
 	case 4353: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4720,6 +5055,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4354 long sys_memfd_create ['const char __user *uname_ptr', 'unsigned int flags']
 	case 4354: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4733,6 +5069,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4355 long sys_bpf ['int cmd', 'union bpf_attr *attr', 'unsigned int size']
 	case 4355: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4748,6 +5085,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4356 long sys_execveat ['int dfd', 'const char __user *filename', 'const char __user *const __user *argv', 'const char __user *const __user *envp', 'int flags']
 	case 4356: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4767,6 +5105,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4357 long sys_userfaultfd ['int flags']
 	case 4357: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4778,6 +5117,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4358 long sys_membarrier ['int cmd', 'int flags']
 	case 4358: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4791,6 +5131,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4359 long sys_mlock2 ['unsigned long start', 'size_t len', 'int flags']
 	case 4359: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4806,6 +5147,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4360 long sys_copy_file_range ['int fd_in', 'loff_t __user *off_in', 'int fd_out', 'loff_t __user *off_out', 'size_t len', 'unsigned int flags']
 	case 4360: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4827,6 +5169,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4361 long sys_preadv2 ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h', 'rwf_t flags']
 	case 4361: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4848,6 +5191,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4362 long sys_pwritev2 ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h', 'rwf_t flags']
 	case 4362: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4869,6 +5213,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4363 long sys_pkey_mprotect ['unsigned long start', 'size_t len', 'unsigned long prot', 'int pkey']
 	case 4363: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4886,6 +5231,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4364 long sys_pkey_alloc ['unsigned long flags', 'unsigned long init_val']
 	case 4364: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4899,6 +5245,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4365 long sys_pkey_free ['int pkey']
 	case 4365: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4910,6 +5257,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4366 long sys_statx ['int dfd', 'const char __user *path', 'unsigned flags', 'unsigned mask', 'struct statx __user *buffer']
 	case 4366: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4929,6 +5277,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4367 long sys_rseq ['struct rseq __user *rseq', 'uint32_t rseq_len', 'int flags', 'uint32_t sig']
 	case 4367: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4946,6 +5295,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4368 long sys_io_pgetevents_time32 ['aio_context_t ctx_id', 'long min_nr', 'long nr', 'struct io_event __user *events', 'struct old_timespec32 __user *timeout', 'const struct __aio_sigset *sig']
 	case 4368: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4967,6 +5317,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4393 long sys_semget ['key_t key', 'int nsems', 'int semflg']
 	case 4393: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4982,6 +5333,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4394 long sys_semctl ['int semid', 'int semnum', 'int cmd', 'unsigned long arg']
 	case 4394: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4999,6 +5351,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4395 long sys_shmget ['key_t key', 'size_t size', 'int flag']
 	case 4395: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5014,6 +5367,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4396 long sys_shmctl ['int shmid', 'int cmd', 'struct shmid_ds __user *buf']
 	case 4396: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5029,6 +5383,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4397 long sys_shmat ['int shmid', 'char __user *shmaddr', 'int shmflg']
 	case 4397: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5044,6 +5399,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4398 long sys_shmdt ['char __user *shmaddr']
 	case 4398: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5055,6 +5411,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4399 long sys_msgget ['key_t key', 'int msgflg']
 	case 4399: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5068,6 +5425,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4400 long sys_msgsnd ['int msqid', 'struct msgbuf __user *msgp', 'size_t msgsz', 'int msgflg']
 	case 4400: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5085,6 +5443,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4401 long sys_msgrcv ['int msqid', 'struct msgbuf __user *msgp', 'size_t msgsz', 'long msgtyp', 'int msgflg']
 	case 4401: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5104,6 +5463,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4402 long sys_msgctl ['int msqid', 'int cmd', 'struct msqid_ds __user *buf']
 	case 4402: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5119,6 +5479,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4403 long sys_clock_gettime ['clockid_t which_clock', 'struct __kernel_timespec __user *tp']
 	case 4403: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5132,6 +5493,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4404 long sys_clock_settime ['clockid_t which_clock', 'const struct __kernel_timespec __user *tp']
 	case 4404: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5145,6 +5507,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4405 long sys_clock_adjtime ['clockid_t which_clock', 'struct __kernel_timex __user *tx']
 	case 4405: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5158,6 +5521,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4406 long sys_clock_getres ['clockid_t which_clock', 'struct __kernel_timespec __user *tp']
 	case 4406: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5171,6 +5535,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4407 long sys_clock_nanosleep ['clockid_t which_clock', 'int flags', 'const struct __kernel_timespec __user *rqtp', 'struct __kernel_timespec __user *rmtp']
 	case 4407: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5188,6 +5553,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4408 long sys_timer_gettime ['timer_t timer_id', 'struct __kernel_itimerspec __user *setting']
 	case 4408: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5201,6 +5567,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4409 long sys_timer_settime ['timer_t timer_id', 'int flags', 'const struct __kernel_itimerspec __user *new_setting', 'struct __kernel_itimerspec __user *old_setting']
 	case 4409: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5218,6 +5585,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4410 long sys_timerfd_gettime ['int ufd', 'struct __kernel_itimerspec __user *otmr']
 	case 4410: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5231,6 +5599,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4411 long sys_timerfd_settime ['int ufd', 'int flags', 'const struct __kernel_itimerspec __user *utmr', 'struct __kernel_itimerspec __user *otmr']
 	case 4411: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5248,6 +5617,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4412 long sys_utimensat ['int dfd', 'const char __user *filename', 'struct __kernel_timespec __user *utimes', 'int flags']
 	case 4412: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5265,6 +5635,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4413 long sys_pselect6 ['int', 'fd_set __user *', 'fd_set __user *', 'fd_set __user *', 'struct __kernel_timespec __user *', 'void __user *']
 	case 4413: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5286,6 +5657,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4414 long sys_ppoll ['struct pollfd __user *', 'unsigned int', 'struct __kernel_timespec __user *', 'const sigset_t __user *', 'size_t']
 	case 4414: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5305,6 +5677,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4416 long sys_io_pgetevents ['aio_context_t ctx_id', 'long min_nr', 'long nr', 'struct io_event __user *events', 'struct __kernel_timespec __user *timeout', 'const struct __aio_sigset *sig']
 	case 4416: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5326,6 +5699,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4417 long sys_recvmmsg ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags', 'struct __kernel_timespec __user *timeout']
 	case 4417: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5345,6 +5719,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4418 long sys_mq_timedsend ['mqd_t mqdes', 'const char __user *msg_ptr', 'size_t msg_len', 'unsigned int msg_prio', 'const struct __kernel_timespec __user *abs_timeout']
 	case 4418: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5364,6 +5739,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4419 long sys_mq_timedreceive ['mqd_t mqdes', 'char __user *msg_ptr', 'size_t msg_len', 'unsigned int __user *msg_prio', 'const struct __kernel_timespec __user *abs_timeout']
 	case 4419: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5383,6 +5759,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4420 long sys_semtimedop ['int semid', 'struct sembuf __user *sops', 'unsigned nsops', 'const struct __kernel_timespec __user *timeout']
 	case 4420: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5400,6 +5777,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4421 long sys_rt_sigtimedwait ['const sigset_t __user *uthese', 'siginfo_t __user *uinfo', 'const struct __kernel_timespec __user *uts', 'size_t sigsetsize']
 	case 4421: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5417,6 +5795,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4422 long sys_futex ['u32 __user *uaddr', 'int op', 'u32 val', 'struct __kernel_timespec __user *utime', 'u32 __user *uaddr2', 'u32 val3']
 	case 4422: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5438,6 +5817,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4423 long sys_sched_rr_get_interval ['pid_t pid', 'struct __kernel_timespec __user *interval']
 	case 4423: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5451,6 +5831,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4424 long sys_pidfd_send_signal ['int pidfd', 'int sig', 'siginfo_t __user *info', 'unsigned int flags']
 	case 4424: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5468,6 +5849,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4425 long sys_io_uring_setup ['u32 entries', 'struct io_uring_params __user *p']
 	case 4425: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5481,6 +5863,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4426 long sys_io_uring_enter ['unsigned int fd', 'u32 to_submit', 'u32 min_complete', 'u32 flags', 'const sigset_t __user *sig', 'size_t sigsz']
 	case 4426: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5502,6 +5885,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4427 long sys_io_uring_register ['unsigned int fd', 'unsigned int op', 'void __user *arg', 'unsigned int nr_args']
 	case 4427: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5519,6 +5903,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4428 long sys_open_tree ['int dfd', 'const char __user *path', 'unsigned flags']
 	case 4428: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5534,6 +5919,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4429 long sys_move_mount ['int from_dfd', 'const char __user *from_path', 'int to_dfd', 'const char __user *to_path', 'unsigned int ms_flags']
 	case 4429: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -5553,6 +5939,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4430 long sys_fsopen ['const char __user *fs_name', 'unsigned int flags']
 	case 4430: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5566,6 +5953,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4431 long sys_fsconfig ['int fs_fd', 'unsigned int cmd', 'const char __user *key', 'const void __user *value', 'int aux']
 	case 4431: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5585,6 +5973,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4432 long sys_fsmount ['int fs_fd', 'unsigned int flags', 'unsigned int ms_flags']
 	case 4432: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5600,6 +5989,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4433 long sys_fspick ['int dfd', 'const char __user *path', 'unsigned int flags']
 	case 4433: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5615,6 +6005,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4434 long sys_pidfd_open ['pid_t pid', 'unsigned int flags']
 	case 4434: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5628,6 +6019,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4437 long sys_openat2 ['int dfd', 'const char __user *filename', 'struct open_how *how', 'size_t size']
 	case 4437: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5645,6 +6037,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4438 long sys_pidfd_getfd ['int pidfd', 'int fd', 'unsigned int flags']
 	case 4438: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5660,6 +6053,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	// 4439 long sys_faccessat2 ['int dfd', 'const char __user *filename', 'int mode', 'int flags']
 	case 4439: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x64.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -873,6 +874,8 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 57 long sys_fork ['void']
 	case 57: {
 		panda_noreturn = false;
+		ctx.double_return = true;
+		printf("double return\n");
 		PPP_RUN_CB(on_sys_fork_enter, cpu, pc);
 	}; break;
 	// 58 long sys_vfork ['void']
@@ -4585,14 +4588,18 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	if (!panda_noreturn) {
 		struct hook h;
 		h.addr = ctx.retaddr;
-		h.asid = ctx.asid;
+		if (ctx.double_return){
+			h.asid = 0;
+		}else{
+			h.asid = ctx.asid;
+		}
 		h.cb.start_block_exec = hook_syscall_return;
 		h.type = PANDA_CB_START_BLOCK_EXEC;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);
 
-		running_syscalls[std::make_pair(ctx.retaddr, ctx.asid)] = ctx;
+		running_syscalls[std::make_pair(ctx.retaddr, h.asid)] = ctx;
 	}
 #endif
 }

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x64.cpp
@@ -49,6 +49,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 0 long sys_read ['unsigned int fd', 'char __user *buf', 'size_t count']
 	case 0: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -64,6 +65,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 1 long sys_write ['unsigned int fd', 'const char __user *buf', 'size_t count']
 	case 1: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -79,6 +81,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 2 long sys_open ['const char __user *filename', 'int flags', 'umode_t mode']
 	case 2: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -94,6 +97,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 3 long sys_close ['unsigned int fd']
 	case 3: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -105,6 +109,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 4 long sys_newstat ['const char __user *filename', 'struct stat __user *statbuf']
 	case 4: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -118,6 +123,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 5 long sys_newfstat ['unsigned int fd', 'struct stat __user *statbuf']
 	case 5: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -131,6 +137,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 6 long sys_newlstat ['const char __user *filename', 'struct stat __user *statbuf']
 	case 6: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -144,6 +151,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 7 long sys_poll ['struct pollfd __user *ufds', 'unsigned int nfds', 'int timeout']
 	case 7: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -159,6 +167,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 8 long sys_lseek ['unsigned int fd', 'off_t offset', 'unsigned int whence']
 	case 8: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -174,6 +183,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 9 long sys_mmap ['unsigned long', 'unsigned long', 'unsigned long', 'unsigned long', 'unsigned long', 'unsigned long']
 	case 9: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -195,6 +205,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 10 long sys_mprotect ['unsigned long start', 'size_t len', 'unsigned long prot']
 	case 10: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -210,6 +221,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 11 long sys_munmap ['unsigned long addr', 'size_t len']
 	case 11: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -223,6 +235,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 12 long sys_brk ['unsigned long brk']
 	case 12: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -234,6 +247,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 13 long sys_rt_sigaction ['int', 'const struct sigaction __user *', 'struct sigaction __user *', 'size_t']
 	case 13: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -251,6 +265,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 14 long sys_rt_sigprocmask ['int how', 'sigset_t __user *set', 'sigset_t __user *oset', 'size_t sigsetsize']
 	case 14: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -268,11 +283,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 15 long sys_rt_sigreturn ['void']
 	case 15: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_rt_sigreturn_enter, cpu, pc);
 	}; break;
 	// 16 long sys_ioctl ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 16: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -288,6 +305,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 17 long sys_pread64 ['unsigned int fd', 'char __user *buf', 'size_t count', 'loff_t pos']
 	case 17: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -305,6 +323,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 18 long sys_pwrite64 ['unsigned int fd', 'const char __user *buf', 'size_t count', 'loff_t pos']
 	case 18: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -322,6 +341,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 19 long sys_readv ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen']
 	case 19: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -337,6 +357,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 20 long sys_writev ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen']
 	case 20: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -352,6 +373,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 21 long sys_access ['const char __user *filename', 'int mode']
 	case 21: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -365,6 +387,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 22 long sys_pipe ['int __user *fildes']
 	case 22: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -376,6 +399,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 23 long sys_select ['int n', 'fd_set __user *inp', 'fd_set __user *outp', 'fd_set __user *exp', 'struct timeval __user *tvp']
 	case 23: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -395,11 +419,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 24 long sys_sched_yield ['void']
 	case 24: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sched_yield_enter, cpu, pc);
 	}; break;
 	// 25 long sys_mremap ['unsigned long addr', 'unsigned long old_len', 'unsigned long new_len', 'unsigned long flags', 'unsigned long new_addr']
 	case 25: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -419,6 +445,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 26 long sys_msync ['unsigned long start', 'size_t len', 'int flags']
 	case 26: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -434,6 +461,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 27 long sys_mincore ['unsigned long start', 'size_t len', 'unsigned char __user *vec']
 	case 27: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -449,6 +477,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 28 long sys_madvise ['unsigned long start', 'size_t len', 'int behavior']
 	case 28: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -464,6 +493,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 29 long sys_shmget ['key_t key', 'size_t size', 'int flag']
 	case 29: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -479,6 +509,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 30 long sys_shmat ['int shmid', 'char __user *shmaddr', 'int shmflg']
 	case 30: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -494,6 +525,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 31 long sys_shmctl ['int shmid', 'int cmd', 'struct shmid_ds __user *buf']
 	case 31: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -509,6 +541,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 32 long sys_dup ['unsigned int fildes']
 	case 32: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -520,6 +553,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 33 long sys_dup2 ['unsigned int oldfd', 'unsigned int newfd']
 	case 33: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -533,11 +567,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 34 long sys_pause ['void']
 	case 34: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_pause_enter, cpu, pc);
 	}; break;
 	// 35 long sys_nanosleep ['struct timespec __user *rqtp', 'struct timespec __user *rmtp']
 	case 35: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -551,6 +587,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 36 long sys_getitimer ['int which', 'struct itimerval __user *value']
 	case 36: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -564,6 +601,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 37 long sys_alarm ['unsigned int seconds']
 	case 37: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -575,6 +613,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 38 long sys_setitimer ['int which', 'struct itimerval __user *value', 'struct itimerval __user *ovalue']
 	case 38: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -590,11 +629,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 39 long sys_getpid ['void']
 	case 39: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getpid_enter, cpu, pc);
 	}; break;
 	// 40 long sys_sendfile64 ['int out_fd', 'int in_fd', 'loff_t __user *offset', 'size_t count']
 	case 40: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -612,6 +653,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 41 long sys_socket ['int', 'int', 'int']
 	case 41: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -627,6 +669,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 42 long sys_connect ['int', 'struct sockaddr __user *', 'int']
 	case 42: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -642,6 +685,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 43 long sys_accept ['int', 'struct sockaddr __user *', 'int __user *']
 	case 43: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -657,6 +701,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 44 long sys_sendto ['int', 'void __user *', 'size_t', 'unsigned', 'struct sockaddr __user *', 'int']
 	case 44: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -678,6 +723,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 45 long sys_recvfrom ['int', 'void __user *', 'size_t', 'unsigned', 'struct sockaddr __user *', 'int __user *']
 	case 45: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -699,6 +745,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 46 long sys_sendmsg ['int fd', 'struct user_msghdr __user *msg', 'unsigned flags']
 	case 46: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -714,6 +761,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 47 long sys_recvmsg ['int fd', 'struct user_msghdr __user *msg', 'unsigned flags']
 	case 47: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -729,6 +777,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 48 long sys_shutdown ['int', 'int']
 	case 48: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -742,6 +791,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 49 long sys_bind ['int', 'struct sockaddr __user *', 'int']
 	case 49: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -757,6 +807,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 50 long sys_listen ['int', 'int']
 	case 50: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -770,6 +821,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 51 long sys_getsockname ['int', 'struct sockaddr __user *', 'int __user *']
 	case 51: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -785,6 +837,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 52 long sys_getpeername ['int', 'struct sockaddr __user *', 'int __user *']
 	case 52: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -800,6 +853,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 53 long sys_socketpair ['int', 'int', 'int', 'int __user *']
 	case 53: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -817,6 +871,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 54 long sys_setsockopt ['int fd', 'int level', 'int optname', 'char __user *optval', 'int optlen']
 	case 54: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -836,6 +891,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 55 long sys_getsockopt ['int fd', 'int level', 'int optname', 'char __user *optval', 'int __user *optlen']
 	case 55: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -855,6 +911,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 56 long sys_clone ['unsigned long', 'unsigned long', 'int __user *', 'int __user *', 'unsigned long']
 	case 56: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -875,17 +932,18 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	case 57: {
 		panda_noreturn = false;
 		ctx.double_return = true;
-		printf("double return\n");
 		PPP_RUN_CB(on_sys_fork_enter, cpu, pc);
 	}; break;
 	// 58 long sys_vfork ['void']
 	case 58: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_vfork_enter, cpu, pc);
 	}; break;
 	// 59 long sys_execve ['const char __user *filename', 'const char __user *const __user *argv', 'const char __user *const __user *envp']
 	case 59: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -901,6 +959,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 60 long sys_exit ['int error_code']
 	case 60: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -912,6 +971,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 61 long sys_wait4 ['pid_t pid', 'int __user *stat_addr', 'int options', 'struct rusage __user *ru']
 	case 61: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -929,6 +989,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 62 long sys_kill ['pid_t pid', 'int sig']
 	case 62: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -942,6 +1003,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 63 long sys_newuname ['struct new_utsname __user *name']
 	case 63: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -953,6 +1015,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 64 long sys_semget ['key_t key', 'int nsems', 'int semflg']
 	case 64: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -968,6 +1031,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 65 long sys_semop ['int semid', 'struct sembuf __user *sops', 'unsigned nsops']
 	case 65: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -983,6 +1047,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 66 long sys_semctl ['int semid', 'int semnum', 'int cmd', 'unsigned long arg']
 	case 66: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1000,6 +1065,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 67 long sys_shmdt ['char __user *shmaddr']
 	case 67: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1011,6 +1077,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 68 long sys_msgget ['key_t key', 'int msgflg']
 	case 68: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1024,6 +1091,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 69 long sys_msgsnd ['int msqid', 'struct msgbuf __user *msgp', 'size_t msgsz', 'int msgflg']
 	case 69: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1041,6 +1109,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 70 long sys_msgrcv ['int msqid', 'struct msgbuf __user *msgp', 'size_t msgsz', 'long msgtyp', 'int msgflg']
 	case 70: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1060,6 +1129,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 71 long sys_msgctl ['int msqid', 'int cmd', 'struct msqid_ds __user *buf']
 	case 71: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1075,6 +1145,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 72 long sys_fcntl ['unsigned int fd', 'unsigned int cmd', 'unsigned long arg']
 	case 72: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1090,6 +1161,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 73 long sys_flock ['unsigned int fd', 'unsigned int cmd']
 	case 73: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1103,6 +1175,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 74 long sys_fsync ['unsigned int fd']
 	case 74: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1114,6 +1187,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 75 long sys_fdatasync ['unsigned int fd']
 	case 75: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1125,6 +1199,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 76 long sys_truncate ['const char __user *path', 'long length']
 	case 76: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1138,6 +1213,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 77 long sys_ftruncate ['unsigned int fd', 'unsigned long length']
 	case 77: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1151,6 +1227,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 78 long sys_getdents ['unsigned int fd', 'struct linux_dirent __user *dirent', 'unsigned int count']
 	case 78: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1166,6 +1243,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 79 long sys_getcwd ['char __user *buf', 'unsigned long size']
 	case 79: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1179,6 +1257,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 80 long sys_chdir ['const char __user *filename']
 	case 80: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1190,6 +1269,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 81 long sys_fchdir ['unsigned int fd']
 	case 81: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1201,6 +1281,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 82 long sys_rename ['const char __user *oldname', 'const char __user *newname']
 	case 82: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1214,6 +1295,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 83 long sys_mkdir ['const char __user *pathname', 'umode_t mode']
 	case 83: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1227,6 +1309,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 84 long sys_rmdir ['const char __user *pathname']
 	case 84: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1238,6 +1321,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 85 long sys_creat ['const char __user *pathname', 'umode_t mode']
 	case 85: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1251,6 +1335,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 86 long sys_link ['const char __user *oldname', 'const char __user *newname']
 	case 86: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1264,6 +1349,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 87 long sys_unlink ['const char __user *pathname']
 	case 87: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1275,6 +1361,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 88 long sys_symlink ['const char __user *old', 'const char __user *new']
 	case 88: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1288,6 +1375,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 89 long sys_readlink ['const char __user *path', 'char __user *buf', 'int bufsiz']
 	case 89: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1303,6 +1391,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 90 long sys_chmod ['const char __user *filename', 'umode_t mode']
 	case 90: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1316,6 +1405,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 91 long sys_fchmod ['unsigned int fd', 'umode_t mode']
 	case 91: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1329,6 +1419,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 92 long sys_chown ['const char __user *filename', 'uid_t user', 'gid_t group']
 	case 92: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1344,6 +1435,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 93 long sys_fchown ['unsigned int fd', 'uid_t user', 'gid_t group']
 	case 93: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1359,6 +1451,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 94 long sys_lchown ['const char __user *filename', 'uid_t user', 'gid_t group']
 	case 94: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1374,6 +1467,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 95 long sys_umask ['int mask']
 	case 95: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1385,6 +1479,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 96 long sys_gettimeofday ['struct timeval __user *tv', 'struct timezone __user *tz']
 	case 96: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1398,6 +1493,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 97 long sys_getrlimit ['unsigned int resource', 'struct rlimit __user *rlim']
 	case 97: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1411,6 +1507,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 98 long sys_getrusage ['int who', 'struct rusage __user *ru']
 	case 98: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1424,6 +1521,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 99 long sys_sysinfo ['struct sysinfo __user *info']
 	case 99: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1435,6 +1533,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 100 long sys_times ['struct tms __user *tbuf']
 	case 100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1446,6 +1545,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 101 long sys_ptrace ['long request', 'long pid', 'unsigned long addr', 'unsigned long data']
 	case 101: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int64_t arg0 = get_s64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1463,11 +1563,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 102 long sys_getuid ['void']
 	case 102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getuid_enter, cpu, pc);
 	}; break;
 	// 103 long sys_syslog ['int type', 'char __user *buf', 'int len']
 	case 103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1483,11 +1585,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 104 long sys_getgid ['void']
 	case 104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getgid_enter, cpu, pc);
 	}; break;
 	// 105 long sys_setuid ['uid_t uid']
 	case 105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1499,6 +1603,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 106 long sys_setgid ['gid_t gid']
 	case 106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1510,16 +1615,19 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 107 long sys_geteuid ['void']
 	case 107: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_geteuid_enter, cpu, pc);
 	}; break;
 	// 108 long sys_getegid ['void']
 	case 108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getegid_enter, cpu, pc);
 	}; break;
 	// 109 long sys_setpgid ['pid_t pid', 'pid_t pgid']
 	case 109: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1533,21 +1641,25 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 110 long sys_getppid ['void']
 	case 110: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getppid_enter, cpu, pc);
 	}; break;
 	// 111 long sys_getpgrp ['void']
 	case 111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_getpgrp_enter, cpu, pc);
 	}; break;
 	// 112 long sys_setsid ['void']
 	case 112: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_setsid_enter, cpu, pc);
 	}; break;
 	// 113 long sys_setreuid ['uid_t ruid', 'uid_t euid']
 	case 113: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1561,6 +1673,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 114 long sys_setregid ['gid_t rgid', 'gid_t egid']
 	case 114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1574,6 +1687,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 115 long sys_getgroups ['int gidsetsize', 'gid_t __user *grouplist']
 	case 115: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1587,6 +1701,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 116 long sys_setgroups ['int gidsetsize', 'gid_t __user *grouplist']
 	case 116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1600,6 +1715,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 117 long sys_setresuid ['uid_t ruid', 'uid_t euid', 'uid_t suid']
 	case 117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1615,6 +1731,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 118 long sys_getresuid ['uid_t __user *ruid', 'uid_t __user *euid', 'uid_t __user *suid']
 	case 118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1630,6 +1747,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 119 long sys_setresgid ['gid_t rgid', 'gid_t egid', 'gid_t sgid']
 	case 119: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1645,6 +1763,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 120 long sys_getresgid ['gid_t __user *rgid', 'gid_t __user *egid', 'gid_t __user *sgid']
 	case 120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1660,6 +1779,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 121 long sys_getpgid ['pid_t pid']
 	case 121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1671,6 +1791,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 122 long sys_setfsuid ['uid_t uid']
 	case 122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1682,6 +1803,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 123 long sys_setfsgid ['gid_t gid']
 	case 123: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1693,6 +1815,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 124 long sys_getsid ['pid_t pid']
 	case 124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1704,6 +1827,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 125 long sys_capget ['cap_user_header_t header', 'cap_user_data_t dataptr']
 	case 125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1717,6 +1841,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 126 long sys_capset ['cap_user_header_t header', 'const cap_user_data_t data']
 	case 126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1730,6 +1855,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 127 long sys_rt_sigpending ['sigset_t __user *set', 'size_t sigsetsize']
 	case 127: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1743,6 +1869,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 128 long sys_rt_sigtimedwait ['const sigset_t __user *uthese', 'siginfo_t __user *uinfo', 'const struct timespec __user *uts', 'size_t sigsetsize']
 	case 128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1760,6 +1887,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 129 long sys_rt_sigqueueinfo ['pid_t pid', 'int sig', 'siginfo_t __user *uinfo']
 	case 129: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1775,6 +1903,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 130 long sys_rt_sigsuspend ['sigset_t __user *unewset', 'size_t sigsetsize']
 	case 130: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1788,6 +1917,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 131 long sys_sigaltstack ['const struct sigaltstack __user *uss', 'struct sigaltstack __user *uoss']
 	case 131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1801,6 +1931,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 132 long sys_utime ['char __user *filename', 'struct utimbuf __user *times']
 	case 132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1814,6 +1945,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 133 long sys_mknod ['const char __user *filename', 'umode_t mode', 'unsigned dev']
 	case 133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1829,6 +1961,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 135 long sys_personality ['unsigned int personality']
 	case 135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1840,6 +1973,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 136 long sys_ustat ['unsigned dev', 'struct ustat __user *ubuf']
 	case 136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1853,6 +1987,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 137 long sys_statfs ['const char __user *path', 'struct statfs __user *buf']
 	case 137: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1866,6 +2001,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 138 long sys_fstatfs ['unsigned int fd', 'struct statfs __user *buf']
 	case 138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1879,6 +2015,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 139 long sys_sysfs ['int option', 'unsigned long arg1', 'unsigned long arg2']
 	case 139: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1894,6 +2031,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 140 long sys_getpriority ['int which', 'int who']
 	case 140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1907,6 +2045,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 141 long sys_setpriority ['int which', 'int who', 'int niceval']
 	case 141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -1922,6 +2061,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 142 long sys_sched_setparam ['pid_t pid', 'struct sched_param __user *param']
 	case 142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1935,6 +2075,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 143 long sys_sched_getparam ['pid_t pid', 'struct sched_param __user *param']
 	case 143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1948,6 +2089,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 144 long sys_sched_setscheduler ['pid_t pid', 'int policy', 'struct sched_param __user *param']
 	case 144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -1963,6 +2105,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 145 long sys_sched_getscheduler ['pid_t pid']
 	case 145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1974,6 +2117,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 146 long sys_sched_get_priority_max ['int policy']
 	case 146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1985,6 +2129,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 147 long sys_sched_get_priority_min ['int policy']
 	case 147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1996,6 +2141,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 148 long sys_sched_rr_get_interval ['pid_t pid', 'struct timespec __user *interval']
 	case 148: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2009,6 +2155,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 149 long sys_mlock ['unsigned long start', 'size_t len']
 	case 149: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2022,6 +2169,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 150 long sys_munlock ['unsigned long start', 'size_t len']
 	case 150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2035,6 +2183,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 151 long sys_mlockall ['int flags']
 	case 151: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2046,16 +2195,19 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 152 long sys_munlockall ['void']
 	case 152: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_munlockall_enter, cpu, pc);
 	}; break;
 	// 153 long sys_vhangup ['void']
 	case 153: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_vhangup_enter, cpu, pc);
 	}; break;
 	// 154 long sys_modify_ldt ['int', 'void __user *', 'unsigned long']
 	case 154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2071,6 +2223,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 155 long sys_pivot_root ['const char __user *new_root', 'const char __user *put_old']
 	case 155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2084,6 +2237,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 156 long sys_sysctl ['struct __sysctl_args __user *args']
 	case 156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2095,6 +2249,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 157 long sys_prctl ['int option', 'unsigned long arg2', 'unsigned long arg3', 'unsigned long arg4', 'unsigned long arg5']
 	case 157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2114,6 +2269,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 158 long sys_arch_prctl ['int', 'unsigned long']
 	case 158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2127,6 +2283,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 159 long sys_adjtimex ['struct timex __user *txc_p']
 	case 159: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2138,6 +2295,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 160 long sys_setrlimit ['unsigned int resource', 'struct rlimit __user *rlim']
 	case 160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2151,6 +2309,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 161 long sys_chroot ['const char __user *filename']
 	case 161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2162,11 +2321,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 162 long sys_sync ['void']
 	case 162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_sync_enter, cpu, pc);
 	}; break;
 	// 163 long sys_acct ['const char __user *name']
 	case 163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2178,6 +2339,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 164 long sys_settimeofday ['struct timeval __user *tv', 'struct timezone __user *tz']
 	case 164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2191,6 +2353,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 165 long sys_mount ['char __user *dev_name', 'char __user *dir_name', 'char __user *type', 'unsigned long flags', 'void __user *data']
 	case 165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2210,6 +2373,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 166 long sys_umount ['char __user *name', 'int flags']
 	case 166: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2223,6 +2387,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 167 long sys_swapon ['const char __user *specialfile', 'int swap_flags']
 	case 167: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2236,6 +2401,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 168 long sys_swapoff ['const char __user *specialfile']
 	case 168: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2247,6 +2413,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 169 long sys_reboot ['int magic1', 'int magic2', 'unsigned int cmd', 'void __user *arg']
 	case 169: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2264,6 +2431,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 170 long sys_sethostname ['char __user *name', 'int len']
 	case 170: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2277,6 +2445,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 171 long sys_setdomainname ['char __user *name', 'int len']
 	case 171: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2290,6 +2459,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 172 long sys_iopl ['unsigned int']
 	case 172: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2301,6 +2471,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 173 long sys_ioperm ['unsigned long', 'unsigned long', 'int']
 	case 173: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2316,6 +2487,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 175 long sys_init_module ['void __user *umod', 'unsigned long len', 'const char __user *uargs']
 	case 175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2331,6 +2503,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 176 long sys_delete_module ['const char __user *name_user', 'unsigned int flags']
 	case 176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2344,6 +2517,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 179 long sys_quotactl ['unsigned int cmd', 'const char __user *special', 'qid_t id', 'void __user *addr']
 	case 179: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2361,11 +2535,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 186 long sys_gettid ['void']
 	case 186: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_gettid_enter, cpu, pc);
 	}; break;
 	// 187 long sys_readahead ['int fd', 'loff_t offset', 'size_t count']
 	case 187: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2381,6 +2557,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 188 long sys_setxattr ['const char __user *path', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 188: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2400,6 +2577,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 189 long sys_lsetxattr ['const char __user *path', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 189: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2419,6 +2597,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 190 long sys_fsetxattr ['int fd', 'const char __user *name', 'const void __user *value', 'size_t size', 'int flags']
 	case 190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2438,6 +2617,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 191 long sys_getxattr ['const char __user *path', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2455,6 +2635,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 192 long sys_lgetxattr ['const char __user *path', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2472,6 +2653,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 193 long sys_fgetxattr ['int fd', 'const char __user *name', 'void __user *value', 'size_t size']
 	case 193: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2489,6 +2671,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 194 long sys_listxattr ['const char __user *path', 'char __user *list', 'size_t size']
 	case 194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2504,6 +2687,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 195 long sys_llistxattr ['const char __user *path', 'char __user *list', 'size_t size']
 	case 195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2519,6 +2703,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 196 long sys_flistxattr ['int fd', 'char __user *list', 'size_t size']
 	case 196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2534,6 +2719,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 197 long sys_removexattr ['const char __user *path', 'const char __user *name']
 	case 197: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2547,6 +2733,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 198 long sys_lremovexattr ['const char __user *path', 'const char __user *name']
 	case 198: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2560,6 +2747,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 199 long sys_fremovexattr ['int fd', 'const char __user *name']
 	case 199: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2573,6 +2761,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 200 long sys_tkill ['pid_t pid', 'int sig']
 	case 200: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2586,6 +2775,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 201 long sys_time ['time_t __user *tloc']
 	case 201: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2597,6 +2787,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 202 long sys_futex ['u32 __user *uaddr', 'int op', 'u32 val', 'struct timespec __user *utime', 'u32 __user *uaddr2', 'u32 val3']
 	case 202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2618,6 +2809,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 203 long sys_sched_setaffinity ['pid_t pid', 'unsigned int len', 'unsigned long __user *user_mask_ptr']
 	case 203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2633,6 +2825,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 204 long sys_sched_getaffinity ['pid_t pid', 'unsigned int len', 'unsigned long __user *user_mask_ptr']
 	case 204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2648,6 +2841,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 206 long sys_io_setup ['unsigned nr_reqs', 'aio_context_t __user *ctx']
 	case 206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2661,6 +2855,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 207 long sys_io_destroy ['aio_context_t ctx']
 	case 207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2672,6 +2867,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 208 long sys_io_getevents ['aio_context_t ctx_id', 'long min_nr', 'long nr', 'struct io_event __user *events', 'struct timespec __user *timeout']
 	case 208: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		int64_t arg2 = get_s64(cpu, 2);
@@ -2691,6 +2887,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 209 long sys_io_submit ['aio_context_t', 'long', 'struct iocb __user * __user *']
 	case 209: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int64_t arg1 = get_s64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2706,6 +2903,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 210 long sys_io_cancel ['aio_context_t ctx_id', 'struct iocb __user *iocb', 'struct io_event __user *result']
 	case 210: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2721,6 +2919,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 212 long sys_lookup_dcookie ['u64 cookie64', 'char __user *buf', 'size_t len']
 	case 212: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2736,6 +2935,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 213 long sys_epoll_create ['int size']
 	case 213: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2747,6 +2947,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 216 long sys_remap_file_pages ['unsigned long start', 'unsigned long size', 'unsigned long prot', 'unsigned long pgoff', 'unsigned long flags']
 	case 216: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2766,6 +2967,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 217 long sys_getdents64 ['unsigned int fd', 'struct linux_dirent64 __user *dirent', 'unsigned int count']
 	case 217: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2781,6 +2983,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 218 long sys_set_tid_address ['int __user *tidptr']
 	case 218: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2792,11 +2995,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 219 long sys_restart_syscall ['void']
 	case 219: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_restart_syscall_enter, cpu, pc);
 	}; break;
 	// 220 long sys_semtimedop ['int semid', 'struct sembuf __user *sops', 'unsigned nsops', 'const struct timespec __user *timeout']
 	case 220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2814,6 +3019,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 221 long sys_fadvise64 ['int fd', 'loff_t offset', 'size_t len', 'int advice']
 	case 221: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2831,6 +3037,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 222 long sys_timer_create ['clockid_t which_clock', 'struct sigevent __user *timer_event_spec', 'timer_t __user *created_timer_id']
 	case 222: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2846,6 +3053,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 223 long sys_timer_settime ['timer_t timer_id', 'int flags', 'const struct itimerspec __user *new_setting', 'struct itimerspec __user *old_setting']
 	case 223: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2863,6 +3071,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 224 long sys_timer_gettime ['timer_t timer_id', 'struct itimerspec __user *setting']
 	case 224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2876,6 +3085,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 225 long sys_timer_getoverrun ['timer_t timer_id']
 	case 225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2887,6 +3097,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 226 long sys_timer_delete ['timer_t timer_id']
 	case 226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2898,6 +3109,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 227 long sys_clock_settime ['clockid_t which_clock', 'const struct timespec __user *tp']
 	case 227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2911,6 +3123,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 228 long sys_clock_gettime ['clockid_t which_clock', 'struct timespec __user *tp']
 	case 228: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2924,6 +3137,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 229 long sys_clock_getres ['clockid_t which_clock', 'struct timespec __user *tp']
 	case 229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2937,6 +3151,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 230 long sys_clock_nanosleep ['clockid_t which_clock', 'int flags', 'const struct timespec __user *rqtp', 'struct timespec __user *rmtp']
 	case 230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -2954,6 +3169,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 231 long sys_exit_group ['int error_code']
 	case 231: {
 		panda_noreturn = true;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2965,6 +3181,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 232 long sys_epoll_wait ['int epfd', 'struct epoll_event __user *events', 'int maxevents', 'int timeout']
 	case 232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2982,6 +3199,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 233 long sys_epoll_ctl ['int epfd', 'int op', 'int fd', 'struct epoll_event __user *event']
 	case 233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -2999,6 +3217,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 234 long sys_tgkill ['pid_t tgid', 'pid_t pid', 'int sig']
 	case 234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3014,6 +3233,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 235 long sys_utimes ['char __user *filename', 'struct timeval __user *utimes']
 	case 235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3027,6 +3247,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 237 long sys_mbind ['unsigned long start', 'unsigned long len', 'unsigned long mode', 'const unsigned long __user *nmask', 'unsigned long maxnode', 'unsigned flags']
 	case 237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3048,6 +3269,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 238 long sys_set_mempolicy ['int mode', 'const unsigned long __user *nmask', 'unsigned long maxnode']
 	case 238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3063,6 +3285,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 239 long sys_get_mempolicy ['int __user *policy', 'unsigned long __user *nmask', 'unsigned long maxnode', 'unsigned long addr', 'unsigned long flags']
 	case 239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3082,6 +3305,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 240 long sys_mq_open ['const char __user *name', 'int oflag', 'umode_t mode', 'struct mq_attr __user *attr']
 	case 240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3099,6 +3323,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 241 long sys_mq_unlink ['const char __user *name']
 	case 241: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3110,6 +3335,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 242 long sys_mq_timedsend ['mqd_t mqdes', 'const char __user *msg_ptr', 'size_t msg_len', 'unsigned int msg_prio', 'const struct timespec __user *abs_timeout']
 	case 242: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3129,6 +3355,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 243 long sys_mq_timedreceive ['mqd_t mqdes', 'char __user *msg_ptr', 'size_t msg_len', 'unsigned int __user *msg_prio', 'const struct timespec __user *abs_timeout']
 	case 243: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3148,6 +3375,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 244 long sys_mq_notify ['mqd_t mqdes', 'const struct sigevent __user *notification']
 	case 244: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3161,6 +3389,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 245 long sys_mq_getsetattr ['mqd_t mqdes', 'const struct mq_attr __user *mqstat', 'struct mq_attr __user *omqstat']
 	case 245: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3176,6 +3405,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 246 long sys_kexec_load ['unsigned long entry', 'unsigned long nr_segments', 'struct kexec_segment __user *segments', 'unsigned long flags']
 	case 246: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3193,6 +3423,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 247 long sys_waitid ['int which', 'pid_t pid', 'struct siginfo __user *infop', 'int options', 'struct rusage __user *ru']
 	case 247: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3212,6 +3443,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 248 long sys_add_key ['const char __user *_type', 'const char __user *_description', 'const void __user *_payload', 'size_t plen', 'key_serial_t destringid']
 	case 248: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3231,6 +3463,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 249 long sys_request_key ['const char __user *_type', 'const char __user *_description', 'const char __user *_callout_info', 'key_serial_t destringid']
 	case 249: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3248,6 +3481,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 250 long sys_keyctl ['int cmd', 'unsigned long arg2', 'unsigned long arg3', 'unsigned long arg4', 'unsigned long arg5']
 	case 250: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3267,6 +3501,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 251 long sys_ioprio_set ['int which', 'int who', 'int ioprio']
 	case 251: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3282,6 +3517,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 252 long sys_ioprio_get ['int which', 'int who']
 	case 252: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3295,11 +3531,13 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 253 long sys_inotify_init ['void']
 	case 253: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_sys_inotify_init_enter, cpu, pc);
 	}; break;
 	// 254 long sys_inotify_add_watch ['int fd', 'const char __user *path', 'u32 mask']
 	case 254: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3315,6 +3553,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 255 long sys_inotify_rm_watch ['int fd', '__s32 wd']
 	case 255: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3328,6 +3567,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 256 long sys_migrate_pages ['pid_t pid', 'unsigned long maxnode', 'const unsigned long __user *from', 'const unsigned long __user *to']
 	case 256: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3345,6 +3585,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 257 long sys_openat ['int dfd', 'const char __user *filename', 'int flags', 'umode_t mode']
 	case 257: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3362,6 +3603,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 258 long sys_mkdirat ['int dfd', 'const char __user *pathname', 'umode_t mode']
 	case 258: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3377,6 +3619,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 259 long sys_mknodat ['int dfd', 'const char __user *filename', 'umode_t mode', 'unsigned dev']
 	case 259: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3394,6 +3637,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 260 long sys_fchownat ['int dfd', 'const char __user *filename', 'uid_t user', 'gid_t group', 'int flag']
 	case 260: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3413,6 +3657,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 261 long sys_futimesat ['int dfd', 'const char __user *filename', 'struct timeval __user *utimes']
 	case 261: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3428,6 +3673,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 262 long sys_newfstatat ['int dfd', 'const char __user *filename', 'struct stat __user *statbuf', 'int flag']
 	case 262: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3445,6 +3691,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 263 long sys_unlinkat ['int dfd', 'const char __user *pathname', 'int flag']
 	case 263: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3460,6 +3707,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 264 long sys_renameat ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname']
 	case 264: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3477,6 +3725,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 265 long sys_linkat ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname', 'int flags']
 	case 265: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3496,6 +3745,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 266 long sys_symlinkat ['const char __user *oldname', 'int newdfd', 'const char __user *newname']
 	case 266: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3511,6 +3761,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 267 long sys_readlinkat ['int dfd', 'const char __user *path', 'char __user *buf', 'int bufsiz']
 	case 267: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3528,6 +3779,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 268 long sys_fchmodat ['int dfd', 'const char __user *filename', 'umode_t mode']
 	case 268: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3543,6 +3795,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 269 long sys_faccessat ['int dfd', 'const char __user *filename', 'int mode']
 	case 269: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3558,6 +3811,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 270 long sys_pselect6 ['int', 'fd_set __user *', 'fd_set __user *', 'fd_set __user *', 'struct timespec __user *', 'void __user *']
 	case 270: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3579,6 +3833,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 271 long sys_ppoll ['struct pollfd __user *', 'unsigned int', 'struct timespec __user *', 'const sigset_t __user *', 'size_t']
 	case 271: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3598,6 +3853,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 272 long sys_unshare ['unsigned long unshare_flags']
 	case 272: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3609,6 +3865,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 273 long sys_set_robust_list ['struct robust_list_head __user *head', 'size_t len']
 	case 273: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3622,6 +3879,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 274 long sys_get_robust_list ['int pid', 'struct robust_list_head __user * __user *head_ptr', 'size_t __user *len_ptr']
 	case 274: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3637,6 +3895,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 275 long sys_splice ['int fd_in', 'loff_t __user *off_in', 'int fd_out', 'loff_t __user *off_out', 'size_t len', 'unsigned int flags']
 	case 275: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3658,6 +3917,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 276 long sys_tee ['int fdin', 'int fdout', 'size_t len', 'unsigned int flags']
 	case 276: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3675,6 +3935,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 277 long sys_sync_file_range ['int fd', 'loff_t offset', 'loff_t nbytes', 'unsigned int flags']
 	case 277: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3692,6 +3953,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 278 long sys_vmsplice ['int fd', 'const struct iovec __user *iov', 'unsigned long nr_segs', 'unsigned int flags']
 	case 278: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3709,6 +3971,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 279 long sys_move_pages ['pid_t pid', 'unsigned long nr_pages', 'const void __user * __user *pages', 'const int __user *nodes', 'int __user *status', 'int flags']
 	case 279: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3730,6 +3993,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 280 long sys_utimensat ['int dfd', 'const char __user *filename', 'struct timespec __user *utimes', 'int flags']
 	case 280: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3747,6 +4011,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 281 long sys_epoll_pwait ['int epfd', 'struct epoll_event __user *events', 'int maxevents', 'int timeout', 'const sigset_t __user *sigmask', 'size_t sigsetsize']
 	case 281: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3768,6 +4033,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 282 long sys_signalfd ['int ufd', 'sigset_t __user *user_mask', 'size_t sizemask']
 	case 282: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3783,6 +4049,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 283 long sys_timerfd_create ['int clockid', 'int flags']
 	case 283: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3796,6 +4063,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 284 long sys_eventfd ['unsigned int count']
 	case 284: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3807,6 +4075,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 285 long sys_fallocate ['int fd', 'int mode', 'loff_t offset', 'loff_t len']
 	case 285: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3824,6 +4093,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 286 long sys_timerfd_settime ['int ufd', 'int flags', 'const struct itimerspec __user *utmr', 'struct itimerspec __user *otmr']
 	case 286: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3841,6 +4111,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 287 long sys_timerfd_gettime ['int ufd', 'struct itimerspec __user *otmr']
 	case 287: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3854,6 +4125,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 288 long sys_accept4 ['int', 'struct sockaddr __user *', 'int __user *', 'int']
 	case 288: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3871,6 +4143,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 289 long sys_signalfd4 ['int ufd', 'sigset_t __user *user_mask', 'size_t sizemask', 'int flags']
 	case 289: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3888,6 +4161,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 290 long sys_eventfd2 ['unsigned int count', 'int flags']
 	case 290: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3901,6 +4175,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 291 long sys_epoll_create1 ['int flags']
 	case 291: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3912,6 +4187,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 292 long sys_dup3 ['unsigned int oldfd', 'unsigned int newfd', 'int flags']
 	case 292: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -3927,6 +4203,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 293 long sys_pipe2 ['int __user *fildes', 'int flags']
 	case 293: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3940,6 +4217,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 294 long sys_inotify_init1 ['int flags']
 	case 294: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3951,6 +4229,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 295 long sys_preadv ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h']
 	case 295: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3970,6 +4249,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 296 long sys_pwritev ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h']
 	case 296: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -3989,6 +4269,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 297 long sys_rt_tgsigqueueinfo ['pid_t tgid', 'pid_t pid', 'int sig', 'siginfo_t __user *uinfo']
 	case 297: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4006,6 +4287,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 298 long sys_perf_event_open ['struct perf_event_attr __user *attr_uptr', 'pid_t pid', 'int cpu', 'int group_fd', 'unsigned long flags']
 	case 298: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4025,6 +4307,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 299 long sys_recvmmsg ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags', 'struct timespec __user *timeout']
 	case 299: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4044,6 +4327,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 300 long sys_fanotify_init ['unsigned int flags', 'unsigned int event_f_flags']
 	case 300: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4057,6 +4341,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 301 long sys_fanotify_mark ['int fanotify_fd', 'unsigned int flags', 'u64 mask', 'int fd', 'const char __user *pathname']
 	case 301: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4076,6 +4361,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 302 long sys_prlimit64 ['pid_t pid', 'unsigned int resource', 'const struct rlimit64 __user *new_rlim', 'struct rlimit64 __user *old_rlim']
 	case 302: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4093,6 +4379,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 303 long sys_name_to_handle_at ['int dfd', 'const char __user *name', 'struct file_handle __user *handle', 'int __user *mnt_id', 'int flag']
 	case 303: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4112,6 +4399,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 304 long sys_open_by_handle_at ['int mountdirfd', 'struct file_handle __user *handle', 'int flags']
 	case 304: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4127,6 +4415,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 305 long sys_clock_adjtime ['clockid_t which_clock', 'struct timex __user *tx']
 	case 305: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4140,6 +4429,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 306 long sys_syncfs ['int fd']
 	case 306: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4151,6 +4441,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 307 long sys_sendmmsg ['int fd', 'struct mmsghdr __user *msg', 'unsigned int vlen', 'unsigned flags']
 	case 307: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4168,6 +4459,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 308 long sys_setns ['int fd', 'int nstype']
 	case 308: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4181,6 +4473,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 309 long sys_getcpu ['unsigned __user *cpu', 'unsigned __user *node', 'struct getcpu_cache __user *cache']
 	case 309: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4196,6 +4489,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 310 long sys_process_vm_readv ['pid_t pid', 'const struct iovec __user *lvec', 'unsigned long liovcnt', 'const struct iovec __user *rvec', 'unsigned long riovcnt', 'unsigned long flags']
 	case 310: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4217,6 +4511,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 311 long sys_process_vm_writev ['pid_t pid', 'const struct iovec __user *lvec', 'unsigned long liovcnt', 'const struct iovec __user *rvec', 'unsigned long riovcnt', 'unsigned long flags']
 	case 311: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4238,6 +4533,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 312 long sys_kcmp ['pid_t pid1', 'pid_t pid2', 'int type', 'unsigned long idx1', 'unsigned long idx2']
 	case 312: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4257,6 +4553,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 313 long sys_finit_module ['int fd', 'const char __user *uargs', 'int flags']
 	case 313: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4272,6 +4569,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 314 long sys_sched_setattr ['pid_t pid', 'struct sched_attr __user *attr', 'unsigned int flags']
 	case 314: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4287,6 +4585,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 315 long sys_sched_getattr ['pid_t pid', 'struct sched_attr __user *attr', 'unsigned int size', 'unsigned int flags']
 	case 315: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4304,6 +4603,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 316 long sys_renameat2 ['int olddfd', 'const char __user *oldname', 'int newdfd', 'const char __user *newname', 'unsigned int flags']
 	case 316: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4323,6 +4623,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 317 long sys_seccomp ['unsigned int op', 'unsigned int flags', 'const char __user *uargs']
 	case 317: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4338,6 +4639,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 318 long sys_getrandom ['char __user *buf', 'size_t count', 'unsigned int flags']
 	case 318: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4353,6 +4655,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 319 long sys_memfd_create ['const char __user *uname_ptr', 'unsigned int flags']
 	case 319: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4366,6 +4669,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 320 long sys_kexec_file_load ['int kernel_fd', 'int initrd_fd', 'unsigned long cmdline_len', 'const char __user *cmdline_ptr', 'unsigned long flags']
 	case 320: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4385,6 +4689,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 321 long sys_bpf ['int cmd', 'union bpf_attr *attr', 'unsigned int size']
 	case 321: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4400,6 +4705,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 322 long sys_execveat ['int dfd', 'const char __user *filename', 'const char __user *const __user *argv', 'const char __user *const __user *envp', 'int flags']
 	case 322: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4419,6 +4725,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 323 long sys_userfaultfd ['int flags']
 	case 323: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4430,6 +4737,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 324 long sys_membarrier ['int cmd', 'int flags']
 	case 324: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4443,6 +4751,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 325 long sys_mlock2 ['unsigned long start', 'size_t len', 'int flags']
 	case 325: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4458,6 +4767,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 326 long sys_copy_file_range ['int fd_in', 'loff_t __user *off_in', 'int fd_out', 'loff_t __user *off_out', 'size_t len', 'unsigned int flags']
 	case 326: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		int32_t arg2 = get_s32(cpu, 2);
@@ -4479,6 +4789,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 327 long sys_preadv2 ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h', 'rwf_t flags']
 	case 327: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4500,6 +4811,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 328 long sys_pwritev2 ['unsigned long fd', 'const struct iovec __user *vec', 'unsigned long vlen', 'unsigned long pos_l', 'unsigned long pos_h', 'rwf_t flags']
 	case 328: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4521,6 +4833,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 329 long sys_pkey_mprotect ['unsigned long start', 'size_t len', 'unsigned long prot', 'int pkey']
 	case 329: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint64_t arg2 = get_64(cpu, 2);
@@ -4538,6 +4851,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 330 long sys_pkey_alloc ['unsigned long flags', 'unsigned long init_val']
 	case 330: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint64_t arg0 = get_64(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4551,6 +4865,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 331 long sys_pkey_free ['int pkey']
 	case 331: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4562,6 +4877,7 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	// 332 long sys_statx ['int dfd', 'const char __user *path', 'unsigned flags', 'unsigned mask', 'struct statx __user *buffer']
 	case 332: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint64_t arg1 = get_64(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4588,18 +4904,14 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 	if (!panda_noreturn) {
 		struct hook h;
 		h.addr = ctx.retaddr;
-		if (ctx.double_return){
-			h.asid = 0;
-		}else{
-			h.asid = ctx.asid;
-		}
+		h.asid = ctx.asid;
 		h.cb.start_block_exec = hook_syscall_return;
 		h.type = PANDA_CB_START_BLOCK_EXEC;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);
 
-		running_syscalls[std::make_pair(ctx.retaddr, h.asid)] = ctx;
+		running_syscalls[std::make_pair(ctx.retaddr, ctx.asid)] = ctx;
 	}
 #endif
 }

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_2000_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_2000_x86.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -48,6 +49,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']
 	case 0: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -69,6 +71,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 1 NTSTATUS NtAccessCheck ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 1: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -94,6 +97,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 2 NTSTATUS NtAccessCheckAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'ACCESS_MASK DesiredAccess', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 2: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -125,6 +129,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 3 NTSTATUS NtAccessCheckByType ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 3: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -156,6 +161,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 4 NTSTATUS NtAccessCheckByTypeAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 4: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -197,6 +203,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 5 NTSTATUS NtAccessCheckByTypeResultList ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 5: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -228,6 +235,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 6 NTSTATUS NtAccessCheckByTypeResultListAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 6: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -269,6 +277,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 7 NTSTATUS NtAccessCheckByTypeResultListAndAuditAlarmByHandle ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'HANDLE ClientToken', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 7: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -312,6 +321,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 8 NTSTATUS NtAddAtom ['PWSTR AtomName', 'ULONG Length', 'PRTL_ATOM Atom']
 	case 8: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -327,6 +337,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 9 NTSTATUS NtAdjustGroupsToken ['HANDLE TokenHandle', 'BOOLEAN ResetToDefault', 'PTOKEN_GROUPS NewState', 'ULONG BufferLength', 'PTOKEN_GROUPS PreviousState', 'PULONG ReturnLength']
 	case 9: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -348,6 +359,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 10 NTSTATUS NtAdjustPrivilegesToken ['HANDLE TokenHandle', 'BOOLEAN DisableAllPrivileges', 'PTOKEN_PRIVILEGES NewState', 'ULONG BufferLength', 'PTOKEN_PRIVILEGES PreviousState', 'PULONG ReturnLength']
 	case 10: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -369,6 +381,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 11 NTSTATUS NtAlertResumeThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 11: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -382,6 +395,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 12 NTSTATUS NtAlertThread ['HANDLE ThreadHandle']
 	case 12: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -393,6 +407,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 13 NTSTATUS NtAllocateLocallyUniqueId ['PLUID Luid']
 	case 13: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -404,6 +419,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 14 NTSTATUS NtAllocateUserPhysicalPages ['HANDLE ProcessHandle', 'PULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 14: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -419,6 +435,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 15 NTSTATUS NtAllocateUuids ['PULARGE_INTEGER Time', 'PULONG Range', 'PULONG Sequence', 'PCHAR Seed']
 	case 15: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -436,6 +453,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 16 NTSTATUS NtAllocateVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'ULONG_PTR ZeroBits', 'PSIZE_T RegionSize', 'ULONG AllocationType', 'ULONG Protect']
 	case 16: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -457,6 +475,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 17 NTSTATUS NtAreMappedFilesTheSame ['PVOID File1MappedAsAnImage', 'PVOID File2MappedAsFile']
 	case 17: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -470,6 +489,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 18 NTSTATUS NtAssignProcessToJobObject ['HANDLE JobHandle', 'HANDLE ProcessHandle']
 	case 18: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -483,6 +503,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 19 NTSTATUS NtCallbackReturn ['PVOID OutputBuffer', 'ULONG OutputLength', 'NTSTATUS Status']
 	case 19: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -498,6 +519,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 20 NTSTATUS NtCancelIoFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 20: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -511,6 +533,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 21 NTSTATUS NtCancelTimer ['HANDLE TimerHandle', 'PBOOLEAN CurrentState']
 	case 21: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -524,6 +547,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 23 NTSTATUS NtClearEvent ['HANDLE EventHandle']
 	case 23: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -535,6 +559,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 24 NTSTATUS NtClose ['HANDLE Handle']
 	case 24: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -546,6 +571,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 25 NTSTATUS NtCloseObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'BOOLEAN GenerateOnClose']
 	case 25: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -561,6 +587,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 26 NTSTATUS NtCompleteConnectPort ['HANDLE PortHandle']
 	case 26: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -572,6 +599,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 27 NTSTATUS NtConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos', 'PPORT_VIEW ClientView', 'PREMOTE_PORT_VIEW ServerView', 'PULONG MaxMessageLength', 'PVOID ConnectionInformation', 'PULONG ConnectionInformationLength']
 	case 27: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -597,6 +625,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 28 NTSTATUS NtContinue ['PCONTEXT ContextRecord', 'BOOLEAN TestAlert']
 	case 28: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -610,6 +639,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 29 NTSTATUS NtCreateDirectoryObject ['PHANDLE DirectoryHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 29: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -625,6 +655,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 30 NTSTATUS NtCreateEvent ['PHANDLE EventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'EVENT_TYPE EventType', 'BOOLEAN InitialState']
 	case 30: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -644,6 +675,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 31 NTSTATUS NtCreateEventPair ['PHANDLE EventPairHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 31: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -659,6 +691,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 32 NTSTATUS NtCreateFile ['PHANDLE FileHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER AllocationSize', 'ULONG FileAttributes', 'ULONG ShareAccess', 'ULONG CreateDisposition', 'ULONG CreateOptions', 'PVOID EaBuffer', 'ULONG EaLength']
 	case 32: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -690,6 +723,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 33 NTSTATUS NtCreateIoCompletion ['PHANDLE IoCompletionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Count']
 	case 33: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -707,6 +741,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 34 NTSTATUS NtCreateJobObject ['PHANDLE JobHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 34: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -722,6 +757,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 35 NTSTATUS NtCreateKey ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG TitleIndex', 'PUNICODE_STRING Class', 'ULONG CreateOptions', 'PULONG Disposition']
 	case 35: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -745,6 +781,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 36 NTSTATUS NtCreateMailslotFile ['PHANDLE FileHandle', 'ULONG DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CreateOptions', 'ULONG MailslotQuota', 'ULONG MaximumMessageSize', 'PLARGE_INTEGER ReadTimeout']
 	case 36: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -770,6 +807,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 37 NTSTATUS NtCreateMutant ['PHANDLE MutantHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'BOOLEAN InitialOwner']
 	case 37: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -787,6 +825,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 38 NTSTATUS NtCreateNamedPipeFile ['PHANDLE FileHandle', 'ULONG DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG ShareAccess', 'ULONG CreateDisposition', 'ULONG CreateOptions', 'ULONG NamedPipeType', 'ULONG ReadMode', 'ULONG CompletionMode', 'ULONG MaximumInstances', 'ULONG InboundQuota', 'ULONG OutboundQuota', 'PLARGE_INTEGER DefaultTimeout']
 	case 38: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -824,6 +863,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 39 NTSTATUS NtCreatePagingFile ['PUNICODE_STRING PageFileName', 'PLARGE_INTEGER MinimumSize', 'PLARGE_INTEGER MaximumSize', 'ULONG Priority']
 	case 39: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -841,6 +881,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 40 NTSTATUS NtCreatePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG MaxConnectionInfoLength', 'ULONG MaxMessageLength', 'ULONG MaxPoolUsage']
 	case 40: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -860,6 +901,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 41 NTSTATUS NtCreateProcess ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ParentProcess', 'BOOLEAN InheritObjectTable', 'HANDLE SectionHandle', 'HANDLE DebugPort', 'HANDLE ExceptionPort']
 	case 41: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -885,6 +927,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 42 NTSTATUS NtCreateProfile ['PHANDLE ProfileHandle', 'HANDLE Process', 'PVOID RangeBase', 'SIZE_T RangeSize', 'ULONG BucketSize', 'PULONG Buffer', 'ULONG BufferSize', 'KPROFILE_SOURCE ProfileSource', 'KAFFINITY Affinity']
 	case 42: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -912,6 +955,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 43 NTSTATUS NtCreateSection ['PHANDLE SectionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PLARGE_INTEGER MaximumSize', 'ULONG SectionPageProtection', 'ULONG AllocationAttributes', 'HANDLE FileHandle']
 	case 43: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -935,6 +979,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 44 NTSTATUS NtCreateSemaphore ['PHANDLE SemaphoreHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'LONG InitialCount', 'LONG MaximumCount']
 	case 44: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -954,6 +999,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 45 NTSTATUS NtCreateSymbolicLinkObject ['PHANDLE LinkHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PUNICODE_STRING LinkTarget']
 	case 45: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -971,6 +1017,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 46 NTSTATUS NtCreateThread ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ProcessHandle', 'PCLIENT_ID ClientId', 'PCONTEXT ThreadContext', 'PINITIAL_TEB InitialTeb', 'BOOLEAN CreateSuspended']
 	case 46: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -996,6 +1043,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 47 NTSTATUS NtCreateTimer ['PHANDLE TimerHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'TIMER_TYPE TimerType']
 	case 47: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1013,6 +1061,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 48 NTSTATUS NtCreateToken ['PHANDLE TokenHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'TOKEN_TYPE TokenType', 'PLUID AuthenticationId', 'PLARGE_INTEGER ExpirationTime', 'PTOKEN_USER User', 'PTOKEN_GROUPS Groups', 'PTOKEN_PRIVILEGES Privileges', 'PTOKEN_OWNER Owner', 'PTOKEN_PRIMARY_GROUP PrimaryGroup', 'PTOKEN_DEFAULT_DACL DefaultDacl', 'PTOKEN_SOURCE TokenSource']
 	case 48: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1048,6 +1097,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 49 NTSTATUS NtCreateWaitablePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG MaxConnectionInfoLength', 'ULONG MaxMessageLength', 'ULONG MaxPoolUsage']
 	case 49: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1067,6 +1117,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 50 NTSTATUS NtDelayExecution ['BOOLEAN Alertable', 'PLARGE_INTEGER DelayInterval']
 	case 50: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1080,6 +1131,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 51 NTSTATUS NtDeleteAtom ['RTL_ATOM Atom']
 	case 51: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1091,6 +1143,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 52 NTSTATUS NtDeleteFile ['POBJECT_ATTRIBUTES ObjectAttributes']
 	case 52: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1102,6 +1155,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 53 NTSTATUS NtDeleteKey ['HANDLE KeyHandle']
 	case 53: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1113,6 +1167,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 54 NTSTATUS NtDeleteObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'BOOLEAN GenerateOnClose']
 	case 54: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1128,6 +1183,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 55 NTSTATUS NtDeleteValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName']
 	case 55: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1141,6 +1197,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 56 NTSTATUS NtDeviceIoControlFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG IoControlCode', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 56: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1170,6 +1227,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 57 NTSTATUS NtDisplayString ['PUNICODE_STRING String']
 	case 57: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1181,6 +1239,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 58 NTSTATUS NtDuplicateObject ['HANDLE SourceProcessHandle', 'HANDLE SourceHandle', 'HANDLE TargetProcessHandle', 'PHANDLE TargetHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'ULONG Options']
 	case 58: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1204,6 +1263,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 59 NTSTATUS NtDuplicateToken ['HANDLE ExistingTokenHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'BOOLEAN EffectiveOnly', 'TOKEN_TYPE TokenType', 'PHANDLE NewTokenHandle']
 	case 59: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1225,6 +1285,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 60 NTSTATUS NtEnumerateKey ['HANDLE KeyHandle', 'ULONG Index', 'KEY_INFORMATION_CLASS KeyInformationClass', 'PVOID KeyInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 60: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1246,6 +1307,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 61 NTSTATUS NtEnumerateValueKey ['HANDLE KeyHandle', 'ULONG Index', 'KEY_VALUE_INFORMATION_CLASS KeyValueInformationClass', 'PVOID KeyValueInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 61: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1267,6 +1329,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 62 NTSTATUS NtExtendSection ['HANDLE SectionHandle', 'PLARGE_INTEGER NewSectionSize']
 	case 62: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1280,6 +1343,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 63 NTSTATUS NtFilterToken ['HANDLE ExistingTokenHandle', 'ULONG Flags', 'PTOKEN_GROUPS SidsToDisable', 'PTOKEN_PRIVILEGES PrivilegesToDelete', 'PTOKEN_GROUPS RestrictedSids', 'PHANDLE NewTokenHandle']
 	case 63: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1301,6 +1365,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 64 NTSTATUS NtFindAtom ['PWSTR AtomName', 'ULONG Length', 'PRTL_ATOM Atom']
 	case 64: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1316,6 +1381,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 65 NTSTATUS NtFlushBuffersFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 65: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1329,6 +1395,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 66 NTSTATUS NtFlushInstructionCache ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'SIZE_T Length']
 	case 66: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1344,6 +1411,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 67 NTSTATUS NtFlushKey ['HANDLE KeyHandle']
 	case 67: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1355,6 +1423,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 68 NTSTATUS NtFlushVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'PIO_STATUS_BLOCK IoStatus']
 	case 68: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1372,11 +1441,13 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 69 NTSTATUS NtFlushWriteBuffer ['']
 	case 69: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtFlushWriteBuffer_enter, cpu, pc);
 	}; break;
 	// 70 NTSTATUS NtFreeUserPhysicalPages ['HANDLE ProcessHandle', 'PULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 70: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1392,6 +1463,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 71 NTSTATUS NtFreeVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG FreeType']
 	case 71: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1409,6 +1481,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 72 NTSTATUS NtFsControlFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG IoControlCode', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 72: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1438,6 +1511,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 73 NTSTATUS NtGetContextThread ['HANDLE ThreadHandle', 'PCONTEXT ThreadContext']
 	case 73: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1451,6 +1525,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 74 NTSTATUS NtGetDevicePowerState ['HANDLE Device', 'DEVICE_POWER_STATE *State']
 	case 74: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1464,6 +1539,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 75 NTSTATUS NtGetPlugPlayEvent ['HANDLE EventHandle', 'PVOID Context', 'PPLUGPLAY_EVENT_BLOCK EventBlock', 'ULONG EventBufferSize']
 	case 75: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1481,6 +1557,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 77 NTSTATUS NtGetWriteWatch ['HANDLE ProcessHandle', 'ULONG Flags', 'PVOID BaseAddress', 'SIZE_T RegionSize', 'PVOID *UserAddressArray', 'PULONG_PTR EntriesInUserAddressArray', 'PULONG Granularity']
 	case 77: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1504,6 +1581,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 78 NTSTATUS NtImpersonateAnonymousToken ['HANDLE ThreadHandle']
 	case 78: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1515,6 +1593,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 79 NTSTATUS NtImpersonateClientOfPort ['HANDLE PortHandle', 'PPORT_MESSAGE Message']
 	case 79: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1528,6 +1607,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 80 NTSTATUS NtImpersonateThread ['HANDLE ServerThreadHandle', 'HANDLE ClientThreadHandle', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos']
 	case 80: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1543,6 +1623,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 81 NTSTATUS NtInitializeRegistry ['USHORT BootCondition']
 	case 81: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1554,6 +1635,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 82 NTSTATUS NtInitiatePowerAction ['POWER_ACTION SystemAction', 'SYSTEM_POWER_STATE MinSystemState', 'ULONG Flags', 'BOOLEAN Asynchronous']
 	case 82: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1571,11 +1653,13 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 83 BOOLEAN NtIsSystemResumeAutomatic ['']
 	case 83: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtIsSystemResumeAutomatic_enter, cpu, pc);
 	}; break;
 	// 84 NTSTATUS NtListenPort ['HANDLE PortHandle', 'PPORT_MESSAGE ConnectionRequest']
 	case 84: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1589,6 +1673,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 85 NTSTATUS NtLoadDriver ['PUNICODE_STRING DriverServiceName']
 	case 85: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1600,6 +1685,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 86 NTSTATUS NtLoadKey ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile']
 	case 86: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1613,6 +1699,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 87 NTSTATUS NtLoadKey2 ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile', 'ULONG Flags']
 	case 87: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1628,6 +1715,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 88 NTSTATUS NtLockFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER ByteOffset', 'PLARGE_INTEGER Length', 'ULONG Key', 'BOOLEAN FailImmediately', 'BOOLEAN ExclusiveLock']
 	case 88: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1657,6 +1745,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 89 NTSTATUS NtLockVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG MapType']
 	case 89: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1674,6 +1763,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 90 NTSTATUS NtMakeTemporaryObject ['HANDLE Handle']
 	case 90: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1685,6 +1775,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 91 NTSTATUS NtMapUserPhysicalPages ['PVOID VirtualAddress', 'ULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 91: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1700,6 +1791,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 92 NTSTATUS NtMapUserPhysicalPagesScatter ['PVOID *VirtualAddresses', 'ULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 92: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1715,6 +1807,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 93 NTSTATUS NtMapViewOfSection ['HANDLE SectionHandle', 'HANDLE ProcessHandle', 'PVOID *BaseAddress', 'ULONG_PTR ZeroBits', 'SIZE_T CommitSize', 'PLARGE_INTEGER SectionOffset', 'PSIZE_T ViewSize', 'SECTION_INHERIT InheritDisposition', 'ULONG AllocationType', 'WIN32_PROTECTION_MASK Win32Protect']
 	case 93: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1744,6 +1837,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 94 NTSTATUS NtNotifyChangeDirectoryFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'ULONG CompletionFilter', 'BOOLEAN WatchTree']
 	case 94: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1771,6 +1865,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 95 NTSTATUS NtNotifyChangeKey ['HANDLE KeyHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CompletionFilter', 'BOOLEAN WatchTree', 'PVOID Buffer', 'ULONG BufferSize', 'BOOLEAN Asynchronous']
 	case 95: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1800,6 +1895,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 96 NTSTATUS NtNotifyChangeMultipleKeys ['HANDLE MasterKeyHandle', 'ULONG Count', 'OBJECT_ATTRIBUTES SlaveObjects[]', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CompletionFilter', 'BOOLEAN WatchTree', 'PVOID Buffer', 'ULONG BufferSize', 'BOOLEAN Asynchronous']
 	case 96: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1833,6 +1929,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 97 NTSTATUS NtOpenDirectoryObject ['PHANDLE DirectoryHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 97: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1848,6 +1945,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 98 NTSTATUS NtOpenEvent ['PHANDLE EventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 98: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1863,6 +1961,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 99 NTSTATUS NtOpenEventPair ['PHANDLE EventPairHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 99: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1878,6 +1977,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 100 NTSTATUS NtOpenFile ['PHANDLE FileHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG ShareAccess', 'ULONG OpenOptions']
 	case 100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1899,6 +1999,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 101 NTSTATUS NtOpenIoCompletion ['PHANDLE IoCompletionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 101: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1914,6 +2015,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 102 NTSTATUS NtOpenJobObject ['PHANDLE JobHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1929,6 +2031,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 103 NTSTATUS NtOpenKey ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1944,6 +2047,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 104 NTSTATUS NtOpenMutant ['PHANDLE MutantHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1959,6 +2063,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 105 NTSTATUS NtOpenObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'ACCESS_MASK GrantedAccess', 'PPRIVILEGE_SET Privileges', 'BOOLEAN ObjectCreation', 'BOOLEAN AccessGranted', 'PBOOLEAN GenerateOnClose']
 	case 105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1992,6 +2097,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 106 NTSTATUS NtOpenProcess ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PCLIENT_ID ClientId']
 	case 106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2009,6 +2115,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 107 NTSTATUS NtOpenProcessToken ['HANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'PHANDLE TokenHandle']
 	case 107: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2024,6 +2131,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 108 NTSTATUS NtOpenSection ['PHANDLE SectionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2039,6 +2147,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 109 NTSTATUS NtOpenSemaphore ['PHANDLE SemaphoreHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 109: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2054,6 +2163,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 110 NTSTATUS NtOpenSymbolicLinkObject ['PHANDLE LinkHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 110: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2069,6 +2179,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 111 NTSTATUS NtOpenThread ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PCLIENT_ID ClientId']
 	case 111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2086,6 +2197,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 112 NTSTATUS NtOpenThreadToken ['HANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'BOOLEAN OpenAsSelf', 'PHANDLE TokenHandle']
 	case 112: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2103,6 +2215,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 113 NTSTATUS NtOpenTimer ['PHANDLE TimerHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 113: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2118,6 +2231,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 114 NTSTATUS NtPlugPlayControl ['PLUGPLAY_CONTROL_CLASS PnPControlClass', 'PVOID PnPControlData', 'ULONG PnPControlDataLength']
 	case 114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2133,6 +2247,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 115 NTSTATUS NtPowerInformation ['POWER_INFORMATION_LEVEL InformationLevel', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 115: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2152,6 +2267,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 116 NTSTATUS NtPrivilegeCheck ['HANDLE ClientToken', 'PPRIVILEGE_SET RequiredPrivileges', 'PBOOLEAN Result']
 	case 116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2167,6 +2283,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 117 NTSTATUS NtPrivilegedServiceAuditAlarm ['PUNICODE_STRING SubsystemName', 'PUNICODE_STRING ServiceName', 'HANDLE ClientToken', 'PPRIVILEGE_SET Privileges', 'BOOLEAN AccessGranted']
 	case 117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2186,6 +2303,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 118 NTSTATUS NtPrivilegeObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'PPRIVILEGE_SET Privileges', 'BOOLEAN AccessGranted']
 	case 118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2207,6 +2325,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 119 NTSTATUS NtProtectVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'WIN32_PROTECTION_MASK NewProtectWin32', 'PULONG OldProtect']
 	case 119: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2226,6 +2345,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 120 NTSTATUS NtPulseEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2239,6 +2359,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 121 NTSTATUS NtQueryInformationAtom ['RTL_ATOM Atom', 'ATOM_INFORMATION_CLASS InformationClass', 'PVOID AtomInformation', 'ULONG AtomInformationLength', 'PULONG ReturnLength']
 	case 121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2258,6 +2379,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 122 NTSTATUS NtQueryAttributesFile ['POBJECT_ATTRIBUTES ObjectAttributes', 'PFILE_BASIC_INFORMATION FileInformation']
 	case 122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2271,6 +2393,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 123 NTSTATUS NtQueryDefaultLocale ['BOOLEAN UserProfile', 'PLCID DefaultLocaleId']
 	case 123: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2284,6 +2407,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 124 NTSTATUS NtQueryDefaultUILanguage ['LANGID *DefaultUILanguageId']
 	case 124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2295,6 +2419,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 125 NTSTATUS NtQueryDirectoryFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass', 'BOOLEAN ReturnSingleEntry', 'PUNICODE_STRING FileName', 'BOOLEAN RestartScan']
 	case 125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2326,6 +2451,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 126 NTSTATUS NtQueryDirectoryObject ['HANDLE DirectoryHandle', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'BOOLEAN RestartScan', 'PULONG Context', 'PULONG ReturnLength']
 	case 126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2349,6 +2475,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 127 NTSTATUS NtQueryEaFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'PVOID EaList', 'ULONG EaListLength', 'PULONG EaIndex', 'BOOLEAN RestartScan']
 	case 127: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2376,6 +2503,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 128 NTSTATUS NtQueryEvent ['HANDLE EventHandle', 'EVENT_INFORMATION_CLASS EventInformationClass', 'PVOID EventInformation', 'ULONG EventInformationLength', 'PULONG ReturnLength']
 	case 128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2395,6 +2523,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 129 NTSTATUS NtQueryFullAttributesFile ['POBJECT_ATTRIBUTES ObjectAttributes', 'PFILE_NETWORK_OPEN_INFORMATION FileInformation']
 	case 129: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2408,6 +2537,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 130 NTSTATUS NtQueryInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass']
 	case 130: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2427,6 +2557,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 131 NTSTATUS NtQueryInformationJobObject ['HANDLE JobHandle', 'JOBOBJECTINFOCLASS JobObjectInformationClass', 'PVOID JobObjectInformation', 'ULONG JobObjectInformationLength', 'PULONG ReturnLength']
 	case 131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2446,6 +2577,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 132 NTSTATUS NtQueryIoCompletion ['HANDLE IoCompletionHandle', 'IO_COMPLETION_INFORMATION_CLASS IoCompletionInformationClass', 'PVOID IoCompletionInformation', 'ULONG IoCompletionInformationLength', 'PULONG ReturnLength']
 	case 132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2465,6 +2597,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 133 NTSTATUS NtQueryInformationPort ['HANDLE PortHandle', 'PORT_INFORMATION_CLASS PortInformationClass', 'PVOID PortInformation', 'ULONG Length', 'PULONG ReturnLength']
 	case 133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2484,6 +2617,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 134 NTSTATUS NtQueryInformationProcess ['HANDLE ProcessHandle', 'PROCESSINFOCLASS ProcessInformationClass', 'PVOID ProcessInformation', 'ULONG ProcessInformationLength', 'PULONG ReturnLength']
 	case 134: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2503,6 +2637,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 135 NTSTATUS NtQueryInformationThread ['HANDLE ThreadHandle', 'THREADINFOCLASS ThreadInformationClass', 'PVOID ThreadInformation', 'ULONG ThreadInformationLength', 'PULONG ReturnLength']
 	case 135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2522,6 +2657,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 136 NTSTATUS NtQueryInformationToken ['HANDLE TokenHandle', 'TOKEN_INFORMATION_CLASS TokenInformationClass', 'PVOID TokenInformation', 'ULONG TokenInformationLength', 'PULONG ReturnLength']
 	case 136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2541,6 +2677,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 137 NTSTATUS NtQueryInstallUILanguage ['LANGID *InstallUILanguageId']
 	case 137: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2552,6 +2689,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 138 NTSTATUS NtQueryIntervalProfile ['KPROFILE_SOURCE ProfileSource', 'PULONG Interval']
 	case 138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2565,6 +2703,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 139 NTSTATUS NtQueryKey ['HANDLE KeyHandle', 'KEY_INFORMATION_CLASS KeyInformationClass', 'PVOID KeyInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 139: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2584,6 +2723,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 140 NTSTATUS NtQueryMultipleValueKey ['HANDLE KeyHandle', 'PKEY_VALUE_ENTRY ValueEntries', 'ULONG EntryCount', 'PVOID ValueBuffer', 'PULONG BufferLength', 'PULONG RequiredBufferLength']
 	case 140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2605,6 +2745,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 141 NTSTATUS NtQueryMutant ['HANDLE MutantHandle', 'MUTANT_INFORMATION_CLASS MutantInformationClass', 'PVOID MutantInformation', 'ULONG MutantInformationLength', 'PULONG ReturnLength']
 	case 141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2624,6 +2765,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 142 NTSTATUS NtQueryObject ['HANDLE Handle', 'OBJECT_INFORMATION_CLASS ObjectInformationClass', 'PVOID ObjectInformation', 'ULONG ObjectInformationLength', 'PULONG ReturnLength']
 	case 142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2643,6 +2785,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 143 NTSTATUS NtQueryOpenSubKeys ['POBJECT_ATTRIBUTES TargetKey', 'PULONG HandleCount']
 	case 143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2656,6 +2799,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 144 NTSTATUS NtQueryPerformanceCounter ['PLARGE_INTEGER PerformanceCounter', 'PLARGE_INTEGER PerformanceFrequency']
 	case 144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2669,6 +2813,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 145 NTSTATUS NtQueryQuotaInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'PVOID SidList', 'ULONG SidListLength', 'PULONG StartSid', 'BOOLEAN RestartScan']
 	case 145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2696,6 +2841,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 146 NTSTATUS NtQuerySection ['HANDLE SectionHandle', 'SECTION_INFORMATION_CLASS SectionInformationClass', 'PVOID SectionInformation', 'SIZE_T SectionInformationLength', 'PSIZE_T ReturnLength']
 	case 146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2715,6 +2861,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 147 NTSTATUS NtQuerySecurityObject ['HANDLE Handle', 'SECURITY_INFORMATION SecurityInformation', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'ULONG Length', 'PULONG LengthNeeded']
 	case 147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2734,6 +2881,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 148 NTSTATUS NtQuerySemaphore ['HANDLE SemaphoreHandle', 'SEMAPHORE_INFORMATION_CLASS SemaphoreInformationClass', 'PVOID SemaphoreInformation', 'ULONG SemaphoreInformationLength', 'PULONG ReturnLength']
 	case 148: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2753,6 +2901,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 149 NTSTATUS NtQuerySymbolicLinkObject ['HANDLE LinkHandle', 'PUNICODE_STRING LinkTarget', 'PULONG ReturnedLength']
 	case 149: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2768,6 +2917,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 150 NTSTATUS NtQuerySystemEnvironmentValue ['PUNICODE_STRING VariableName', 'PWSTR VariableValue', 'USHORT ValueLength', 'PUSHORT ReturnLength']
 	case 150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2785,6 +2935,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 151 NTSTATUS NtQuerySystemInformation ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID SystemInformation', 'ULONG SystemInformationLength', 'PULONG ReturnLength']
 	case 151: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2802,6 +2953,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 152 NTSTATUS NtQuerySystemTime ['PLARGE_INTEGER SystemTime']
 	case 152: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2813,6 +2965,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 153 NTSTATUS NtQueryTimer ['HANDLE TimerHandle', 'TIMER_INFORMATION_CLASS TimerInformationClass', 'PVOID TimerInformation', 'ULONG TimerInformationLength', 'PULONG ReturnLength']
 	case 153: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2832,6 +2985,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 154 NTSTATUS NtQueryTimerResolution ['PULONG MaximumTime', 'PULONG MinimumTime', 'PULONG CurrentTime']
 	case 154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2847,6 +3001,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 155 NTSTATUS NtQueryValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName', 'KEY_VALUE_INFORMATION_CLASS KeyValueInformationClass', 'PVOID KeyValueInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2868,6 +3023,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 156 NTSTATUS NtQueryVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'MEMORY_INFORMATION_CLASS MemoryInformationClass', 'PVOID MemoryInformation', 'SIZE_T MemoryInformationLength', 'PSIZE_T ReturnLength']
 	case 156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2889,6 +3045,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 157 NTSTATUS NtQueryVolumeInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FsInformation', 'ULONG Length', 'FS_INFORMATION_CLASS FsInformationClass']
 	case 157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2908,6 +3065,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 158 NTSTATUS NtQueueApcThread ['HANDLE ThreadHandle', 'PPS_APC_ROUTINE ApcRoutine', 'PVOID ApcArgument1', 'PVOID ApcArgument2', 'PVOID ApcArgument3']
 	case 158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2927,6 +3085,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 159 NTSTATUS NtRaiseException ['PEXCEPTION_RECORD ExceptionRecord', 'PCONTEXT ContextRecord', 'BOOLEAN FirstChance']
 	case 159: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2942,6 +3101,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 160 NTSTATUS NtRaiseHardError ['NTSTATUS ErrorStatus', 'ULONG NumberOfParameters', 'ULONG UnicodeStringParameterMask', 'PULONG_PTR Parameters', 'ULONG ValidResponseOptions', 'PULONG Response']
 	case 160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2963,6 +3123,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 161 NTSTATUS NtReadFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2990,6 +3151,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 162 NTSTATUS NtReadFileScatter ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PFILE_SEGMENT_ELEMENT SegmentArray', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3017,6 +3179,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 163 NTSTATUS NtReadRequestData ['HANDLE PortHandle', 'PPORT_MESSAGE Message', 'ULONG DataEntryIndex', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesRead']
 	case 163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3038,6 +3201,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 164 NTSTATUS NtReadVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesRead']
 	case 164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3057,6 +3221,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 165 NTSTATUS NtRegisterThreadTerminatePort ['HANDLE PortHandle']
 	case 165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3068,6 +3233,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 166 NTSTATUS NtReleaseMutant ['HANDLE MutantHandle', 'PLONG PreviousCount']
 	case 166: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3081,6 +3247,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 167 NTSTATUS NtReleaseSemaphore ['HANDLE SemaphoreHandle', 'LONG ReleaseCount', 'PLONG PreviousCount']
 	case 167: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3096,6 +3263,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 168 NTSTATUS NtRemoveIoCompletion ['HANDLE IoCompletionHandle', 'PVOID *KeyContext', 'PVOID *ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER Timeout']
 	case 168: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3115,6 +3283,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 169 NTSTATUS NtReplaceKey ['POBJECT_ATTRIBUTES NewFile', 'HANDLE TargetHandle', 'POBJECT_ATTRIBUTES OldFile']
 	case 169: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3130,6 +3299,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 170 NTSTATUS NtReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE ReplyMessage']
 	case 170: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3143,6 +3313,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 171 NTSTATUS NtReplyWaitReceivePort ['HANDLE PortHandle', 'PVOID *PortContext', 'PPORT_MESSAGE ReplyMessage', 'PPORT_MESSAGE ReceiveMessage']
 	case 171: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3160,6 +3331,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 172 NTSTATUS NtReplyWaitReceivePortEx ['HANDLE PortHandle', 'PVOID *PortContext', 'PPORT_MESSAGE ReplyMessage', 'PPORT_MESSAGE ReceiveMessage', 'PLARGE_INTEGER Timeout']
 	case 172: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3179,6 +3351,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 173 NTSTATUS NtReplyWaitReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE ReplyMessage']
 	case 173: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3192,6 +3365,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 175 NTSTATUS NtRequestPort ['HANDLE PortHandle', 'PPORT_MESSAGE RequestMessage']
 	case 175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3205,6 +3379,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 176 NTSTATUS NtRequestWaitReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE RequestMessage', 'PPORT_MESSAGE ReplyMessage']
 	case 176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3220,6 +3395,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 178 NTSTATUS NtResetEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 178: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3233,6 +3409,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 179 NTSTATUS NtResetWriteWatch ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'SIZE_T RegionSize']
 	case 179: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3248,6 +3425,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 180 NTSTATUS NtRestoreKey ['HANDLE KeyHandle', 'HANDLE FileHandle', 'ULONG Flags']
 	case 180: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3263,6 +3441,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 181 NTSTATUS NtResumeThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 181: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3276,6 +3455,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 182 NTSTATUS NtSaveKey ['HANDLE KeyHandle', 'HANDLE FileHandle']
 	case 182: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3289,6 +3469,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 183 NTSTATUS NtSaveMergedKeys ['HANDLE HighPrecedenceKeyHandle', 'HANDLE LowPrecedenceKeyHandle', 'HANDLE FileHandle']
 	case 183: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3304,6 +3485,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 184 NTSTATUS NtSecureConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos', 'PPORT_VIEW ClientView', 'PSID RequiredServerSid', 'PREMOTE_PORT_VIEW ServerView', 'PULONG MaxMessageLength', 'PVOID ConnectionInformation', 'PULONG ConnectionInformationLength']
 	case 184: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3331,6 +3513,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 185 NTSTATUS NtSetIoCompletion ['HANDLE IoCompletionHandle', 'PVOID KeyContext', 'PVOID ApcContext', 'NTSTATUS IoStatus', 'ULONG_PTR IoStatusInformation']
 	case 185: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3350,6 +3533,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 186 NTSTATUS NtSetContextThread ['HANDLE ThreadHandle', 'PCONTEXT ThreadContext']
 	case 186: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3363,6 +3547,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 187 NTSTATUS NtSetDefaultHardErrorPort ['HANDLE DefaultHardErrorPort']
 	case 187: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3374,6 +3559,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 188 NTSTATUS NtSetDefaultLocale ['BOOLEAN UserProfile', 'LCID DefaultLocaleId']
 	case 188: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3387,6 +3573,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 189 NTSTATUS NtSetDefaultUILanguage ['LANGID DefaultUILanguageId']
 	case 189: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3398,6 +3585,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 190 NTSTATUS NtSetEaFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length']
 	case 190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3415,6 +3603,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 191 NTSTATUS NtSetEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3428,6 +3617,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 192 NTSTATUS NtSetHighEventPair ['HANDLE EventPairHandle']
 	case 192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3439,6 +3629,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 193 NTSTATUS NtSetHighWaitLowEventPair ['HANDLE EventPairHandle']
 	case 193: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3450,6 +3641,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 194 NTSTATUS NtSetInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass']
 	case 194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3469,6 +3661,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 195 NTSTATUS NtSetInformationJobObject ['HANDLE JobHandle', 'JOBOBJECTINFOCLASS JobObjectInformationClass', 'PVOID JobObjectInformation', 'ULONG JobObjectInformationLength']
 	case 195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3486,6 +3679,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 196 NTSTATUS NtSetInformationKey ['HANDLE KeyHandle', 'KEY_SET_INFORMATION_CLASS KeySetInformationClass', 'PVOID KeySetInformation', 'ULONG KeySetInformationLength']
 	case 196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3503,6 +3697,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 197 NTSTATUS NtSetInformationObject ['HANDLE Handle', 'OBJECT_INFORMATION_CLASS ObjectInformationClass', 'PVOID ObjectInformation', 'ULONG ObjectInformationLength']
 	case 197: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3520,6 +3715,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 198 NTSTATUS NtSetInformationProcess ['HANDLE ProcessHandle', 'PROCESSINFOCLASS ProcessInformationClass', 'PVOID ProcessInformation', 'ULONG ProcessInformationLength']
 	case 198: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3537,6 +3733,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 199 NTSTATUS NtSetInformationThread ['HANDLE ThreadHandle', 'THREADINFOCLASS ThreadInformationClass', 'PVOID ThreadInformation', 'ULONG ThreadInformationLength']
 	case 199: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3554,6 +3751,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 200 NTSTATUS NtSetInformationToken ['HANDLE TokenHandle', 'TOKEN_INFORMATION_CLASS TokenInformationClass', 'PVOID TokenInformation', 'ULONG TokenInformationLength']
 	case 200: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3571,6 +3769,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 201 NTSTATUS NtSetIntervalProfile ['ULONG Interval', 'KPROFILE_SOURCE Source']
 	case 201: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3584,6 +3783,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 202 NTSTATUS NtSetLdtEntries ['ULONG Selector0', 'ULONG Entry0Low', 'ULONG Entry0Hi', 'ULONG Selector1', 'ULONG Entry1Low', 'ULONG Entry1Hi']
 	case 202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3605,6 +3805,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 203 NTSTATUS NtSetLowEventPair ['HANDLE EventPairHandle']
 	case 203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3616,6 +3817,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 204 NTSTATUS NtSetLowWaitHighEventPair ['HANDLE EventPairHandle']
 	case 204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3627,6 +3829,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 205 NTSTATUS NtSetQuotaInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length']
 	case 205: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3644,6 +3847,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 206 NTSTATUS NtSetSecurityObject ['HANDLE Handle', 'SECURITY_INFORMATION SecurityInformation', 'PSECURITY_DESCRIPTOR SecurityDescriptor']
 	case 206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3659,6 +3863,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 207 NTSTATUS NtSetSystemEnvironmentValue ['PUNICODE_STRING VariableName', 'PUNICODE_STRING VariableValue']
 	case 207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3672,6 +3877,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 208 NTSTATUS NtSetSystemInformation ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID SystemInformation', 'ULONG SystemInformationLength']
 	case 208: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3687,6 +3893,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 209 NTSTATUS NtSetSystemPowerState ['POWER_ACTION SystemAction', 'SYSTEM_POWER_STATE MinSystemState', 'ULONG Flags']
 	case 209: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3702,6 +3909,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 210 NTSTATUS NtSetSystemTime ['PLARGE_INTEGER SystemTime', 'PLARGE_INTEGER PreviousTime']
 	case 210: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3715,6 +3923,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 211 NTSTATUS NtSetThreadExecutionState ['EXECUTION_STATE esFlags', 'PEXECUTION_STATE PreviousFlags']
 	case 211: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3728,6 +3937,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 212 NTSTATUS NtSetTimer ['HANDLE TimerHandle', 'PLARGE_INTEGER DueTime', 'PTIMER_APC_ROUTINE TimerApcRoutine', 'PVOID TimerContext', 'BOOLEAN WakeTimer', 'LONG Period', 'PBOOLEAN PreviousState']
 	case 212: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3751,6 +3961,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 213 NTSTATUS NtSetTimerResolution ['ULONG DesiredTime', 'BOOLEAN SetResolution', 'PULONG ActualTime']
 	case 213: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3766,6 +3977,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 214 NTSTATUS NtSetUuidSeed ['PCHAR Seed']
 	case 214: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3777,6 +3989,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 215 NTSTATUS NtSetValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName', 'ULONG TitleIndex', 'ULONG Type', 'PVOID Data', 'ULONG DataSize']
 	case 215: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3798,6 +4011,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 216 NTSTATUS NtSetVolumeInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FsInformation', 'ULONG Length', 'FS_INFORMATION_CLASS FsInformationClass']
 	case 216: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3817,6 +4031,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 217 NTSTATUS NtShutdownSystem ['SHUTDOWN_ACTION Action']
 	case 217: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3828,6 +4043,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 218 NTSTATUS NtSignalAndWaitForSingleObject ['HANDLE SignalHandle', 'HANDLE WaitHandle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 218: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3845,6 +4061,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 219 NTSTATUS NtStartProfile ['HANDLE ProfileHandle']
 	case 219: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3856,6 +4073,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 220 NTSTATUS NtStopProfile ['HANDLE ProfileHandle']
 	case 220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3867,6 +4085,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 221 NTSTATUS NtSuspendThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 221: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3880,6 +4099,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 222 NTSTATUS NtSystemDebugControl ['SYSDBG_COMMAND Command', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength', 'PULONG ReturnLength']
 	case 222: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3901,6 +4121,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 223 NTSTATUS NtTerminateJobObject ['HANDLE JobHandle', 'NTSTATUS ExitStatus']
 	case 223: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3914,6 +4135,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 224 NTSTATUS NtTerminateProcess ['HANDLE ProcessHandle', 'NTSTATUS ExitStatus']
 	case 224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3927,6 +4149,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 225 NTSTATUS NtTerminateThread ['HANDLE ThreadHandle', 'NTSTATUS ExitStatus']
 	case 225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3940,11 +4163,13 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 226 NTSTATUS NtTestAlert ['']
 	case 226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtTestAlert_enter, cpu, pc);
 	}; break;
 	// 227 NTSTATUS NtUnloadDriver ['PUNICODE_STRING DriverServiceName']
 	case 227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3956,6 +4181,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 228 NTSTATUS NtUnloadKey ['POBJECT_ATTRIBUTES TargetKey']
 	case 228: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3967,6 +4193,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 229 NTSTATUS NtUnlockFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER ByteOffset', 'PLARGE_INTEGER Length', 'ULONG Key']
 	case 229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3986,6 +4213,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 230 NTSTATUS NtUnlockVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG MapType']
 	case 230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4003,6 +4231,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 231 NTSTATUS NtUnmapViewOfSection ['HANDLE ProcessHandle', 'PVOID BaseAddress']
 	case 231: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4016,6 +4245,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 232 NTSTATUS NtVdmControl ['VDMSERVICECLASS Service', 'PVOID ServiceData']
 	case 232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4029,6 +4259,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 233 NTSTATUS NtWaitForMultipleObjects ['ULONG Count', 'HANDLE Handles[]', 'WAIT_TYPE WaitType', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4048,6 +4279,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 234 NTSTATUS NtWaitForSingleObject ['HANDLE Handle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4063,6 +4295,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 235 NTSTATUS NtWaitHighEventPair ['HANDLE EventPairHandle']
 	case 235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4074,6 +4307,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 236 NTSTATUS NtWaitLowEventPair ['HANDLE EventPairHandle']
 	case 236: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4085,6 +4319,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 237 NTSTATUS NtWriteFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4112,6 +4347,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 238 NTSTATUS NtWriteFileGather ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PFILE_SEGMENT_ELEMENT SegmentArray', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4139,6 +4375,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 239 NTSTATUS NtWriteRequestData ['HANDLE PortHandle', 'PPORT_MESSAGE Message', 'ULONG DataEntryIndex', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesWritten']
 	case 239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4160,6 +4397,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 240 NTSTATUS NtWriteVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesWritten']
 	case 240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4179,6 +4417,7 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 	// 247 NTSTATUS NtYieldExecution ['']
 	case 247: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtYieldExecution_enter, cpu, pc);
 	}; break;
 	default:

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_7_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_7_x86.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -48,6 +49,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']
 	case 0: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -69,6 +71,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 1 NTSTATUS NtAccessCheck ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 1: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -94,6 +97,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 2 NTSTATUS NtAccessCheckAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'ACCESS_MASK DesiredAccess', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 2: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -125,6 +129,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 3 NTSTATUS NtAccessCheckByType ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 3: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -156,6 +161,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 4 NTSTATUS NtAccessCheckByTypeAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 4: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -197,6 +203,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 5 NTSTATUS NtAccessCheckByTypeResultList ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 5: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -228,6 +235,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 6 NTSTATUS NtAccessCheckByTypeResultListAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 6: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -269,6 +277,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 7 NTSTATUS NtAccessCheckByTypeResultListAndAuditAlarmByHandle ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'HANDLE ClientToken', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 7: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -312,6 +321,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 8 NTSTATUS NtAddAtom ['PWSTR AtomName', 'ULONG Length', 'PRTL_ATOM Atom']
 	case 8: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -327,6 +337,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 9 NTSTATUS NtAddBootEntry ['PBOOT_ENTRY BootEntry', 'PULONG Id']
 	case 9: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -340,6 +351,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 10 NTSTATUS NtAddDriverEntry ['PEFI_DRIVER_ENTRY DriverEntry', 'PULONG Id']
 	case 10: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -353,6 +365,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 11 NTSTATUS NtAdjustGroupsToken ['HANDLE TokenHandle', 'BOOLEAN ResetToDefault', 'PTOKEN_GROUPS NewState', 'ULONG BufferLength', 'PTOKEN_GROUPS PreviousState', 'PULONG ReturnLength']
 	case 11: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -374,6 +387,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 12 NTSTATUS NtAdjustPrivilegesToken ['HANDLE TokenHandle', 'BOOLEAN DisableAllPrivileges', 'PTOKEN_PRIVILEGES NewState', 'ULONG BufferLength', 'PTOKEN_PRIVILEGES PreviousState', 'PULONG ReturnLength']
 	case 12: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -395,6 +409,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 13 NTSTATUS NtAlertResumeThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 13: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -408,6 +423,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 14 NTSTATUS NtAlertThread ['HANDLE ThreadHandle']
 	case 14: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -419,6 +435,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 15 NTSTATUS NtAllocateLocallyUniqueId ['PLUID Luid']
 	case 15: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -430,6 +447,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 16 NTSTATUS NtAllocateReserveObject ['PHANDLE MemoryReserveHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'MEMORY_RESERVE_TYPE Type']
 	case 16: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -445,6 +463,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 17 NTSTATUS NtAllocateUserPhysicalPages ['HANDLE ProcessHandle', 'PULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 17: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -460,6 +479,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 18 NTSTATUS NtAllocateUuids ['PULARGE_INTEGER Time', 'PULONG Range', 'PULONG Sequence', 'PCHAR Seed']
 	case 18: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -477,6 +497,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 19 NTSTATUS NtAllocateVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'ULONG_PTR ZeroBits', 'PSIZE_T RegionSize', 'ULONG AllocationType', 'ULONG Protect']
 	case 19: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -498,6 +519,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 20 NTSTATUS NtAlpcAcceptConnectPort ['PHANDLE PortHandle', 'HANDLE ConnectionPortHandle', 'ULONG Flags', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PALPC_PORT_ATTRIBUTES PortAttributes', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'PALPC_MESSAGE_ATTRIBUTES ConnectionMessageAttributes', 'BOOLEAN AcceptConnection']
 	case 20: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -525,6 +547,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 21 NTSTATUS NtAlpcCancelMessage ['HANDLE PortHandle', 'ULONG Flags', 'PALPC_CONTEXT_ATTR MessageContext']
 	case 21: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -540,6 +563,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 22 NTSTATUS NtAlpcConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PALPC_PORT_ATTRIBUTES PortAttributes', 'ULONG Flags', 'PSID RequiredServerSid', 'PPORT_MESSAGE ConnectionMessage', 'PULONG BufferLength', 'PALPC_MESSAGE_ATTRIBUTES OutMessageAttributes', 'PALPC_MESSAGE_ATTRIBUTES InMessageAttributes', 'PLARGE_INTEGER Timeout']
 	case 22: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -571,6 +595,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 23 NTSTATUS NtAlpcCreatePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PALPC_PORT_ATTRIBUTES PortAttributes']
 	case 23: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -586,6 +611,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 24 NTSTATUS NtAlpcCreatePortSection ['HANDLE PortHandle', 'ULONG Flags', 'HANDLE SectionHandle', 'SIZE_T SectionSize', 'PALPC_HANDLE AlpcSectionHandle', 'PSIZE_T ActualSectionSize']
 	case 24: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -607,6 +633,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 25 NTSTATUS NtAlpcCreateResourceReserve ['HANDLE PortHandle', 'ULONG Flags', 'SIZE_T MessageSize', 'PALPC_HANDLE ResourceId']
 	case 25: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -624,6 +651,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 26 NTSTATUS NtAlpcCreateSectionView ['HANDLE PortHandle', 'ULONG Flags', 'PALPC_DATA_VIEW_ATTR ViewAttributes']
 	case 26: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -639,6 +667,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 27 NTSTATUS NtAlpcCreateSecurityContext ['HANDLE PortHandle', 'ULONG Flags', 'PALPC_SECURITY_ATTR SecurityAttribute']
 	case 27: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -654,6 +683,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 28 NTSTATUS NtAlpcDeletePortSection ['HANDLE PortHandle', 'ULONG Flags', 'ALPC_HANDLE SectionHandle']
 	case 28: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -669,6 +699,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 29 NTSTATUS NtAlpcDeleteResourceReserve ['HANDLE PortHandle', 'ULONG Flags', 'ALPC_HANDLE ResourceId']
 	case 29: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -684,6 +715,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 30 NTSTATUS NtAlpcDeleteSectionView ['HANDLE PortHandle', 'ULONG Flags', 'PVOID ViewBase']
 	case 30: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -699,6 +731,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 31 NTSTATUS NtAlpcDeleteSecurityContext ['HANDLE PortHandle', 'ULONG Flags', 'ALPC_HANDLE ContextHandle']
 	case 31: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -714,6 +747,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 32 NTSTATUS NtAlpcDisconnectPort ['HANDLE PortHandle', 'ULONG Flags']
 	case 32: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -727,6 +761,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 33 NTSTATUS NtAlpcImpersonateClientOfPort ['HANDLE PortHandle', 'PPORT_MESSAGE PortMessage', 'PVOID Reserved']
 	case 33: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -742,6 +777,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 34 NTSTATUS NtAlpcOpenSenderProcess ['PHANDLE ProcessHandle', 'HANDLE PortHandle', 'PPORT_MESSAGE PortMessage', 'ULONG Flags', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 34: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -763,6 +799,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 35 NTSTATUS NtAlpcOpenSenderThread ['PHANDLE ThreadHandle', 'HANDLE PortHandle', 'PPORT_MESSAGE PortMessage', 'ULONG Flags', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 35: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -784,6 +821,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 36 NTSTATUS NtAlpcQueryInformation ['HANDLE PortHandle', 'ALPC_PORT_INFORMATION_CLASS PortInformationClass', 'PVOID PortInformation', 'ULONG Length', 'PULONG ReturnLength']
 	case 36: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -803,6 +841,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 37 NTSTATUS NtAlpcQueryInformationMessage ['HANDLE PortHandle', 'PPORT_MESSAGE PortMessage', 'ALPC_MESSAGE_INFORMATION_CLASS MessageInformationClass', 'PVOID MessageInformation', 'ULONG Length', 'PULONG ReturnLength']
 	case 37: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -824,6 +863,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 38 NTSTATUS NtAlpcRevokeSecurityContext ['HANDLE PortHandle', 'ULONG Flags', 'ALPC_HANDLE ContextHandle']
 	case 38: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -839,6 +879,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 39 NTSTATUS NtAlpcSendWaitReceivePort ['HANDLE PortHandle', 'ULONG Flags', 'PPORT_MESSAGE SendMessage', 'PALPC_MESSAGE_ATTRIBUTES SendMessageAttributes', 'PPORT_MESSAGE ReceiveMessage', 'PULONG BufferLength', 'PALPC_MESSAGE_ATTRIBUTES ReceiveMessageAttributes', 'PLARGE_INTEGER Timeout']
 	case 39: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -864,6 +905,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 40 NTSTATUS NtAlpcSetInformation ['HANDLE PortHandle', 'ALPC_PORT_INFORMATION_CLASS PortInformationClass', 'PVOID PortInformation', 'ULONG Length']
 	case 40: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -881,6 +923,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 41 NTSTATUS NtApphelpCacheControl ['APPHELPCOMMAND type', 'PVOID buf']
 	case 41: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -894,6 +937,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 42 NTSTATUS NtAreMappedFilesTheSame ['PVOID File1MappedAsAnImage', 'PVOID File2MappedAsFile']
 	case 42: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -907,6 +951,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 43 NTSTATUS NtAssignProcessToJobObject ['HANDLE JobHandle', 'HANDLE ProcessHandle']
 	case 43: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -920,6 +965,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 44 NTSTATUS NtCallbackReturn ['PVOID OutputBuffer', 'ULONG OutputLength', 'NTSTATUS Status']
 	case 44: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -935,6 +981,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 45 NTSTATUS NtCancelIoFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 45: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -948,6 +995,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 46 NTSTATUS NtCancelIoFileEx ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoRequestToCancel', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 46: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -963,6 +1011,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 47 NTSTATUS NtCancelSynchronousIoFile ['HANDLE ThreadHandle', 'PIO_STATUS_BLOCK IoRequestToCancel', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 47: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -978,6 +1027,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 48 NTSTATUS NtCancelTimer ['HANDLE TimerHandle', 'PBOOLEAN CurrentState']
 	case 48: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -991,6 +1041,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 49 NTSTATUS NtClearEvent ['HANDLE EventHandle']
 	case 49: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1002,6 +1053,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 50 NTSTATUS NtClose ['HANDLE Handle']
 	case 50: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1013,6 +1065,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 51 NTSTATUS NtCloseObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'BOOLEAN GenerateOnClose']
 	case 51: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1028,6 +1081,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 52 NTSTATUS NtCommitComplete ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 52: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1041,6 +1095,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 53 NTSTATUS NtCommitEnlistment ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 53: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1054,6 +1109,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 54 NTSTATUS NtCommitTransaction ['HANDLE TransactionHandle', 'BOOLEAN Wait']
 	case 54: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1067,6 +1123,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 55 NTSTATUS NtCompactKeys ['ULONG Count', 'HANDLE KeyArray[]']
 	case 55: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1080,6 +1137,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 56 NTSTATUS NtCompareTokens ['HANDLE FirstTokenHandle', 'HANDLE SecondTokenHandle', 'PBOOLEAN Equal']
 	case 56: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1095,6 +1153,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 57 NTSTATUS NtCompleteConnectPort ['HANDLE PortHandle']
 	case 57: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1106,6 +1165,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 58 NTSTATUS NtCompressKey ['HANDLE Key']
 	case 58: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1117,6 +1177,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 59 NTSTATUS NtConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos', 'PPORT_VIEW ClientView', 'PREMOTE_PORT_VIEW ServerView', 'PULONG MaxMessageLength', 'PVOID ConnectionInformation', 'PULONG ConnectionInformationLength']
 	case 59: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1142,6 +1203,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 60 NTSTATUS NtContinue ['PCONTEXT ContextRecord', 'BOOLEAN TestAlert']
 	case 60: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1155,6 +1217,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 61 NTSTATUS NtCreateDebugObject ['PHANDLE DebugObjectHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Flags']
 	case 61: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1172,6 +1235,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 62 NTSTATUS NtCreateDirectoryObject ['PHANDLE DirectoryHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 62: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1187,6 +1251,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 63 NTSTATUS NtCreateEnlistment ['PHANDLE EnlistmentHandle', 'ACCESS_MASK DesiredAccess', 'HANDLE ResourceManagerHandle', 'HANDLE TransactionHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG CreateOptions', 'NOTIFICATION_MASK NotificationMask', 'PVOID EnlistmentKey']
 	case 63: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1212,6 +1277,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 64 NTSTATUS NtCreateEvent ['PHANDLE EventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'EVENT_TYPE EventType', 'BOOLEAN InitialState']
 	case 64: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1231,6 +1297,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 65 NTSTATUS NtCreateEventPair ['PHANDLE EventPairHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 65: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1246,6 +1313,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 66 NTSTATUS NtCreateFile ['PHANDLE FileHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER AllocationSize', 'ULONG FileAttributes', 'ULONG ShareAccess', 'ULONG CreateDisposition', 'ULONG CreateOptions', 'PVOID EaBuffer', 'ULONG EaLength']
 	case 66: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1277,6 +1345,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 67 NTSTATUS NtCreateIoCompletion ['PHANDLE IoCompletionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Count']
 	case 67: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1294,6 +1363,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 68 NTSTATUS NtCreateJobObject ['PHANDLE JobHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 68: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1309,6 +1379,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 69 NTSTATUS NtCreateJobSet ['ULONG NumJob', 'PJOB_SET_ARRAY UserJobSet', 'ULONG Flags']
 	case 69: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1324,6 +1395,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 70 NTSTATUS NtCreateKey ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG TitleIndex', 'PUNICODE_STRING Class', 'ULONG CreateOptions', 'PULONG Disposition']
 	case 70: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1347,6 +1419,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 71 NTSTATUS NtCreateKeyedEvent ['PHANDLE KeyedEventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Flags']
 	case 71: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1364,6 +1437,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 72 NTSTATUS NtCreateKeyTransacted ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG TitleIndex', 'PUNICODE_STRING Class', 'ULONG CreateOptions', 'HANDLE TransactionHandle', 'PULONG Disposition']
 	case 72: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1389,6 +1463,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 73 NTSTATUS NtCreateMailslotFile ['PHANDLE FileHandle', 'ULONG DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CreateOptions', 'ULONG MailslotQuota', 'ULONG MaximumMessageSize', 'PLARGE_INTEGER ReadTimeout']
 	case 73: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1414,6 +1489,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 74 NTSTATUS NtCreateMutant ['PHANDLE MutantHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'BOOLEAN InitialOwner']
 	case 74: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1431,6 +1507,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 75 NTSTATUS NtCreateNamedPipeFile ['PHANDLE FileHandle', 'ULONG DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG ShareAccess', 'ULONG CreateDisposition', 'ULONG CreateOptions', 'ULONG NamedPipeType', 'ULONG ReadMode', 'ULONG CompletionMode', 'ULONG MaximumInstances', 'ULONG InboundQuota', 'ULONG OutboundQuota', 'PLARGE_INTEGER DefaultTimeout']
 	case 75: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1468,6 +1545,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 76 NTSTATUS NtCreatePagingFile ['PUNICODE_STRING PageFileName', 'PLARGE_INTEGER MinimumSize', 'PLARGE_INTEGER MaximumSize', 'ULONG Priority']
 	case 76: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1485,6 +1563,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 77 NTSTATUS NtCreatePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG MaxConnectionInfoLength', 'ULONG MaxMessageLength', 'ULONG MaxPoolUsage']
 	case 77: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1504,6 +1583,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 78 NTSTATUS NtCreatePrivateNamespace ['PHANDLE NamespaceHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PVOID BoundaryDescriptor']
 	case 78: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1521,6 +1601,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 79 NTSTATUS NtCreateProcess ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ParentProcess', 'BOOLEAN InheritObjectTable', 'HANDLE SectionHandle', 'HANDLE DebugPort', 'HANDLE ExceptionPort']
 	case 79: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1546,6 +1627,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 80 NTSTATUS NtCreateProcessEx ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ParentProcess', 'ULONG Flags', 'HANDLE SectionHandle', 'HANDLE DebugPort', 'HANDLE ExceptionPort', 'ULONG JobMemberLevel']
 	case 80: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1573,6 +1655,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 81 NTSTATUS NtCreateProfile ['PHANDLE ProfileHandle', 'HANDLE Process', 'PVOID RangeBase', 'SIZE_T RangeSize', 'ULONG BucketSize', 'PULONG Buffer', 'ULONG BufferSize', 'KPROFILE_SOURCE ProfileSource', 'KAFFINITY Affinity']
 	case 81: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1600,6 +1683,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 82 NTSTATUS NtCreateProfileEx ['PHANDLE ProfileHandle', 'HANDLE Process', 'PVOID ProfileBase', 'SIZE_T ProfileSize', 'ULONG BucketSize', 'PULONG Buffer', 'ULONG BufferSize', 'KPROFILE_SOURCE ProfileSource', 'ULONG GroupAffinityCount', 'PGROUP_AFFINITY GroupAffinity']
 	case 82: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1629,6 +1713,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 83 NTSTATUS NtCreateResourceManager ['PHANDLE ResourceManagerHandle', 'ACCESS_MASK DesiredAccess', 'HANDLE TmHandle', 'LPGUID RmGuid', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG CreateOptions', 'PUNICODE_STRING Description']
 	case 83: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1652,6 +1737,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 84 NTSTATUS NtCreateSection ['PHANDLE SectionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PLARGE_INTEGER MaximumSize', 'ULONG SectionPageProtection', 'ULONG AllocationAttributes', 'HANDLE FileHandle']
 	case 84: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1675,6 +1761,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 85 NTSTATUS NtCreateSemaphore ['PHANDLE SemaphoreHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'LONG InitialCount', 'LONG MaximumCount']
 	case 85: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1694,6 +1781,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 86 NTSTATUS NtCreateSymbolicLinkObject ['PHANDLE LinkHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PUNICODE_STRING LinkTarget']
 	case 86: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1711,6 +1799,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 87 NTSTATUS NtCreateThread ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ProcessHandle', 'PCLIENT_ID ClientId', 'PCONTEXT ThreadContext', 'PINITIAL_TEB InitialTeb', 'BOOLEAN CreateSuspended']
 	case 87: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1736,6 +1825,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 88 NTSTATUS NtCreateThreadEx ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ProcessHandle', 'PVOID StartRoutine', 'PVOID Argument', 'ULONG CreateFlags', 'ULONG_PTR ZeroBits', 'SIZE_T StackSize', 'SIZE_T MaximumStackSize', 'PPS_ATTRIBUTE_LIST AttributeList']
 	case 88: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1767,6 +1857,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 89 NTSTATUS NtCreateTimer ['PHANDLE TimerHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'TIMER_TYPE TimerType']
 	case 89: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1784,6 +1875,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 90 NTSTATUS NtCreateToken ['PHANDLE TokenHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'TOKEN_TYPE TokenType', 'PLUID AuthenticationId', 'PLARGE_INTEGER ExpirationTime', 'PTOKEN_USER User', 'PTOKEN_GROUPS Groups', 'PTOKEN_PRIVILEGES Privileges', 'PTOKEN_OWNER Owner', 'PTOKEN_PRIMARY_GROUP PrimaryGroup', 'PTOKEN_DEFAULT_DACL DefaultDacl', 'PTOKEN_SOURCE TokenSource']
 	case 90: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1819,6 +1911,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 91 NTSTATUS NtCreateTransaction ['PHANDLE TransactionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'LPGUID Uow', 'HANDLE TmHandle', 'ULONG CreateOptions', 'ULONG IsolationLevel', 'ULONG IsolationFlags', 'PLARGE_INTEGER Timeout', 'PUNICODE_STRING Description']
 	case 91: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1848,6 +1941,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 92 NTSTATUS NtCreateTransactionManager ['PHANDLE TmHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PUNICODE_STRING LogFileName', 'ULONG CreateOptions', 'ULONG CommitStrength']
 	case 92: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1869,6 +1963,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 93 NTSTATUS NtCreateUserProcess ['PHANDLE ProcessHandle', 'PHANDLE ThreadHandle', 'ACCESS_MASK ProcessDesiredAccess', 'ACCESS_MASK ThreadDesiredAccess', 'POBJECT_ATTRIBUTES ProcessObjectAttributes', 'POBJECT_ATTRIBUTES ThreadObjectAttributes', 'ULONG ProcessFlags', 'ULONG ThreadFlags', 'PRTL_USER_PROCESS_PARAMETERS ProcessParameters', 'PPROCESS_CREATE_INFO CreateInfo', 'PPROCESS_ATTRIBUTE_LIST AttributeList']
 	case 93: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1900,6 +1995,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 94 NTSTATUS NtCreateWaitablePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG MaxConnectionInfoLength', 'ULONG MaxMessageLength', 'ULONG MaxPoolUsage']
 	case 94: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1919,6 +2015,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 95 NTSTATUS NtCreateWorkerFactory ['PHANDLE WorkerFactoryHandleReturn', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE CompletionPortHandle', 'HANDLE WorkerProcessHandle', 'PVOID StartRoutine', 'PVOID StartParameter', 'ULONG MaxThreadCount', 'SIZE_T StackReserve', 'SIZE_T StackCommit']
 	case 95: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1948,6 +2045,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 96 NTSTATUS NtDebugActiveProcess ['HANDLE ProcessHandle', 'HANDLE DebugObjectHandle']
 	case 96: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1961,6 +2059,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 97 NTSTATUS NtDebugContinue ['HANDLE DebugObjectHandle', 'PCLIENT_ID ClientId', 'NTSTATUS ContinueStatus']
 	case 97: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1976,6 +2075,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 98 NTSTATUS NtDelayExecution ['BOOLEAN Alertable', 'PLARGE_INTEGER DelayInterval']
 	case 98: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1989,6 +2089,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 99 NTSTATUS NtDeleteAtom ['RTL_ATOM Atom']
 	case 99: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2000,6 +2101,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 100 NTSTATUS NtDeleteBootEntry ['ULONG Id']
 	case 100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2011,6 +2113,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 101 NTSTATUS NtDeleteDriverEntry ['ULONG Id']
 	case 101: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2022,6 +2125,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 102 NTSTATUS NtDeleteFile ['POBJECT_ATTRIBUTES ObjectAttributes']
 	case 102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2033,6 +2137,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 103 NTSTATUS NtDeleteKey ['HANDLE KeyHandle']
 	case 103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2044,6 +2149,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 104 NTSTATUS NtDeleteObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'BOOLEAN GenerateOnClose']
 	case 104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2059,6 +2165,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 105 NTSTATUS NtDeletePrivateNamespace ['HANDLE NamespaceHandle']
 	case 105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2070,6 +2177,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 106 NTSTATUS NtDeleteValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName']
 	case 106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2083,6 +2191,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 107 NTSTATUS NtDeviceIoControlFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG IoControlCode', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 107: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2112,11 +2221,13 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 108 NTSTATUS NtDisableLastKnownGood ['']
 	case 108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtDisableLastKnownGood_enter, cpu, pc);
 	}; break;
 	// 109 NTSTATUS NtDisplayString ['PUNICODE_STRING String']
 	case 109: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2128,6 +2239,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 110 NTSTATUS NtDrawText ['PUNICODE_STRING Text']
 	case 110: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2139,6 +2251,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 111 NTSTATUS NtDuplicateObject ['HANDLE SourceProcessHandle', 'HANDLE SourceHandle', 'HANDLE TargetProcessHandle', 'PHANDLE TargetHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'ULONG Options']
 	case 111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2162,6 +2275,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 112 NTSTATUS NtDuplicateToken ['HANDLE ExistingTokenHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'BOOLEAN EffectiveOnly', 'TOKEN_TYPE TokenType', 'PHANDLE NewTokenHandle']
 	case 112: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2183,11 +2297,13 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 113 NTSTATUS NtEnableLastKnownGood ['']
 	case 113: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtEnableLastKnownGood_enter, cpu, pc);
 	}; break;
 	// 114 NTSTATUS NtEnumerateBootEntries ['PVOID Buffer', 'PULONG BufferLength']
 	case 114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2201,6 +2317,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 115 NTSTATUS NtEnumerateDriverEntries ['PVOID Buffer', 'PULONG BufferLength']
 	case 115: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2214,6 +2331,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 116 NTSTATUS NtEnumerateKey ['HANDLE KeyHandle', 'ULONG Index', 'KEY_INFORMATION_CLASS KeyInformationClass', 'PVOID KeyInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2235,6 +2353,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 117 NTSTATUS NtEnumerateSystemEnvironmentValuesEx ['ULONG InformationClass', 'PVOID Buffer', 'PULONG BufferLength']
 	case 117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2250,6 +2369,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 118 NTSTATUS NtEnumerateTransactionObject ['HANDLE RootObjectHandle', 'KTMOBJECT_TYPE QueryType', 'PKTMOBJECT_CURSOR ObjectCursor', 'ULONG ObjectCursorLength', 'PULONG ReturnLength']
 	case 118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2269,6 +2389,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 119 NTSTATUS NtEnumerateValueKey ['HANDLE KeyHandle', 'ULONG Index', 'KEY_VALUE_INFORMATION_CLASS KeyValueInformationClass', 'PVOID KeyValueInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 119: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2290,6 +2411,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 120 NTSTATUS NtExtendSection ['HANDLE SectionHandle', 'PLARGE_INTEGER NewSectionSize']
 	case 120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2303,6 +2425,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 121 NTSTATUS NtFilterToken ['HANDLE ExistingTokenHandle', 'ULONG Flags', 'PTOKEN_GROUPS SidsToDisable', 'PTOKEN_PRIVILEGES PrivilegesToDelete', 'PTOKEN_GROUPS RestrictedSids', 'PHANDLE NewTokenHandle']
 	case 121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2324,6 +2447,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 122 NTSTATUS NtFindAtom ['PWSTR AtomName', 'ULONG Length', 'PRTL_ATOM Atom']
 	case 122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2339,6 +2463,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 123 NTSTATUS NtFlushBuffersFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 123: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2352,6 +2477,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 124 NTSTATUS NtFlushInstallUILanguage ['LANGID InstallUILanguage', 'ULONG SetComittedFlag']
 	case 124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2365,6 +2491,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 125 NTSTATUS NtFlushInstructionCache ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'SIZE_T Length']
 	case 125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2380,6 +2507,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 126 NTSTATUS NtFlushKey ['HANDLE KeyHandle']
 	case 126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2391,11 +2519,13 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 127 VOID NtFlushProcessWriteBuffers ['']
 	case 127: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtFlushProcessWriteBuffers_enter, cpu, pc);
 	}; break;
 	// 128 NTSTATUS NtFlushVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'PIO_STATUS_BLOCK IoStatus']
 	case 128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2413,11 +2543,13 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 129 NTSTATUS NtFlushWriteBuffer ['']
 	case 129: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtFlushWriteBuffer_enter, cpu, pc);
 	}; break;
 	// 130 NTSTATUS NtFreeUserPhysicalPages ['HANDLE ProcessHandle', 'PULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 130: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2433,6 +2565,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 131 NTSTATUS NtFreeVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG FreeType']
 	case 131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2450,6 +2583,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 132 NTSTATUS NtFreezeRegistry ['ULONG TimeOutInSeconds']
 	case 132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2461,6 +2595,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 133 NTSTATUS NtFreezeTransactions ['PLARGE_INTEGER FreezeTimeout', 'PLARGE_INTEGER ThawTimeout']
 	case 133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2474,6 +2609,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 134 NTSTATUS NtFsControlFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG IoControlCode', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 134: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2503,6 +2639,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 135 NTSTATUS NtGetContextThread ['HANDLE ThreadHandle', 'PCONTEXT ThreadContext']
 	case 135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2516,11 +2653,13 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 136 ULONG NtGetCurrentProcessorNumber ['']
 	case 136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtGetCurrentProcessorNumber_enter, cpu, pc);
 	}; break;
 	// 137 NTSTATUS NtGetDevicePowerState ['HANDLE Device', 'DEVICE_POWER_STATE *State']
 	case 137: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2534,6 +2673,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 138 NTSTATUS NtGetMUIRegistryInfo ['ULONG Flags', 'PULONG DataSize', 'PVOID Data']
 	case 138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2549,6 +2689,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 139 NTSTATUS NtGetNextProcess ['HANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'ULONG Flags', 'PHANDLE NewProcessHandle']
 	case 139: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2568,6 +2709,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 140 NTSTATUS NtGetNextThread ['HANDLE ProcessHandle', 'HANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'ULONG Flags', 'PHANDLE NewThreadHandle']
 	case 140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2589,6 +2731,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 141 NTSTATUS NtGetNlsSectionPtr ['ULONG SectionType', 'ULONG SectionData', 'PVOID ContextData', 'PVOID *SectionPointer', 'PULONG SectionSize']
 	case 141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2608,6 +2751,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 142 NTSTATUS NtGetNotificationResourceManager ['HANDLE ResourceManagerHandle', 'PTRANSACTION_NOTIFICATION TransactionNotification', 'ULONG NotificationLength', 'PLARGE_INTEGER Timeout', 'PULONG ReturnLength', 'ULONG Asynchronous', 'ULONG_PTR AsynchronousContext']
 	case 142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2631,6 +2775,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 143 NTSTATUS NtGetPlugPlayEvent ['HANDLE EventHandle', 'PVOID Context', 'PPLUGPLAY_EVENT_BLOCK EventBlock', 'ULONG EventBufferSize']
 	case 143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2648,6 +2793,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 144 NTSTATUS NtGetWriteWatch ['HANDLE ProcessHandle', 'ULONG Flags', 'PVOID BaseAddress', 'SIZE_T RegionSize', 'PVOID *UserAddressArray', 'PULONG_PTR EntriesInUserAddressArray', 'PULONG Granularity']
 	case 144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2671,6 +2817,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 145 NTSTATUS NtImpersonateAnonymousToken ['HANDLE ThreadHandle']
 	case 145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2682,6 +2829,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 146 NTSTATUS NtImpersonateClientOfPort ['HANDLE PortHandle', 'PPORT_MESSAGE Message']
 	case 146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2695,6 +2843,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 147 NTSTATUS NtImpersonateThread ['HANDLE ServerThreadHandle', 'HANDLE ClientThreadHandle', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos']
 	case 147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2710,6 +2859,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 148 NTSTATUS NtInitializeNlsFiles ['PVOID *BaseAddress', 'PLCID DefaultLocaleId', 'PLARGE_INTEGER DefaultCasingTableSize']
 	case 148: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2725,6 +2875,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 149 NTSTATUS NtInitializeRegistry ['USHORT BootCondition']
 	case 149: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2736,6 +2887,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 150 NTSTATUS NtInitiatePowerAction ['POWER_ACTION SystemAction', 'SYSTEM_POWER_STATE MinSystemState', 'ULONG Flags', 'BOOLEAN Asynchronous']
 	case 150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2753,6 +2905,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 151 NTSTATUS NtIsProcessInJob ['HANDLE ProcessHandle', 'HANDLE JobHandle']
 	case 151: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2766,16 +2919,19 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 152 BOOLEAN NtIsSystemResumeAutomatic ['']
 	case 152: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtIsSystemResumeAutomatic_enter, cpu, pc);
 	}; break;
 	// 153 NTSTATUS NtIsUILanguageComitted ['']
 	case 153: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtIsUILanguageComitted_enter, cpu, pc);
 	}; break;
 	// 154 NTSTATUS NtListenPort ['HANDLE PortHandle', 'PPORT_MESSAGE ConnectionRequest']
 	case 154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2789,6 +2945,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 155 NTSTATUS NtLoadDriver ['PUNICODE_STRING DriverServiceName']
 	case 155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2800,6 +2957,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 156 NTSTATUS NtLoadKey ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile']
 	case 156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2813,6 +2971,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 157 NTSTATUS NtLoadKey2 ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile', 'ULONG Flags']
 	case 157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2828,6 +2987,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 158 NTSTATUS NtLoadKeyEx ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile', 'ULONG Flags', 'HANDLE TrustClassKey']
 	case 158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2845,6 +3005,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 159 NTSTATUS NtLockFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER ByteOffset', 'PLARGE_INTEGER Length', 'ULONG Key', 'BOOLEAN FailImmediately', 'BOOLEAN ExclusiveLock']
 	case 159: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2874,6 +3035,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 160 NTSTATUS NtLockProductActivationKeys ['ULONG *pPrivateVer', 'ULONG *pSafeMode']
 	case 160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2887,6 +3049,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 161 NTSTATUS NtLockRegistryKey ['HANDLE KeyHandle']
 	case 161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2898,6 +3061,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 162 NTSTATUS NtLockVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG MapType']
 	case 162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2915,6 +3079,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 163 NTSTATUS NtMakePermanentObject ['HANDLE Handle']
 	case 163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2926,6 +3091,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 164 NTSTATUS NtMakeTemporaryObject ['HANDLE Handle']
 	case 164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2937,6 +3103,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 165 NTSTATUS NtMapCMFModule ['ULONG What', 'ULONG Index', 'PULONG CacheIndexOut', 'PULONG CacheFlagsOut', 'PULONG ViewSizeOut', 'PVOID *BaseAddress']
 	case 165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2958,6 +3125,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 166 NTSTATUS NtMapUserPhysicalPages ['PVOID VirtualAddress', 'ULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 166: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2973,6 +3141,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 167 NTSTATUS NtMapUserPhysicalPagesScatter ['PVOID *VirtualAddresses', 'ULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 167: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2988,6 +3157,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 168 NTSTATUS NtMapViewOfSection ['HANDLE SectionHandle', 'HANDLE ProcessHandle', 'PVOID *BaseAddress', 'ULONG_PTR ZeroBits', 'SIZE_T CommitSize', 'PLARGE_INTEGER SectionOffset', 'PSIZE_T ViewSize', 'SECTION_INHERIT InheritDisposition', 'ULONG AllocationType', 'WIN32_PROTECTION_MASK Win32Protect']
 	case 168: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3017,6 +3187,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 169 NTSTATUS NtModifyBootEntry ['PBOOT_ENTRY BootEntry']
 	case 169: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3028,6 +3199,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 170 NTSTATUS NtModifyDriverEntry ['PEFI_DRIVER_ENTRY DriverEntry']
 	case 170: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3039,6 +3211,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 171 NTSTATUS NtNotifyChangeDirectoryFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'ULONG CompletionFilter', 'BOOLEAN WatchTree']
 	case 171: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3066,6 +3239,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 172 NTSTATUS NtNotifyChangeKey ['HANDLE KeyHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CompletionFilter', 'BOOLEAN WatchTree', 'PVOID Buffer', 'ULONG BufferSize', 'BOOLEAN Asynchronous']
 	case 172: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3095,6 +3269,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 173 NTSTATUS NtNotifyChangeMultipleKeys ['HANDLE MasterKeyHandle', 'ULONG Count', 'OBJECT_ATTRIBUTES SlaveObjects[]', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CompletionFilter', 'BOOLEAN WatchTree', 'PVOID Buffer', 'ULONG BufferSize', 'BOOLEAN Asynchronous']
 	case 173: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3128,6 +3303,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 174 NTSTATUS NtNotifyChangeSession ['HANDLE Session', 'ULONG IoStateSequence', 'PVOID Reserved', 'ULONG Action', 'IO_SESSION_STATE IoState', 'IO_SESSION_STATE IoState2', 'PVOID Buffer', 'ULONG BufferSize']
 	case 174: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3153,6 +3329,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 175 NTSTATUS NtOpenDirectoryObject ['PHANDLE DirectoryHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3168,6 +3345,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 176 NTSTATUS NtOpenEnlistment ['PHANDLE EnlistmentHandle', 'ACCESS_MASK DesiredAccess', 'HANDLE ResourceManagerHandle', 'LPGUID EnlistmentGuid', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3187,6 +3365,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 177 NTSTATUS NtOpenEvent ['PHANDLE EventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 177: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3202,6 +3381,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 178 NTSTATUS NtOpenEventPair ['PHANDLE EventPairHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 178: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3217,6 +3397,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 179 NTSTATUS NtOpenFile ['PHANDLE FileHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG ShareAccess', 'ULONG OpenOptions']
 	case 179: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3238,6 +3419,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 180 NTSTATUS NtOpenIoCompletion ['PHANDLE IoCompletionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 180: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3253,6 +3435,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 181 NTSTATUS NtOpenJobObject ['PHANDLE JobHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 181: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3268,6 +3451,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 182 NTSTATUS NtOpenKey ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 182: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3283,6 +3467,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 183 NTSTATUS NtOpenKeyEx ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG OpenOptions']
 	case 183: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3300,6 +3485,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 184 NTSTATUS NtOpenKeyedEvent ['PHANDLE KeyedEventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 184: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3315,6 +3501,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 185 NTSTATUS NtOpenKeyTransacted ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE TransactionHandle']
 	case 185: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3332,6 +3519,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 186 NTSTATUS NtOpenKeyTransactedEx ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG OpenOptions', 'HANDLE TransactionHandle']
 	case 186: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3351,6 +3539,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 187 NTSTATUS NtOpenMutant ['PHANDLE MutantHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 187: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3366,6 +3555,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 188 NTSTATUS NtOpenObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'ACCESS_MASK GrantedAccess', 'PPRIVILEGE_SET Privileges', 'BOOLEAN ObjectCreation', 'BOOLEAN AccessGranted', 'PBOOLEAN GenerateOnClose']
 	case 188: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3399,6 +3589,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 189 NTSTATUS NtOpenPrivateNamespace ['PHANDLE NamespaceHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PVOID BoundaryDescriptor']
 	case 189: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3416,6 +3607,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 190 NTSTATUS NtOpenProcess ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PCLIENT_ID ClientId']
 	case 190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3433,6 +3625,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 191 NTSTATUS NtOpenProcessToken ['HANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'PHANDLE TokenHandle']
 	case 191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3448,6 +3641,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 192 NTSTATUS NtOpenProcessTokenEx ['HANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'PHANDLE TokenHandle']
 	case 192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3465,6 +3659,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 193 NTSTATUS NtOpenResourceManager ['PHANDLE ResourceManagerHandle', 'ACCESS_MASK DesiredAccess', 'HANDLE TmHandle', 'LPGUID ResourceManagerGuid', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 193: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3484,6 +3679,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 194 NTSTATUS NtOpenSection ['PHANDLE SectionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3499,6 +3695,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 195 NTSTATUS NtOpenSemaphore ['PHANDLE SemaphoreHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3514,6 +3711,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 196 NTSTATUS NtOpenSession ['PHANDLE SessionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3529,6 +3727,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 197 NTSTATUS NtOpenSymbolicLinkObject ['PHANDLE LinkHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 197: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3544,6 +3743,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 198 NTSTATUS NtOpenThread ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PCLIENT_ID ClientId']
 	case 198: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3561,6 +3761,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 199 NTSTATUS NtOpenThreadToken ['HANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'BOOLEAN OpenAsSelf', 'PHANDLE TokenHandle']
 	case 199: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3578,6 +3779,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 200 NTSTATUS NtOpenThreadTokenEx ['HANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'BOOLEAN OpenAsSelf', 'ULONG HandleAttributes', 'PHANDLE TokenHandle']
 	case 200: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3597,6 +3799,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 201 NTSTATUS NtOpenTimer ['PHANDLE TimerHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 201: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3612,6 +3815,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 202 NTSTATUS NtOpenTransaction ['PHANDLE TransactionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'LPGUID Uow', 'HANDLE TmHandle']
 	case 202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3631,6 +3835,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 203 NTSTATUS NtOpenTransactionManager ['PHANDLE TmHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PUNICODE_STRING LogFileName', 'LPGUID TmIdentity', 'ULONG OpenOptions']
 	case 203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3652,6 +3857,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 204 NTSTATUS NtPlugPlayControl ['PLUGPLAY_CONTROL_CLASS PnPControlClass', 'PVOID PnPControlData', 'ULONG PnPControlDataLength']
 	case 204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3667,6 +3873,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 205 NTSTATUS NtPowerInformation ['POWER_INFORMATION_LEVEL InformationLevel', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 205: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3686,6 +3893,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 206 NTSTATUS NtPrepareComplete ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3699,6 +3907,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 207 NTSTATUS NtPrepareEnlistment ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3712,6 +3921,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 208 NTSTATUS NtPrePrepareComplete ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 208: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3725,6 +3935,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 209 NTSTATUS NtPrePrepareEnlistment ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 209: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3738,6 +3949,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 210 NTSTATUS NtPrivilegeCheck ['HANDLE ClientToken', 'PPRIVILEGE_SET RequiredPrivileges', 'PBOOLEAN Result']
 	case 210: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3753,6 +3965,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 211 NTSTATUS NtPrivilegedServiceAuditAlarm ['PUNICODE_STRING SubsystemName', 'PUNICODE_STRING ServiceName', 'HANDLE ClientToken', 'PPRIVILEGE_SET Privileges', 'BOOLEAN AccessGranted']
 	case 211: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3772,6 +3985,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 212 NTSTATUS NtPrivilegeObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'PPRIVILEGE_SET Privileges', 'BOOLEAN AccessGranted']
 	case 212: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3793,6 +4007,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 213 NTSTATUS NtPropagationComplete ['HANDLE ResourceManagerHandle', 'ULONG RequestCookie', 'ULONG BufferLength', 'PVOID Buffer']
 	case 213: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3810,6 +4025,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 214 NTSTATUS NtPropagationFailed ['HANDLE ResourceManagerHandle', 'ULONG RequestCookie', 'NTSTATUS PropStatus']
 	case 214: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3825,6 +4041,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 215 NTSTATUS NtProtectVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'WIN32_PROTECTION_MASK NewProtectWin32', 'PULONG OldProtect']
 	case 215: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3844,6 +4061,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 216 NTSTATUS NtPulseEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 216: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3857,6 +4075,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 217 NTSTATUS NtQueryAttributesFile ['POBJECT_ATTRIBUTES ObjectAttributes', 'PFILE_BASIC_INFORMATION FileInformation']
 	case 217: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3870,6 +4089,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 218 NTSTATUS NtQueryBootEntryOrder ['PULONG Ids', 'PULONG Count']
 	case 218: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3883,6 +4103,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 219 NTSTATUS NtQueryBootOptions ['PBOOT_OPTIONS BootOptions', 'PULONG BootOptionsLength']
 	case 219: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3896,6 +4117,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 220 NTSTATUS NtQueryDebugFilterState ['ULONG ComponentId', 'ULONG Level']
 	case 220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3909,6 +4131,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 221 NTSTATUS NtQueryDefaultLocale ['BOOLEAN UserProfile', 'PLCID DefaultLocaleId']
 	case 221: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3922,6 +4145,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 222 NTSTATUS NtQueryDefaultUILanguage ['LANGID *DefaultUILanguageId']
 	case 222: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3933,6 +4157,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 223 NTSTATUS NtQueryDirectoryFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass', 'BOOLEAN ReturnSingleEntry', 'PUNICODE_STRING FileName', 'BOOLEAN RestartScan']
 	case 223: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3964,6 +4189,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 224 NTSTATUS NtQueryDirectoryObject ['HANDLE DirectoryHandle', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'BOOLEAN RestartScan', 'PULONG Context', 'PULONG ReturnLength']
 	case 224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3987,6 +4213,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 225 NTSTATUS NtQueryDriverEntryOrder ['PULONG Ids', 'PULONG Count']
 	case 225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4000,6 +4227,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 226 NTSTATUS NtQueryEaFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'PVOID EaList', 'ULONG EaListLength', 'PULONG EaIndex', 'BOOLEAN RestartScan']
 	case 226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4027,6 +4255,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 227 NTSTATUS NtQueryEvent ['HANDLE EventHandle', 'EVENT_INFORMATION_CLASS EventInformationClass', 'PVOID EventInformation', 'ULONG EventInformationLength', 'PULONG ReturnLength']
 	case 227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4046,6 +4275,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 228 NTSTATUS NtQueryFullAttributesFile ['POBJECT_ATTRIBUTES ObjectAttributes', 'PFILE_NETWORK_OPEN_INFORMATION FileInformation']
 	case 228: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4059,6 +4289,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 229 NTSTATUS NtQueryInformationAtom ['RTL_ATOM Atom', 'ATOM_INFORMATION_CLASS InformationClass', 'PVOID AtomInformation', 'ULONG AtomInformationLength', 'PULONG ReturnLength']
 	case 229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4078,6 +4309,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 230 NTSTATUS NtQueryInformationEnlistment ['HANDLE EnlistmentHandle', 'ENLISTMENT_INFORMATION_CLASS EnlistmentInformationClass', 'PVOID EnlistmentInformation', 'ULONG EnlistmentInformationLength', 'PULONG ReturnLength']
 	case 230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4097,6 +4329,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 231 NTSTATUS NtQueryInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass']
 	case 231: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4116,6 +4349,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 232 NTSTATUS NtQueryInformationJobObject ['HANDLE JobHandle', 'JOBOBJECTINFOCLASS JobObjectInformationClass', 'PVOID JobObjectInformation', 'ULONG JobObjectInformationLength', 'PULONG ReturnLength']
 	case 232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4135,6 +4369,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 233 NTSTATUS NtQueryInformationPort ['HANDLE PortHandle', 'PORT_INFORMATION_CLASS PortInformationClass', 'PVOID PortInformation', 'ULONG Length', 'PULONG ReturnLength']
 	case 233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4154,6 +4389,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 234 NTSTATUS NtQueryInformationProcess ['HANDLE ProcessHandle', 'PROCESSINFOCLASS ProcessInformationClass', 'PVOID ProcessInformation', 'ULONG ProcessInformationLength', 'PULONG ReturnLength']
 	case 234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4173,6 +4409,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 235 NTSTATUS NtQueryInformationResourceManager ['HANDLE ResourceManagerHandle', 'RESOURCEMANAGER_INFORMATION_CLASS ResourceManagerInformationClass', 'PVOID ResourceManagerInformation', 'ULONG ResourceManagerInformationLength', 'PULONG ReturnLength']
 	case 235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4192,6 +4429,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 236 NTSTATUS NtQueryInformationThread ['HANDLE ThreadHandle', 'THREADINFOCLASS ThreadInformationClass', 'PVOID ThreadInformation', 'ULONG ThreadInformationLength', 'PULONG ReturnLength']
 	case 236: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4211,6 +4449,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 237 NTSTATUS NtQueryInformationToken ['HANDLE TokenHandle', 'TOKEN_INFORMATION_CLASS TokenInformationClass', 'PVOID TokenInformation', 'ULONG TokenInformationLength', 'PULONG ReturnLength']
 	case 237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4230,6 +4469,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 238 NTSTATUS NtQueryInformationTransaction ['HANDLE TransactionHandle', 'TRANSACTION_INFORMATION_CLASS TransactionInformationClass', 'PVOID TransactionInformation', 'ULONG TransactionInformationLength', 'PULONG ReturnLength']
 	case 238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4249,6 +4489,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 239 NTSTATUS NtQueryInformationTransactionManager ['HANDLE TransactionManagerHandle', 'TRANSACTIONMANAGER_INFORMATION_CLASS TransactionManagerInformationClass', 'PVOID TransactionManagerInformation', 'ULONG TransactionManagerInformationLength', 'PULONG ReturnLength']
 	case 239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4268,6 +4509,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 240 NTSTATUS NtQueryInformationWorkerFactory ['HANDLE WorkerFactoryHandle', 'WORKERFACTORYINFOCLASS WorkerFactoryInformationClass', 'PVOID WorkerFactoryInformation', 'ULONG WorkerFactoryInformationLength', 'PULONG ReturnLength']
 	case 240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4287,6 +4529,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 241 NTSTATUS NtQueryInstallUILanguage ['LANGID *InstallUILanguageId']
 	case 241: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4298,6 +4541,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 242 NTSTATUS NtQueryIntervalProfile ['KPROFILE_SOURCE ProfileSource', 'PULONG Interval']
 	case 242: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4311,6 +4555,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 243 NTSTATUS NtQueryIoCompletion ['HANDLE IoCompletionHandle', 'IO_COMPLETION_INFORMATION_CLASS IoCompletionInformationClass', 'PVOID IoCompletionInformation', 'ULONG IoCompletionInformationLength', 'PULONG ReturnLength']
 	case 243: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4330,6 +4575,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 244 NTSTATUS NtQueryKey ['HANDLE KeyHandle', 'KEY_INFORMATION_CLASS KeyInformationClass', 'PVOID KeyInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 244: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4349,6 +4595,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 245 NTSTATUS NtQueryLicenseValue ['PUNICODE_STRING Name', 'PULONG Type', 'PVOID Buffer', 'ULONG Length', 'PULONG ReturnedLength']
 	case 245: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4368,6 +4615,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 246 NTSTATUS NtQueryMultipleValueKey ['HANDLE KeyHandle', 'PKEY_VALUE_ENTRY ValueEntries', 'ULONG EntryCount', 'PVOID ValueBuffer', 'PULONG BufferLength', 'PULONG RequiredBufferLength']
 	case 246: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4389,6 +4637,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 247 NTSTATUS NtQueryMutant ['HANDLE MutantHandle', 'MUTANT_INFORMATION_CLASS MutantInformationClass', 'PVOID MutantInformation', 'ULONG MutantInformationLength', 'PULONG ReturnLength']
 	case 247: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4408,6 +4657,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 248 NTSTATUS NtQueryObject ['HANDLE Handle', 'OBJECT_INFORMATION_CLASS ObjectInformationClass', 'PVOID ObjectInformation', 'ULONG ObjectInformationLength', 'PULONG ReturnLength']
 	case 248: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4427,6 +4677,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 249 NTSTATUS NtQueryOpenSubKeys ['POBJECT_ATTRIBUTES TargetKey', 'PULONG HandleCount']
 	case 249: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4440,6 +4691,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 250 NTSTATUS NtQueryOpenSubKeysEx ['POBJECT_ATTRIBUTES TargetKey', 'ULONG BufferLength', 'PVOID Buffer', 'PULONG RequiredSize']
 	case 250: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4457,6 +4709,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 251 NTSTATUS NtQueryPerformanceCounter ['PLARGE_INTEGER PerformanceCounter', 'PLARGE_INTEGER PerformanceFrequency']
 	case 251: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4470,11 +4723,13 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 252 NTSTATUS NtQueryPortInformationProcess ['']
 	case 252: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtQueryPortInformationProcess_enter, cpu, pc);
 	}; break;
 	// 253 NTSTATUS NtQueryQuotaInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'PVOID SidList', 'ULONG SidListLength', 'PULONG StartSid', 'BOOLEAN RestartScan']
 	case 253: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4502,6 +4757,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 254 NTSTATUS NtQuerySection ['HANDLE SectionHandle', 'SECTION_INFORMATION_CLASS SectionInformationClass', 'PVOID SectionInformation', 'SIZE_T SectionInformationLength', 'PSIZE_T ReturnLength']
 	case 254: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4521,6 +4777,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 255 NTSTATUS NtQuerySecurityAttributesToken ['HANDLE TokenHandle', 'PUNICODE_STRING Attributes', 'ULONG NumberOfAttributes', 'PVOID Buffer', 'ULONG Length', 'PULONG ReturnLength']
 	case 255: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4542,6 +4799,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 256 NTSTATUS NtQuerySecurityObject ['HANDLE Handle', 'SECURITY_INFORMATION SecurityInformation', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'ULONG Length', 'PULONG LengthNeeded']
 	case 256: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4561,6 +4819,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 257 NTSTATUS NtQuerySemaphore ['HANDLE SemaphoreHandle', 'SEMAPHORE_INFORMATION_CLASS SemaphoreInformationClass', 'PVOID SemaphoreInformation', 'ULONG SemaphoreInformationLength', 'PULONG ReturnLength']
 	case 257: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4580,6 +4839,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 258 NTSTATUS NtQuerySymbolicLinkObject ['HANDLE LinkHandle', 'PUNICODE_STRING LinkTarget', 'PULONG ReturnedLength']
 	case 258: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4595,6 +4855,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 259 NTSTATUS NtQuerySystemEnvironmentValue ['PUNICODE_STRING VariableName', 'PWSTR VariableValue', 'USHORT ValueLength', 'PUSHORT ReturnLength']
 	case 259: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4612,6 +4873,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 260 NTSTATUS NtQuerySystemEnvironmentValueEx ['PUNICODE_STRING VariableName', 'LPGUID VendorGuid', 'PVOID Value', 'PULONG ValueLength', 'PULONG Attributes']
 	case 260: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4631,6 +4893,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 261 NTSTATUS NtQuerySystemInformation ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID SystemInformation', 'ULONG SystemInformationLength', 'PULONG ReturnLength']
 	case 261: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4648,6 +4911,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 262 NTSTATUS NtQuerySystemInformationEx ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID QueryInformation', 'ULONG QueryInformationLength', 'PVOID SystemInformation', 'ULONG SystemInformationLength', 'PULONG ReturnLength']
 	case 262: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4669,6 +4933,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 263 NTSTATUS NtQuerySystemTime ['PLARGE_INTEGER SystemTime']
 	case 263: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4680,6 +4945,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 264 NTSTATUS NtQueryTimer ['HANDLE TimerHandle', 'TIMER_INFORMATION_CLASS TimerInformationClass', 'PVOID TimerInformation', 'ULONG TimerInformationLength', 'PULONG ReturnLength']
 	case 264: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4699,6 +4965,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 265 NTSTATUS NtQueryTimerResolution ['PULONG MaximumTime', 'PULONG MinimumTime', 'PULONG CurrentTime']
 	case 265: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4714,6 +4981,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 266 NTSTATUS NtQueryValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName', 'KEY_VALUE_INFORMATION_CLASS KeyValueInformationClass', 'PVOID KeyValueInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 266: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4735,6 +5003,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 267 NTSTATUS NtQueryVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'MEMORY_INFORMATION_CLASS MemoryInformationClass', 'PVOID MemoryInformation', 'SIZE_T MemoryInformationLength', 'PSIZE_T ReturnLength']
 	case 267: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4756,6 +5025,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 268 NTSTATUS NtQueryVolumeInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FsInformation', 'ULONG Length', 'FS_INFORMATION_CLASS FsInformationClass']
 	case 268: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4775,6 +5045,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 269 NTSTATUS NtQueueApcThread ['HANDLE ThreadHandle', 'PPS_APC_ROUTINE ApcRoutine', 'PVOID ApcArgument1', 'PVOID ApcArgument2', 'PVOID ApcArgument3']
 	case 269: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4794,6 +5065,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 270 NTSTATUS NtQueueApcThreadEx ['HANDLE ThreadHandle', 'HANDLE UserApcReserveHandle', 'PPS_APC_ROUTINE ApcRoutine', 'PVOID ApcArgument1', 'PVOID ApcArgument2', 'PVOID ApcArgument3']
 	case 270: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4815,6 +5087,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 271 NTSTATUS NtRaiseException ['PEXCEPTION_RECORD ExceptionRecord', 'PCONTEXT ContextRecord', 'BOOLEAN FirstChance']
 	case 271: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4830,6 +5103,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 272 NTSTATUS NtRaiseHardError ['NTSTATUS ErrorStatus', 'ULONG NumberOfParameters', 'ULONG UnicodeStringParameterMask', 'PULONG_PTR Parameters', 'ULONG ValidResponseOptions', 'PULONG Response']
 	case 272: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4851,6 +5125,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 273 NTSTATUS NtReadFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 273: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4878,6 +5153,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 274 NTSTATUS NtReadFileScatter ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PFILE_SEGMENT_ELEMENT SegmentArray', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 274: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4905,6 +5181,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 275 NTSTATUS NtReadOnlyEnlistment ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 275: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4918,6 +5195,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 276 NTSTATUS NtReadRequestData ['HANDLE PortHandle', 'PPORT_MESSAGE Message', 'ULONG DataEntryIndex', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesRead']
 	case 276: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4939,6 +5217,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 277 NTSTATUS NtReadVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesRead']
 	case 277: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4958,6 +5237,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 278 NTSTATUS NtRecoverEnlistment ['HANDLE EnlistmentHandle', 'PVOID EnlistmentKey']
 	case 278: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4971,6 +5251,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 279 NTSTATUS NtRecoverResourceManager ['HANDLE ResourceManagerHandle']
 	case 279: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4982,6 +5263,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 280 NTSTATUS NtRecoverTransactionManager ['HANDLE TransactionManagerHandle']
 	case 280: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4993,6 +5275,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 281 NTSTATUS NtRegisterProtocolAddressInformation ['HANDLE ResourceManager', 'PCRM_PROTOCOL_ID ProtocolId', 'ULONG ProtocolInformationSize', 'PVOID ProtocolInformation', 'ULONG CreateOptions']
 	case 281: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5012,6 +5295,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 282 NTSTATUS NtRegisterThreadTerminatePort ['HANDLE PortHandle']
 	case 282: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5023,6 +5307,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 283 NTSTATUS NtReleaseKeyedEvent ['HANDLE KeyedEventHandle', 'PVOID KeyValue', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 283: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5040,6 +5325,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 284 NTSTATUS NtReleaseMutant ['HANDLE MutantHandle', 'PLONG PreviousCount']
 	case 284: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5053,6 +5339,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 285 NTSTATUS NtReleaseSemaphore ['HANDLE SemaphoreHandle', 'LONG ReleaseCount', 'PLONG PreviousCount']
 	case 285: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5068,6 +5355,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 286 NTSTATUS NtReleaseWorkerFactoryWorker ['HANDLE WorkerFactoryHandle']
 	case 286: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5079,6 +5367,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 287 NTSTATUS NtRemoveIoCompletion ['HANDLE IoCompletionHandle', 'PVOID *KeyContext', 'PVOID *ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER Timeout']
 	case 287: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5098,6 +5387,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 288 NTSTATUS NtRemoveIoCompletionEx ['HANDLE IoCompletionHandle', 'PFILE_IO_COMPLETION_INFORMATION IoCompletionInformation', 'ULONG Count', 'PULONG NumEntriesRemoved', 'PLARGE_INTEGER Timeout', 'BOOLEAN Alertable']
 	case 288: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5119,6 +5409,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 289 NTSTATUS NtRemoveProcessDebug ['HANDLE ProcessHandle', 'HANDLE DebugObjectHandle']
 	case 289: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5132,6 +5423,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 290 NTSTATUS NtRenameKey ['HANDLE KeyHandle', 'PUNICODE_STRING NewName']
 	case 290: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5145,6 +5437,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 291 NTSTATUS NtRenameTransactionManager ['PUNICODE_STRING LogFileName', 'LPGUID ExistingTransactionManagerGuid']
 	case 291: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5158,6 +5451,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 292 NTSTATUS NtReplaceKey ['POBJECT_ATTRIBUTES NewFile', 'HANDLE TargetHandle', 'POBJECT_ATTRIBUTES OldFile']
 	case 292: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5173,6 +5467,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 293 NTSTATUS NtReplacePartitionUnit ['PUNICODE_STRING TargetInstancePath', 'PUNICODE_STRING SpareInstancePath', 'ULONG Flags']
 	case 293: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5188,6 +5483,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 294 NTSTATUS NtReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE ReplyMessage']
 	case 294: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5201,6 +5497,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 295 NTSTATUS NtReplyWaitReceivePort ['HANDLE PortHandle', 'PVOID *PortContext', 'PPORT_MESSAGE ReplyMessage', 'PPORT_MESSAGE ReceiveMessage']
 	case 295: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5218,6 +5515,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 296 NTSTATUS NtReplyWaitReceivePortEx ['HANDLE PortHandle', 'PVOID *PortContext', 'PPORT_MESSAGE ReplyMessage', 'PPORT_MESSAGE ReceiveMessage', 'PLARGE_INTEGER Timeout']
 	case 296: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5237,6 +5535,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 297 NTSTATUS NtReplyWaitReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE ReplyMessage']
 	case 297: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5250,6 +5549,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 298 NTSTATUS NtRequestPort ['HANDLE PortHandle', 'PPORT_MESSAGE RequestMessage']
 	case 298: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5263,6 +5563,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 299 NTSTATUS NtRequestWaitReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE RequestMessage', 'PPORT_MESSAGE ReplyMessage']
 	case 299: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5278,6 +5579,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 300 NTSTATUS NtResetEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 300: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5291,6 +5593,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 301 NTSTATUS NtResetWriteWatch ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'SIZE_T RegionSize']
 	case 301: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5306,6 +5609,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 302 NTSTATUS NtRestoreKey ['HANDLE KeyHandle', 'HANDLE FileHandle', 'ULONG Flags']
 	case 302: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5321,6 +5625,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 303 NTSTATUS NtResumeProcess ['HANDLE ProcessHandle']
 	case 303: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5332,6 +5637,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 304 NTSTATUS NtResumeThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 304: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5345,6 +5651,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 305 NTSTATUS NtRollbackComplete ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 305: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5358,6 +5665,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 306 NTSTATUS NtRollbackEnlistment ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 306: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5371,6 +5679,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 307 NTSTATUS NtRollbackTransaction ['HANDLE TransactionHandle', 'BOOLEAN Wait']
 	case 307: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5384,6 +5693,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 308 NTSTATUS NtRollforwardTransactionManager ['HANDLE TransactionManagerHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 308: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5397,6 +5707,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 309 NTSTATUS NtSaveKey ['HANDLE KeyHandle', 'HANDLE FileHandle']
 	case 309: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5410,6 +5721,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 310 NTSTATUS NtSaveKeyEx ['HANDLE KeyHandle', 'HANDLE FileHandle', 'ULONG Format']
 	case 310: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5425,6 +5737,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 311 NTSTATUS NtSaveMergedKeys ['HANDLE HighPrecedenceKeyHandle', 'HANDLE LowPrecedenceKeyHandle', 'HANDLE FileHandle']
 	case 311: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5440,6 +5753,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 312 NTSTATUS NtSecureConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos', 'PPORT_VIEW ClientView', 'PSID RequiredServerSid', 'PREMOTE_PORT_VIEW ServerView', 'PULONG MaxMessageLength', 'PVOID ConnectionInformation', 'PULONG ConnectionInformationLength']
 	case 312: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5467,11 +5781,13 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 313 NTSTATUS NtSerializeBoot ['']
 	case 313: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtSerializeBoot_enter, cpu, pc);
 	}; break;
 	// 314 NTSTATUS NtSetBootEntryOrder ['PULONG Ids', 'ULONG Count']
 	case 314: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5485,6 +5801,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 315 NTSTATUS NtSetBootOptions ['PBOOT_OPTIONS BootOptions', 'ULONG FieldsToChange']
 	case 315: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5498,6 +5815,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 316 NTSTATUS NtSetContextThread ['HANDLE ThreadHandle', 'PCONTEXT ThreadContext']
 	case 316: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5511,6 +5829,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 317 NTSTATUS NtSetDebugFilterState ['ULONG ComponentId', 'ULONG Level', 'BOOLEAN State']
 	case 317: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5526,6 +5845,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 318 NTSTATUS NtSetDefaultHardErrorPort ['HANDLE DefaultHardErrorPort']
 	case 318: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5537,6 +5857,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 319 NTSTATUS NtSetDefaultLocale ['BOOLEAN UserProfile', 'LCID DefaultLocaleId']
 	case 319: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5550,6 +5871,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 320 NTSTATUS NtSetDefaultUILanguage ['LANGID DefaultUILanguageId']
 	case 320: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5561,6 +5883,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 321 NTSTATUS NtSetDriverEntryOrder ['PULONG Ids', 'ULONG Count']
 	case 321: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5574,6 +5897,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 322 NTSTATUS NtSetEaFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length']
 	case 322: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5591,6 +5915,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 323 NTSTATUS NtSetEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 323: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5604,6 +5929,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 324 NTSTATUS NtSetEventBoostPriority ['HANDLE EventHandle']
 	case 324: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5615,6 +5941,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 325 NTSTATUS NtSetHighEventPair ['HANDLE EventPairHandle']
 	case 325: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5626,6 +5953,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 326 NTSTATUS NtSetHighWaitLowEventPair ['HANDLE EventPairHandle']
 	case 326: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5637,6 +5965,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 327 NTSTATUS NtSetInformationDebugObject ['HANDLE DebugObjectHandle', 'DEBUGOBJECTINFOCLASS DebugObjectInformationClass', 'PVOID DebugInformation', 'ULONG DebugInformationLength', 'PULONG ReturnLength']
 	case 327: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5656,6 +5985,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 328 NTSTATUS NtSetInformationEnlistment ['HANDLE EnlistmentHandle', 'ENLISTMENT_INFORMATION_CLASS EnlistmentInformationClass', 'PVOID EnlistmentInformation', 'ULONG EnlistmentInformationLength']
 	case 328: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5673,6 +6003,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 329 NTSTATUS NtSetInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass']
 	case 329: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5692,6 +6023,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 330 NTSTATUS NtSetInformationJobObject ['HANDLE JobHandle', 'JOBOBJECTINFOCLASS JobObjectInformationClass', 'PVOID JobObjectInformation', 'ULONG JobObjectInformationLength']
 	case 330: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5709,6 +6041,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 331 NTSTATUS NtSetInformationKey ['HANDLE KeyHandle', 'KEY_SET_INFORMATION_CLASS KeySetInformationClass', 'PVOID KeySetInformation', 'ULONG KeySetInformationLength']
 	case 331: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5726,6 +6059,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 332 NTSTATUS NtSetInformationObject ['HANDLE Handle', 'OBJECT_INFORMATION_CLASS ObjectInformationClass', 'PVOID ObjectInformation', 'ULONG ObjectInformationLength']
 	case 332: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5743,6 +6077,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 333 NTSTATUS NtSetInformationProcess ['HANDLE ProcessHandle', 'PROCESSINFOCLASS ProcessInformationClass', 'PVOID ProcessInformation', 'ULONG ProcessInformationLength']
 	case 333: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5760,6 +6095,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 334 NTSTATUS NtSetInformationResourceManager ['HANDLE ResourceManagerHandle', 'RESOURCEMANAGER_INFORMATION_CLASS ResourceManagerInformationClass', 'PVOID ResourceManagerInformation', 'ULONG ResourceManagerInformationLength']
 	case 334: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5777,6 +6113,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 335 NTSTATUS NtSetInformationThread ['HANDLE ThreadHandle', 'THREADINFOCLASS ThreadInformationClass', 'PVOID ThreadInformation', 'ULONG ThreadInformationLength']
 	case 335: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5794,6 +6131,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 336 NTSTATUS NtSetInformationToken ['HANDLE TokenHandle', 'TOKEN_INFORMATION_CLASS TokenInformationClass', 'PVOID TokenInformation', 'ULONG TokenInformationLength']
 	case 336: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5811,6 +6149,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 337 NTSTATUS NtSetInformationTransaction ['HANDLE TransactionHandle', 'TRANSACTION_INFORMATION_CLASS TransactionInformationClass', 'PVOID TransactionInformation', 'ULONG TransactionInformationLength']
 	case 337: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5828,6 +6167,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 338 NTSTATUS NtSetInformationTransactionManager ['HANDLE TmHandle', 'TRANSACTIONMANAGER_INFORMATION_CLASS TransactionManagerInformationClass', 'PVOID TransactionManagerInformation', 'ULONG TransactionManagerInformationLength']
 	case 338: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5845,6 +6185,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 339 NTSTATUS NtSetInformationWorkerFactory ['HANDLE WorkerFactoryHandle', 'WORKERFACTORYINFOCLASS WorkerFactoryInformationClass', 'PVOID WorkerFactoryInformation', 'ULONG WorkerFactoryInformationLength']
 	case 339: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5862,6 +6203,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 340 NTSTATUS NtSetIntervalProfile ['ULONG Interval', 'KPROFILE_SOURCE Source']
 	case 340: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -5875,6 +6217,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 341 NTSTATUS NtSetIoCompletion ['HANDLE IoCompletionHandle', 'PVOID KeyContext', 'PVOID ApcContext', 'NTSTATUS IoStatus', 'ULONG_PTR IoStatusInformation']
 	case 341: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5894,6 +6237,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 342 NTSTATUS NtSetIoCompletionEx ['HANDLE IoCompletionHandle', 'HANDLE IoCompletionReserveHandle', 'PVOID KeyContext', 'PVOID ApcContext', 'NTSTATUS IoStatus', 'ULONG_PTR IoStatusInformation']
 	case 342: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5915,6 +6259,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 343 NTSTATUS NtSetLdtEntries ['ULONG Selector0', 'ULONG Entry0Low', 'ULONG Entry0Hi', 'ULONG Selector1', 'ULONG Entry1Low', 'ULONG Entry1Hi']
 	case 343: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5936,6 +6281,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 344 NTSTATUS NtSetLowEventPair ['HANDLE EventPairHandle']
 	case 344: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5947,6 +6293,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 345 NTSTATUS NtSetLowWaitHighEventPair ['HANDLE EventPairHandle']
 	case 345: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -5958,6 +6305,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 346 NTSTATUS NtSetQuotaInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length']
 	case 346: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5975,6 +6323,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 347 NTSTATUS NtSetSecurityObject ['HANDLE Handle', 'SECURITY_INFORMATION SecurityInformation', 'PSECURITY_DESCRIPTOR SecurityDescriptor']
 	case 347: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -5990,6 +6339,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 348 NTSTATUS NtSetSystemEnvironmentValue ['PUNICODE_STRING VariableName', 'PUNICODE_STRING VariableValue']
 	case 348: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6003,6 +6353,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 349 NTSTATUS NtSetSystemEnvironmentValueEx ['PUNICODE_STRING VariableName', 'LPGUID VendorGuid', 'PVOID Value', 'ULONG ValueLength', 'ULONG Attributes']
 	case 349: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6022,6 +6373,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 350 NTSTATUS NtSetSystemInformation ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID SystemInformation', 'ULONG SystemInformationLength']
 	case 350: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6037,6 +6389,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 351 NTSTATUS NtSetSystemPowerState ['POWER_ACTION SystemAction', 'SYSTEM_POWER_STATE MinSystemState', 'ULONG Flags']
 	case 351: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6052,6 +6405,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 352 NTSTATUS NtSetSystemTime ['PLARGE_INTEGER SystemTime', 'PLARGE_INTEGER PreviousTime']
 	case 352: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6065,6 +6419,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 353 NTSTATUS NtSetThreadExecutionState ['EXECUTION_STATE esFlags', 'PEXECUTION_STATE PreviousFlags']
 	case 353: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6078,6 +6433,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 354 NTSTATUS NtSetTimer ['HANDLE TimerHandle', 'PLARGE_INTEGER DueTime', 'PTIMER_APC_ROUTINE TimerApcRoutine', 'PVOID TimerContext', 'BOOLEAN WakeTimer', 'LONG Period', 'PBOOLEAN PreviousState']
 	case 354: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6101,6 +6457,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 355 NTSTATUS NtSetTimerEx ['HANDLE TimerHandle', 'TIMER_SET_INFORMATION_CLASS TimerSetInformationClass', 'PVOID TimerSetInformation', 'ULONG TimerSetInformationLength']
 	case 355: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6118,6 +6475,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 356 NTSTATUS NtSetTimerResolution ['ULONG DesiredTime', 'BOOLEAN SetResolution', 'PULONG ActualTime']
 	case 356: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6133,6 +6491,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 357 NTSTATUS NtSetUuidSeed ['PCHAR Seed']
 	case 357: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6144,6 +6503,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 358 NTSTATUS NtSetValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName', 'ULONG TitleIndex', 'ULONG Type', 'PVOID Data', 'ULONG DataSize']
 	case 358: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6165,6 +6525,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 359 NTSTATUS NtSetVolumeInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FsInformation', 'ULONG Length', 'FS_INFORMATION_CLASS FsInformationClass']
 	case 359: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6184,6 +6545,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 360 NTSTATUS NtShutdownSystem ['SHUTDOWN_ACTION Action']
 	case 360: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6195,6 +6557,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 361 NTSTATUS NtShutdownWorkerFactory ['HANDLE WorkerFactoryHandle', 'LONG *PendingWorkerCount']
 	case 361: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6208,6 +6571,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 362 NTSTATUS NtSignalAndWaitForSingleObject ['HANDLE SignalHandle', 'HANDLE WaitHandle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 362: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6225,6 +6589,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 363 NTSTATUS NtSinglePhaseReject ['HANDLE EnlistmentHandle', 'PLARGE_INTEGER TmVirtualClock']
 	case 363: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6238,6 +6603,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 364 NTSTATUS NtStartProfile ['HANDLE ProfileHandle']
 	case 364: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6249,6 +6615,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 365 NTSTATUS NtStopProfile ['HANDLE ProfileHandle']
 	case 365: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6260,6 +6627,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 366 NTSTATUS NtSuspendProcess ['HANDLE ProcessHandle']
 	case 366: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6271,6 +6639,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 367 NTSTATUS NtSuspendThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 367: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6284,6 +6653,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 368 NTSTATUS NtSystemDebugControl ['SYSDBG_COMMAND Command', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength', 'PULONG ReturnLength']
 	case 368: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6305,6 +6675,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 369 NTSTATUS NtTerminateJobObject ['HANDLE JobHandle', 'NTSTATUS ExitStatus']
 	case 369: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6318,6 +6689,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 370 NTSTATUS NtTerminateProcess ['HANDLE ProcessHandle', 'NTSTATUS ExitStatus']
 	case 370: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6331,6 +6703,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 371 NTSTATUS NtTerminateThread ['HANDLE ThreadHandle', 'NTSTATUS ExitStatus']
 	case 371: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6344,21 +6717,25 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 372 NTSTATUS NtTestAlert ['']
 	case 372: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtTestAlert_enter, cpu, pc);
 	}; break;
 	// 373 NTSTATUS NtThawRegistry ['']
 	case 373: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtThawRegistry_enter, cpu, pc);
 	}; break;
 	// 374 NTSTATUS NtThawTransactions ['']
 	case 374: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtThawTransactions_enter, cpu, pc);
 	}; break;
 	// 375 NTSTATUS NtTraceControl ['ULONG FunctionCode', 'PVOID InBuffer', 'ULONG InBufferLen', 'PVOID OutBuffer', 'ULONG OutBufferLen', 'PULONG ReturnLength']
 	case 375: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6380,6 +6757,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 376 NTSTATUS NtTraceEvent ['HANDLE TraceHandle', 'ULONG Flags', 'ULONG FieldSize', 'PVOID Fields']
 	case 376: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6397,6 +6775,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 377 NTSTATUS NtTranslateFilePath ['PFILE_PATH InputFilePath', 'ULONG OutputType', 'PFILE_PATH OutputFilePath', 'PULONG OutputFilePathLength']
 	case 377: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6414,6 +6793,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 378 NTSTATUS NtUmsThreadYield ['PVOID SchedulerParam']
 	case 378: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6425,6 +6805,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 379 NTSTATUS NtUnloadDriver ['PUNICODE_STRING DriverServiceName']
 	case 379: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6436,6 +6817,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 380 NTSTATUS NtUnloadKey ['POBJECT_ATTRIBUTES TargetKey']
 	case 380: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6447,6 +6829,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 381 NTSTATUS NtUnloadKey2 ['POBJECT_ATTRIBUTES TargetKey', 'ULONG Flags']
 	case 381: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6460,6 +6843,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 382 NTSTATUS NtUnloadKeyEx ['POBJECT_ATTRIBUTES TargetKey', 'HANDLE Event']
 	case 382: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6473,6 +6857,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 383 NTSTATUS NtUnlockFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER ByteOffset', 'PLARGE_INTEGER Length', 'ULONG Key']
 	case 383: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6492,6 +6877,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 384 NTSTATUS NtUnlockVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG MapType']
 	case 384: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6509,6 +6895,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 385 NTSTATUS NtUnmapViewOfSection ['HANDLE ProcessHandle', 'PVOID BaseAddress']
 	case 385: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6522,6 +6909,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 386 NTSTATUS NtVdmControl ['VDMSERVICECLASS Service', 'PVOID ServiceData']
 	case 386: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6535,6 +6923,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 387 NTSTATUS NtWaitForDebugEvent ['HANDLE DebugObjectHandle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout', 'PDBGUI_WAIT_STATE_CHANGE WaitStateChange']
 	case 387: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6552,6 +6941,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 388 NTSTATUS NtWaitForKeyedEvent ['HANDLE KeyedEventHandle', 'PVOID KeyValue', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 388: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6569,6 +6959,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 389 NTSTATUS NtWaitForMultipleObjects ['ULONG Count', 'HANDLE Handles[]', 'WAIT_TYPE WaitType', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 389: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6588,6 +6979,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 390 NTSTATUS NtWaitForMultipleObjects32 ['ULONG Count', 'LONG Handles[]', 'WAIT_TYPE WaitType', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 390: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6607,6 +6999,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 391 NTSTATUS NtWaitForSingleObject ['HANDLE Handle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 391: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6622,6 +7015,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 392 NTSTATUS NtWaitForWorkViaWorkerFactory ['HANDLE WorkerFactoryHandle', 'PFILE_IO_COMPLETION_INFORMATION MiniPacket']
 	case 392: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -6635,6 +7029,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 393 NTSTATUS NtWaitHighEventPair ['HANDLE EventPairHandle']
 	case 393: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6646,6 +7041,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 394 NTSTATUS NtWaitLowEventPair ['HANDLE EventPairHandle']
 	case 394: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6657,6 +7053,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 395 NTSTATUS NtWorkerFactoryWorkerReady ['HANDLE WorkerFactoryHandle']
 	case 395: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -6668,6 +7065,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 396 NTSTATUS NtWriteFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 396: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6695,6 +7093,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 397 NTSTATUS NtWriteFileGather ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PFILE_SEGMENT_ELEMENT SegmentArray', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 397: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6722,6 +7121,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 398 NTSTATUS NtWriteRequestData ['HANDLE PortHandle', 'PPORT_MESSAGE Message', 'ULONG DataEntryIndex', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesWritten']
 	case 398: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6743,6 +7143,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 399 NTSTATUS NtWriteVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesWritten']
 	case 399: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -6762,6 +7163,7 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 	// 400 NTSTATUS NtYieldExecution ['']
 	case 400: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtYieldExecution_enter, cpu, pc);
 	}; break;
 	default:

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp2_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp2_x86.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -48,6 +49,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']
 	case 0: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -69,6 +71,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 1 NTSTATUS NtAccessCheck ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 1: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -94,6 +97,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 2 NTSTATUS NtAccessCheckAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'ACCESS_MASK DesiredAccess', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 2: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -125,6 +129,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 3 NTSTATUS NtAccessCheckByType ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 3: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -156,6 +161,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 4 NTSTATUS NtAccessCheckByTypeAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 4: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -197,6 +203,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 5 NTSTATUS NtAccessCheckByTypeResultList ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 5: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -228,6 +235,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 6 NTSTATUS NtAccessCheckByTypeResultListAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 6: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -269,6 +277,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 7 NTSTATUS NtAccessCheckByTypeResultListAndAuditAlarmByHandle ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'HANDLE ClientToken', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 7: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -312,6 +321,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 8 NTSTATUS NtAddAtom ['PWSTR AtomName', 'ULONG Length', 'PRTL_ATOM Atom']
 	case 8: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -327,6 +337,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 9 NTSTATUS NtAddBootEntry ['PBOOT_ENTRY BootEntry', 'PULONG Id']
 	case 9: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -340,6 +351,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 10 NTSTATUS NtAdjustGroupsToken ['HANDLE TokenHandle', 'BOOLEAN ResetToDefault', 'PTOKEN_GROUPS NewState', 'ULONG BufferLength', 'PTOKEN_GROUPS PreviousState', 'PULONG ReturnLength']
 	case 10: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -361,6 +373,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 11 NTSTATUS NtAdjustPrivilegesToken ['HANDLE TokenHandle', 'BOOLEAN DisableAllPrivileges', 'PTOKEN_PRIVILEGES NewState', 'ULONG BufferLength', 'PTOKEN_PRIVILEGES PreviousState', 'PULONG ReturnLength']
 	case 11: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -382,6 +395,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 12 NTSTATUS NtAlertResumeThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 12: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -395,6 +409,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 13 NTSTATUS NtAlertThread ['HANDLE ThreadHandle']
 	case 13: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -406,6 +421,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 14 NTSTATUS NtAllocateLocallyUniqueId ['PLUID Luid']
 	case 14: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -417,6 +433,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 15 NTSTATUS NtAllocateUserPhysicalPages ['HANDLE ProcessHandle', 'PULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 15: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -432,6 +449,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 16 NTSTATUS NtAllocateUuids ['PULARGE_INTEGER Time', 'PULONG Range', 'PULONG Sequence', 'PCHAR Seed']
 	case 16: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -449,6 +467,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 17 NTSTATUS NtAllocateVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'ULONG_PTR ZeroBits', 'PSIZE_T RegionSize', 'ULONG AllocationType', 'ULONG Protect']
 	case 17: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -470,6 +489,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 18 NTSTATUS NtAreMappedFilesTheSame ['PVOID File1MappedAsAnImage', 'PVOID File2MappedAsFile']
 	case 18: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -483,6 +503,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 19 NTSTATUS NtAssignProcessToJobObject ['HANDLE JobHandle', 'HANDLE ProcessHandle']
 	case 19: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -496,6 +517,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 20 NTSTATUS NtCallbackReturn ['PVOID OutputBuffer', 'ULONG OutputLength', 'NTSTATUS Status']
 	case 20: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -511,6 +533,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 22 NTSTATUS NtCancelIoFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 22: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -524,6 +547,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 23 NTSTATUS NtCancelTimer ['HANDLE TimerHandle', 'PBOOLEAN CurrentState']
 	case 23: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -537,6 +561,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 24 NTSTATUS NtClearEvent ['HANDLE EventHandle']
 	case 24: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -548,6 +573,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 25 NTSTATUS NtClose ['HANDLE Handle']
 	case 25: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -559,6 +585,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 26 NTSTATUS NtCloseObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'BOOLEAN GenerateOnClose']
 	case 26: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -574,6 +601,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 27 NTSTATUS NtCompactKeys ['ULONG Count', 'HANDLE KeyArray[]']
 	case 27: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -587,6 +615,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 28 NTSTATUS NtCompareTokens ['HANDLE FirstTokenHandle', 'HANDLE SecondTokenHandle', 'PBOOLEAN Equal']
 	case 28: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -602,6 +631,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 29 NTSTATUS NtCompleteConnectPort ['HANDLE PortHandle']
 	case 29: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -613,6 +643,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 30 NTSTATUS NtCompressKey ['HANDLE Key']
 	case 30: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -624,6 +655,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 31 NTSTATUS NtConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos', 'PPORT_VIEW ClientView', 'PREMOTE_PORT_VIEW ServerView', 'PULONG MaxMessageLength', 'PVOID ConnectionInformation', 'PULONG ConnectionInformationLength']
 	case 31: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -649,6 +681,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 32 NTSTATUS NtContinue ['PCONTEXT ContextRecord', 'BOOLEAN TestAlert']
 	case 32: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -662,6 +695,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 33 NTSTATUS NtCreateDebugObject ['PHANDLE DebugObjectHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Flags']
 	case 33: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -679,6 +713,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 34 NTSTATUS NtCreateDirectoryObject ['PHANDLE DirectoryHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 34: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -694,6 +729,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 35 NTSTATUS NtCreateEvent ['PHANDLE EventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'EVENT_TYPE EventType', 'BOOLEAN InitialState']
 	case 35: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -713,6 +749,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 36 NTSTATUS NtCreateEventPair ['PHANDLE EventPairHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 36: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -728,6 +765,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 37 NTSTATUS NtCreateFile ['PHANDLE FileHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER AllocationSize', 'ULONG FileAttributes', 'ULONG ShareAccess', 'ULONG CreateDisposition', 'ULONG CreateOptions', 'PVOID EaBuffer', 'ULONG EaLength']
 	case 37: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -759,6 +797,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 38 NTSTATUS NtCreateIoCompletion ['PHANDLE IoCompletionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Count']
 	case 38: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -776,6 +815,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 39 NTSTATUS NtCreateJobObject ['PHANDLE JobHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 39: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -791,6 +831,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 40 NTSTATUS NtCreateJobSet ['ULONG NumJob', 'PJOB_SET_ARRAY UserJobSet', 'ULONG Flags']
 	case 40: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -806,6 +847,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 41 NTSTATUS NtCreateKey ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG TitleIndex', 'PUNICODE_STRING Class', 'ULONG CreateOptions', 'PULONG Disposition']
 	case 41: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -829,6 +871,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 42 NTSTATUS NtCreateMailslotFile ['PHANDLE FileHandle', 'ULONG DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CreateOptions', 'ULONG MailslotQuota', 'ULONG MaximumMessageSize', 'PLARGE_INTEGER ReadTimeout']
 	case 42: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -854,6 +897,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 43 NTSTATUS NtCreateMutant ['PHANDLE MutantHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'BOOLEAN InitialOwner']
 	case 43: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -871,6 +915,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 44 NTSTATUS NtCreateNamedPipeFile ['PHANDLE FileHandle', 'ULONG DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG ShareAccess', 'ULONG CreateDisposition', 'ULONG CreateOptions', 'ULONG NamedPipeType', 'ULONG ReadMode', 'ULONG CompletionMode', 'ULONG MaximumInstances', 'ULONG InboundQuota', 'ULONG OutboundQuota', 'PLARGE_INTEGER DefaultTimeout']
 	case 44: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -908,6 +953,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 45 NTSTATUS NtCreatePagingFile ['PUNICODE_STRING PageFileName', 'PLARGE_INTEGER MinimumSize', 'PLARGE_INTEGER MaximumSize', 'ULONG Priority']
 	case 45: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -925,6 +971,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 46 NTSTATUS NtCreatePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG MaxConnectionInfoLength', 'ULONG MaxMessageLength', 'ULONG MaxPoolUsage']
 	case 46: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -944,6 +991,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 47 NTSTATUS NtCreateProcess ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ParentProcess', 'BOOLEAN InheritObjectTable', 'HANDLE SectionHandle', 'HANDLE DebugPort', 'HANDLE ExceptionPort']
 	case 47: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -969,6 +1017,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 48 NTSTATUS NtCreateProcessEx ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ParentProcess', 'ULONG Flags', 'HANDLE SectionHandle', 'HANDLE DebugPort', 'HANDLE ExceptionPort', 'ULONG JobMemberLevel']
 	case 48: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -996,6 +1045,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 49 NTSTATUS NtCreateProfile ['PHANDLE ProfileHandle', 'HANDLE Process', 'PVOID RangeBase', 'SIZE_T RangeSize', 'ULONG BucketSize', 'PULONG Buffer', 'ULONG BufferSize', 'KPROFILE_SOURCE ProfileSource', 'KAFFINITY Affinity']
 	case 49: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1023,6 +1073,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 50 NTSTATUS NtCreateSection ['PHANDLE SectionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PLARGE_INTEGER MaximumSize', 'ULONG SectionPageProtection', 'ULONG AllocationAttributes', 'HANDLE FileHandle']
 	case 50: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1046,6 +1097,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 51 NTSTATUS NtCreateSemaphore ['PHANDLE SemaphoreHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'LONG InitialCount', 'LONG MaximumCount']
 	case 51: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1065,6 +1117,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 52 NTSTATUS NtCreateSymbolicLinkObject ['PHANDLE LinkHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PUNICODE_STRING LinkTarget']
 	case 52: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1082,6 +1135,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 53 NTSTATUS NtCreateThread ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ProcessHandle', 'PCLIENT_ID ClientId', 'PCONTEXT ThreadContext', 'PINITIAL_TEB InitialTeb', 'BOOLEAN CreateSuspended']
 	case 53: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1107,6 +1161,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 54 NTSTATUS NtCreateTimer ['PHANDLE TimerHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'TIMER_TYPE TimerType']
 	case 54: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1124,6 +1179,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 55 NTSTATUS NtCreateToken ['PHANDLE TokenHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'TOKEN_TYPE TokenType', 'PLUID AuthenticationId', 'PLARGE_INTEGER ExpirationTime', 'PTOKEN_USER User', 'PTOKEN_GROUPS Groups', 'PTOKEN_PRIVILEGES Privileges', 'PTOKEN_OWNER Owner', 'PTOKEN_PRIMARY_GROUP PrimaryGroup', 'PTOKEN_DEFAULT_DACL DefaultDacl', 'PTOKEN_SOURCE TokenSource']
 	case 55: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1159,6 +1215,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 56 NTSTATUS NtCreateWaitablePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG MaxConnectionInfoLength', 'ULONG MaxMessageLength', 'ULONG MaxPoolUsage']
 	case 56: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1178,6 +1235,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 57 NTSTATUS NtDebugActiveProcess ['HANDLE ProcessHandle', 'HANDLE DebugObjectHandle']
 	case 57: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1191,6 +1249,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 58 NTSTATUS NtDebugContinue ['HANDLE DebugObjectHandle', 'PCLIENT_ID ClientId', 'NTSTATUS ContinueStatus']
 	case 58: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1206,6 +1265,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 59 NTSTATUS NtDelayExecution ['BOOLEAN Alertable', 'PLARGE_INTEGER DelayInterval']
 	case 59: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1219,6 +1279,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 60 NTSTATUS NtDeleteAtom ['RTL_ATOM Atom']
 	case 60: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1230,6 +1291,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 61 NTSTATUS NtDeleteBootEntry ['ULONG Id']
 	case 61: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1241,6 +1303,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 62 NTSTATUS NtDeleteFile ['POBJECT_ATTRIBUTES ObjectAttributes']
 	case 62: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1252,6 +1315,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 63 NTSTATUS NtDeleteKey ['HANDLE KeyHandle']
 	case 63: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1263,6 +1327,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 64 NTSTATUS NtDeleteObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'BOOLEAN GenerateOnClose']
 	case 64: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1278,6 +1343,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 65 NTSTATUS NtDeleteValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName']
 	case 65: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1291,6 +1357,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 66 NTSTATUS NtDeviceIoControlFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG IoControlCode', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 66: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1320,6 +1387,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 67 NTSTATUS NtDisplayString ['PUNICODE_STRING String']
 	case 67: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1331,6 +1399,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 68 NTSTATUS NtDuplicateObject ['HANDLE SourceProcessHandle', 'HANDLE SourceHandle', 'HANDLE TargetProcessHandle', 'PHANDLE TargetHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'ULONG Options']
 	case 68: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1354,6 +1423,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 69 NTSTATUS NtDuplicateToken ['HANDLE ExistingTokenHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'BOOLEAN EffectiveOnly', 'TOKEN_TYPE TokenType', 'PHANDLE NewTokenHandle']
 	case 69: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1375,6 +1445,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 70 NTSTATUS NtEnumerateBootEntries ['PVOID Buffer', 'PULONG BufferLength']
 	case 70: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1388,6 +1459,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 71 NTSTATUS NtEnumerateKey ['HANDLE KeyHandle', 'ULONG Index', 'KEY_INFORMATION_CLASS KeyInformationClass', 'PVOID KeyInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 71: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1409,6 +1481,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 72 NTSTATUS NtEnumerateSystemEnvironmentValuesEx ['ULONG InformationClass', 'PVOID Buffer', 'PULONG BufferLength']
 	case 72: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1424,6 +1497,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 73 NTSTATUS NtEnumerateValueKey ['HANDLE KeyHandle', 'ULONG Index', 'KEY_VALUE_INFORMATION_CLASS KeyValueInformationClass', 'PVOID KeyValueInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 73: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1445,6 +1519,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 74 NTSTATUS NtExtendSection ['HANDLE SectionHandle', 'PLARGE_INTEGER NewSectionSize']
 	case 74: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1458,6 +1533,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 75 NTSTATUS NtFilterToken ['HANDLE ExistingTokenHandle', 'ULONG Flags', 'PTOKEN_GROUPS SidsToDisable', 'PTOKEN_PRIVILEGES PrivilegesToDelete', 'PTOKEN_GROUPS RestrictedSids', 'PHANDLE NewTokenHandle']
 	case 75: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1479,6 +1555,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 76 NTSTATUS NtFindAtom ['PWSTR AtomName', 'ULONG Length', 'PRTL_ATOM Atom']
 	case 76: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1494,6 +1571,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 77 NTSTATUS NtFlushBuffersFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 77: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1507,6 +1585,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 78 NTSTATUS NtFlushInstructionCache ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'SIZE_T Length']
 	case 78: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1522,6 +1601,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 79 NTSTATUS NtFlushKey ['HANDLE KeyHandle']
 	case 79: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1533,6 +1613,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 80 NTSTATUS NtFlushVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'PIO_STATUS_BLOCK IoStatus']
 	case 80: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1550,11 +1631,13 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 81 NTSTATUS NtFlushWriteBuffer ['']
 	case 81: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtFlushWriteBuffer_enter, cpu, pc);
 	}; break;
 	// 82 NTSTATUS NtFreeUserPhysicalPages ['HANDLE ProcessHandle', 'PULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 82: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1570,6 +1653,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 83 NTSTATUS NtFreeVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG FreeType']
 	case 83: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1587,6 +1671,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 84 NTSTATUS NtFsControlFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG IoControlCode', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 84: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1616,6 +1701,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 85 NTSTATUS NtGetContextThread ['HANDLE ThreadHandle', 'PCONTEXT ThreadContext']
 	case 85: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1629,6 +1715,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 86 NTSTATUS NtGetDevicePowerState ['HANDLE Device', 'DEVICE_POWER_STATE *State']
 	case 86: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1642,6 +1729,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 87 NTSTATUS NtGetPlugPlayEvent ['HANDLE EventHandle', 'PVOID Context', 'PPLUGPLAY_EVENT_BLOCK EventBlock', 'ULONG EventBufferSize']
 	case 87: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1659,6 +1747,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 88 NTSTATUS NtGetWriteWatch ['HANDLE ProcessHandle', 'ULONG Flags', 'PVOID BaseAddress', 'SIZE_T RegionSize', 'PVOID *UserAddressArray', 'PULONG_PTR EntriesInUserAddressArray', 'PULONG Granularity']
 	case 88: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1682,6 +1771,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 89 NTSTATUS NtImpersonateAnonymousToken ['HANDLE ThreadHandle']
 	case 89: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1693,6 +1783,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 90 NTSTATUS NtImpersonateClientOfPort ['HANDLE PortHandle', 'PPORT_MESSAGE Message']
 	case 90: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1706,6 +1797,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 91 NTSTATUS NtImpersonateThread ['HANDLE ServerThreadHandle', 'HANDLE ClientThreadHandle', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos']
 	case 91: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1721,6 +1813,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 92 NTSTATUS NtInitializeRegistry ['USHORT BootCondition']
 	case 92: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1732,6 +1825,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 93 NTSTATUS NtInitiatePowerAction ['POWER_ACTION SystemAction', 'SYSTEM_POWER_STATE MinSystemState', 'ULONG Flags', 'BOOLEAN Asynchronous']
 	case 93: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1749,6 +1843,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 94 NTSTATUS NtIsProcessInJob ['HANDLE ProcessHandle', 'HANDLE JobHandle']
 	case 94: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1762,11 +1857,13 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 95 BOOLEAN NtIsSystemResumeAutomatic ['']
 	case 95: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtIsSystemResumeAutomatic_enter, cpu, pc);
 	}; break;
 	// 96 NTSTATUS NtListenPort ['HANDLE PortHandle', 'PPORT_MESSAGE ConnectionRequest']
 	case 96: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1780,6 +1877,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 97 NTSTATUS NtLoadDriver ['PUNICODE_STRING DriverServiceName']
 	case 97: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1791,6 +1889,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 98 NTSTATUS NtLoadKey ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile']
 	case 98: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1804,6 +1903,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 99 NTSTATUS NtLoadKey2 ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile', 'ULONG Flags']
 	case 99: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1819,6 +1919,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 100 NTSTATUS NtLockFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER ByteOffset', 'PLARGE_INTEGER Length', 'ULONG Key', 'BOOLEAN FailImmediately', 'BOOLEAN ExclusiveLock']
 	case 100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1848,6 +1949,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 101 NTSTATUS NtLockProductActivationKeys ['ULONG *pPrivateVer', 'ULONG *pSafeMode']
 	case 101: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1861,6 +1963,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 102 NTSTATUS NtLockRegistryKey ['HANDLE KeyHandle']
 	case 102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1872,6 +1975,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 103 NTSTATUS NtLockVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG MapType']
 	case 103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1889,6 +1993,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 104 NTSTATUS NtMakePermanentObject ['HANDLE Handle']
 	case 104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1900,6 +2005,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 105 NTSTATUS NtMakeTemporaryObject ['HANDLE Handle']
 	case 105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1911,6 +2017,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 106 NTSTATUS NtMapUserPhysicalPages ['PVOID VirtualAddress', 'ULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1926,6 +2033,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 107 NTSTATUS NtMapUserPhysicalPagesScatter ['PVOID *VirtualAddresses', 'ULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 107: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1941,6 +2049,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 108 NTSTATUS NtMapViewOfSection ['HANDLE SectionHandle', 'HANDLE ProcessHandle', 'PVOID *BaseAddress', 'ULONG_PTR ZeroBits', 'SIZE_T CommitSize', 'PLARGE_INTEGER SectionOffset', 'PSIZE_T ViewSize', 'SECTION_INHERIT InheritDisposition', 'ULONG AllocationType', 'WIN32_PROTECTION_MASK Win32Protect']
 	case 108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1970,6 +2079,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 109 NTSTATUS NtModifyBootEntry ['PBOOT_ENTRY BootEntry']
 	case 109: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1981,6 +2091,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 110 NTSTATUS NtNotifyChangeDirectoryFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'ULONG CompletionFilter', 'BOOLEAN WatchTree']
 	case 110: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2008,6 +2119,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 111 NTSTATUS NtNotifyChangeKey ['HANDLE KeyHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CompletionFilter', 'BOOLEAN WatchTree', 'PVOID Buffer', 'ULONG BufferSize', 'BOOLEAN Asynchronous']
 	case 111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2037,6 +2149,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 112 NTSTATUS NtNotifyChangeMultipleKeys ['HANDLE MasterKeyHandle', 'ULONG Count', 'OBJECT_ATTRIBUTES SlaveObjects[]', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CompletionFilter', 'BOOLEAN WatchTree', 'PVOID Buffer', 'ULONG BufferSize', 'BOOLEAN Asynchronous']
 	case 112: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2070,6 +2183,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 113 NTSTATUS NtOpenDirectoryObject ['PHANDLE DirectoryHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 113: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2085,6 +2199,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 114 NTSTATUS NtOpenEvent ['PHANDLE EventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2100,6 +2215,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 115 NTSTATUS NtOpenEventPair ['PHANDLE EventPairHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 115: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2115,6 +2231,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 116 NTSTATUS NtOpenFile ['PHANDLE FileHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG ShareAccess', 'ULONG OpenOptions']
 	case 116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2136,6 +2253,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 117 NTSTATUS NtOpenIoCompletion ['PHANDLE IoCompletionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2151,6 +2269,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 118 NTSTATUS NtOpenJobObject ['PHANDLE JobHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2166,6 +2285,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 119 NTSTATUS NtOpenKey ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 119: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2181,6 +2301,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 120 NTSTATUS NtOpenMutant ['PHANDLE MutantHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2196,6 +2317,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 121 NTSTATUS NtOpenObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'ACCESS_MASK GrantedAccess', 'PPRIVILEGE_SET Privileges', 'BOOLEAN ObjectCreation', 'BOOLEAN AccessGranted', 'PBOOLEAN GenerateOnClose']
 	case 121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2229,6 +2351,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 122 NTSTATUS NtOpenProcess ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PCLIENT_ID ClientId']
 	case 122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2246,6 +2369,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 123 NTSTATUS NtOpenProcessToken ['HANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'PHANDLE TokenHandle']
 	case 123: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2261,6 +2385,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 124 NTSTATUS NtOpenProcessTokenEx ['HANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'PHANDLE TokenHandle']
 	case 124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2278,6 +2403,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 125 NTSTATUS NtOpenSection ['PHANDLE SectionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2293,6 +2419,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 126 NTSTATUS NtOpenSemaphore ['PHANDLE SemaphoreHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2308,6 +2435,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 127 NTSTATUS NtOpenSymbolicLinkObject ['PHANDLE LinkHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 127: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2323,6 +2451,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 128 NTSTATUS NtOpenThread ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PCLIENT_ID ClientId']
 	case 128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2340,6 +2469,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 129 NTSTATUS NtOpenThreadToken ['HANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'BOOLEAN OpenAsSelf', 'PHANDLE TokenHandle']
 	case 129: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2357,6 +2487,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 130 NTSTATUS NtOpenThreadTokenEx ['HANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'BOOLEAN OpenAsSelf', 'ULONG HandleAttributes', 'PHANDLE TokenHandle']
 	case 130: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2376,6 +2507,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 131 NTSTATUS NtOpenTimer ['PHANDLE TimerHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2391,6 +2523,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 132 NTSTATUS NtPlugPlayControl ['PLUGPLAY_CONTROL_CLASS PnPControlClass', 'PVOID PnPControlData', 'ULONG PnPControlDataLength']
 	case 132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2406,6 +2539,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 133 NTSTATUS NtPowerInformation ['POWER_INFORMATION_LEVEL InformationLevel', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2425,6 +2559,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 134 NTSTATUS NtPrivilegeCheck ['HANDLE ClientToken', 'PPRIVILEGE_SET RequiredPrivileges', 'PBOOLEAN Result']
 	case 134: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2440,6 +2575,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 135 NTSTATUS NtPrivilegeObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'PPRIVILEGE_SET Privileges', 'BOOLEAN AccessGranted']
 	case 135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2461,6 +2597,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 136 NTSTATUS NtPrivilegedServiceAuditAlarm ['PUNICODE_STRING SubsystemName', 'PUNICODE_STRING ServiceName', 'HANDLE ClientToken', 'PPRIVILEGE_SET Privileges', 'BOOLEAN AccessGranted']
 	case 136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2480,6 +2617,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 137 NTSTATUS NtProtectVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'WIN32_PROTECTION_MASK NewProtectWin32', 'PULONG OldProtect']
 	case 137: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2499,6 +2637,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 138 NTSTATUS NtPulseEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2512,6 +2651,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 139 NTSTATUS NtQueryAttributesFile ['POBJECT_ATTRIBUTES ObjectAttributes', 'PFILE_BASIC_INFORMATION FileInformation']
 	case 139: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2525,6 +2665,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 140 NTSTATUS NtQueryBootEntryOrder ['PULONG Ids', 'PULONG Count']
 	case 140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2538,6 +2679,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 141 NTSTATUS NtQueryBootOptions ['PBOOT_OPTIONS BootOptions', 'PULONG BootOptionsLength']
 	case 141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2551,6 +2693,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 142 NTSTATUS NtQueryDebugFilterState ['ULONG ComponentId', 'ULONG Level']
 	case 142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2564,6 +2707,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 143 NTSTATUS NtQueryDefaultLocale ['BOOLEAN UserProfile', 'PLCID DefaultLocaleId']
 	case 143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2577,6 +2721,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 144 NTSTATUS NtQueryDefaultUILanguage ['LANGID *DefaultUILanguageId']
 	case 144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2588,6 +2733,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 145 NTSTATUS NtQueryDirectoryFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass', 'BOOLEAN ReturnSingleEntry', 'PUNICODE_STRING FileName', 'BOOLEAN RestartScan']
 	case 145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2619,6 +2765,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 146 NTSTATUS NtQueryDirectoryObject ['HANDLE DirectoryHandle', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'BOOLEAN RestartScan', 'PULONG Context', 'PULONG ReturnLength']
 	case 146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2642,6 +2789,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 147 NTSTATUS NtQueryEaFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'PVOID EaList', 'ULONG EaListLength', 'PULONG EaIndex', 'BOOLEAN RestartScan']
 	case 147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2669,6 +2817,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 148 NTSTATUS NtQueryEvent ['HANDLE EventHandle', 'EVENT_INFORMATION_CLASS EventInformationClass', 'PVOID EventInformation', 'ULONG EventInformationLength', 'PULONG ReturnLength']
 	case 148: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2688,6 +2837,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 149 NTSTATUS NtQueryFullAttributesFile ['POBJECT_ATTRIBUTES ObjectAttributes', 'PFILE_NETWORK_OPEN_INFORMATION FileInformation']
 	case 149: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2701,6 +2851,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 150 NTSTATUS NtQueryInformationAtom ['RTL_ATOM Atom', 'ATOM_INFORMATION_CLASS InformationClass', 'PVOID AtomInformation', 'ULONG AtomInformationLength', 'PULONG ReturnLength']
 	case 150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2720,6 +2871,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 151 NTSTATUS NtQueryInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass']
 	case 151: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2739,6 +2891,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 152 NTSTATUS NtQueryInformationJobObject ['HANDLE JobHandle', 'JOBOBJECTINFOCLASS JobObjectInformationClass', 'PVOID JobObjectInformation', 'ULONG JobObjectInformationLength', 'PULONG ReturnLength']
 	case 152: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2758,6 +2911,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 153 NTSTATUS NtQueryInformationPort ['HANDLE PortHandle', 'PORT_INFORMATION_CLASS PortInformationClass', 'PVOID PortInformation', 'ULONG Length', 'PULONG ReturnLength']
 	case 153: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2777,6 +2931,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 154 NTSTATUS NtQueryInformationProcess ['HANDLE ProcessHandle', 'PROCESSINFOCLASS ProcessInformationClass', 'PVOID ProcessInformation', 'ULONG ProcessInformationLength', 'PULONG ReturnLength']
 	case 154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2796,6 +2951,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 155 NTSTATUS NtQueryInformationThread ['HANDLE ThreadHandle', 'THREADINFOCLASS ThreadInformationClass', 'PVOID ThreadInformation', 'ULONG ThreadInformationLength', 'PULONG ReturnLength']
 	case 155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2815,6 +2971,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 156 NTSTATUS NtQueryInformationToken ['HANDLE TokenHandle', 'TOKEN_INFORMATION_CLASS TokenInformationClass', 'PVOID TokenInformation', 'ULONG TokenInformationLength', 'PULONG ReturnLength']
 	case 156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2834,6 +2991,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 157 NTSTATUS NtQueryInstallUILanguage ['LANGID *InstallUILanguageId']
 	case 157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2845,6 +3003,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 158 NTSTATUS NtQueryIntervalProfile ['KPROFILE_SOURCE ProfileSource', 'PULONG Interval']
 	case 158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2858,6 +3017,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 159 NTSTATUS NtQueryIoCompletion ['HANDLE IoCompletionHandle', 'IO_COMPLETION_INFORMATION_CLASS IoCompletionInformationClass', 'PVOID IoCompletionInformation', 'ULONG IoCompletionInformationLength', 'PULONG ReturnLength']
 	case 159: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2877,6 +3037,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 160 NTSTATUS NtQueryKey ['HANDLE KeyHandle', 'KEY_INFORMATION_CLASS KeyInformationClass', 'PVOID KeyInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2896,6 +3057,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 161 NTSTATUS NtQueryMultipleValueKey ['HANDLE KeyHandle', 'PKEY_VALUE_ENTRY ValueEntries', 'ULONG EntryCount', 'PVOID ValueBuffer', 'PULONG BufferLength', 'PULONG RequiredBufferLength']
 	case 161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2917,6 +3079,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 162 NTSTATUS NtQueryMutant ['HANDLE MutantHandle', 'MUTANT_INFORMATION_CLASS MutantInformationClass', 'PVOID MutantInformation', 'ULONG MutantInformationLength', 'PULONG ReturnLength']
 	case 162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2936,6 +3099,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 163 NTSTATUS NtQueryObject ['HANDLE Handle', 'OBJECT_INFORMATION_CLASS ObjectInformationClass', 'PVOID ObjectInformation', 'ULONG ObjectInformationLength', 'PULONG ReturnLength']
 	case 163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2955,6 +3119,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 164 NTSTATUS NtQueryOpenSubKeys ['POBJECT_ATTRIBUTES TargetKey', 'PULONG HandleCount']
 	case 164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2968,6 +3133,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 165 NTSTATUS NtQueryPerformanceCounter ['PLARGE_INTEGER PerformanceCounter', 'PLARGE_INTEGER PerformanceFrequency']
 	case 165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2981,6 +3147,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 166 NTSTATUS NtQueryQuotaInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'PVOID SidList', 'ULONG SidListLength', 'PULONG StartSid', 'BOOLEAN RestartScan']
 	case 166: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3008,6 +3175,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 167 NTSTATUS NtQuerySection ['HANDLE SectionHandle', 'SECTION_INFORMATION_CLASS SectionInformationClass', 'PVOID SectionInformation', 'SIZE_T SectionInformationLength', 'PSIZE_T ReturnLength']
 	case 167: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3027,6 +3195,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 168 NTSTATUS NtQuerySecurityObject ['HANDLE Handle', 'SECURITY_INFORMATION SecurityInformation', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'ULONG Length', 'PULONG LengthNeeded']
 	case 168: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3046,6 +3215,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 169 NTSTATUS NtQuerySemaphore ['HANDLE SemaphoreHandle', 'SEMAPHORE_INFORMATION_CLASS SemaphoreInformationClass', 'PVOID SemaphoreInformation', 'ULONG SemaphoreInformationLength', 'PULONG ReturnLength']
 	case 169: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3065,6 +3235,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 170 NTSTATUS NtQuerySymbolicLinkObject ['HANDLE LinkHandle', 'PUNICODE_STRING LinkTarget', 'PULONG ReturnedLength']
 	case 170: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3080,6 +3251,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 171 NTSTATUS NtQuerySystemEnvironmentValue ['PUNICODE_STRING VariableName', 'PWSTR VariableValue', 'USHORT ValueLength', 'PUSHORT ReturnLength']
 	case 171: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3097,6 +3269,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 172 NTSTATUS NtQuerySystemEnvironmentValueEx ['PUNICODE_STRING VariableName', 'LPGUID VendorGuid', 'PVOID Value', 'PULONG ValueLength', 'PULONG Attributes']
 	case 172: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3116,6 +3289,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 173 NTSTATUS NtQuerySystemInformation ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID SystemInformation', 'ULONG SystemInformationLength', 'PULONG ReturnLength']
 	case 173: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3133,6 +3307,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 174 NTSTATUS NtQuerySystemTime ['PLARGE_INTEGER SystemTime']
 	case 174: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3144,6 +3319,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 175 NTSTATUS NtQueryTimer ['HANDLE TimerHandle', 'TIMER_INFORMATION_CLASS TimerInformationClass', 'PVOID TimerInformation', 'ULONG TimerInformationLength', 'PULONG ReturnLength']
 	case 175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3163,6 +3339,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 176 NTSTATUS NtQueryTimerResolution ['PULONG MaximumTime', 'PULONG MinimumTime', 'PULONG CurrentTime']
 	case 176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3178,6 +3355,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 177 NTSTATUS NtQueryValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName', 'KEY_VALUE_INFORMATION_CLASS KeyValueInformationClass', 'PVOID KeyValueInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 177: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3199,6 +3377,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 178 NTSTATUS NtQueryVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'MEMORY_INFORMATION_CLASS MemoryInformationClass', 'PVOID MemoryInformation', 'SIZE_T MemoryInformationLength', 'PSIZE_T ReturnLength']
 	case 178: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3220,6 +3399,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 179 NTSTATUS NtQueryVolumeInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FsInformation', 'ULONG Length', 'FS_INFORMATION_CLASS FsInformationClass']
 	case 179: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3239,6 +3419,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 180 NTSTATUS NtQueueApcThread ['HANDLE ThreadHandle', 'PPS_APC_ROUTINE ApcRoutine', 'PVOID ApcArgument1', 'PVOID ApcArgument2', 'PVOID ApcArgument3']
 	case 180: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3258,6 +3439,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 181 NTSTATUS NtRaiseException ['PEXCEPTION_RECORD ExceptionRecord', 'PCONTEXT ContextRecord', 'BOOLEAN FirstChance']
 	case 181: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3273,6 +3455,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 182 NTSTATUS NtRaiseHardError ['NTSTATUS ErrorStatus', 'ULONG NumberOfParameters', 'ULONG UnicodeStringParameterMask', 'PULONG_PTR Parameters', 'ULONG ValidResponseOptions', 'PULONG Response']
 	case 182: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3294,6 +3477,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 183 NTSTATUS NtReadFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 183: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3321,6 +3505,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 184 NTSTATUS NtReadFileScatter ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PFILE_SEGMENT_ELEMENT SegmentArray', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 184: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3348,6 +3533,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 185 NTSTATUS NtReadRequestData ['HANDLE PortHandle', 'PPORT_MESSAGE Message', 'ULONG DataEntryIndex', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesRead']
 	case 185: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3369,6 +3555,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 186 NTSTATUS NtReadVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesRead']
 	case 186: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3388,6 +3575,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 187 NTSTATUS NtRegisterThreadTerminatePort ['HANDLE PortHandle']
 	case 187: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3399,6 +3587,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 188 NTSTATUS NtReleaseMutant ['HANDLE MutantHandle', 'PLONG PreviousCount']
 	case 188: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3412,6 +3601,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 189 NTSTATUS NtReleaseSemaphore ['HANDLE SemaphoreHandle', 'LONG ReleaseCount', 'PLONG PreviousCount']
 	case 189: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3427,6 +3617,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 190 NTSTATUS NtRemoveIoCompletion ['HANDLE IoCompletionHandle', 'PVOID *KeyContext', 'PVOID *ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER Timeout']
 	case 190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3446,6 +3637,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 191 NTSTATUS NtRemoveProcessDebug ['HANDLE ProcessHandle', 'HANDLE DebugObjectHandle']
 	case 191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3459,6 +3651,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 192 NTSTATUS NtRenameKey ['HANDLE KeyHandle', 'PUNICODE_STRING NewName']
 	case 192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3472,6 +3665,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 193 NTSTATUS NtReplaceKey ['POBJECT_ATTRIBUTES NewFile', 'HANDLE TargetHandle', 'POBJECT_ATTRIBUTES OldFile']
 	case 193: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3487,6 +3681,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 194 NTSTATUS NtReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE ReplyMessage']
 	case 194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3500,6 +3695,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 195 NTSTATUS NtReplyWaitReceivePort ['HANDLE PortHandle', 'PVOID *PortContext', 'PPORT_MESSAGE ReplyMessage', 'PPORT_MESSAGE ReceiveMessage']
 	case 195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3517,6 +3713,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 196 NTSTATUS NtReplyWaitReceivePortEx ['HANDLE PortHandle', 'PVOID *PortContext', 'PPORT_MESSAGE ReplyMessage', 'PPORT_MESSAGE ReceiveMessage', 'PLARGE_INTEGER Timeout']
 	case 196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3536,6 +3733,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 197 NTSTATUS NtReplyWaitReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE ReplyMessage']
 	case 197: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3549,6 +3747,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 199 NTSTATUS NtRequestPort ['HANDLE PortHandle', 'PPORT_MESSAGE RequestMessage']
 	case 199: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3562,6 +3761,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 200 NTSTATUS NtRequestWaitReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE RequestMessage', 'PPORT_MESSAGE ReplyMessage']
 	case 200: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3577,6 +3777,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 202 NTSTATUS NtResetEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3590,6 +3791,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 203 NTSTATUS NtResetWriteWatch ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'SIZE_T RegionSize']
 	case 203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3605,6 +3807,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 204 NTSTATUS NtRestoreKey ['HANDLE KeyHandle', 'HANDLE FileHandle', 'ULONG Flags']
 	case 204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3620,6 +3823,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 205 NTSTATUS NtResumeProcess ['HANDLE ProcessHandle']
 	case 205: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3631,6 +3835,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 206 NTSTATUS NtResumeThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3644,6 +3849,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 207 NTSTATUS NtSaveKey ['HANDLE KeyHandle', 'HANDLE FileHandle']
 	case 207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3657,6 +3863,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 208 NTSTATUS NtSaveKeyEx ['HANDLE KeyHandle', 'HANDLE FileHandle', 'ULONG Format']
 	case 208: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3672,6 +3879,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 209 NTSTATUS NtSaveMergedKeys ['HANDLE HighPrecedenceKeyHandle', 'HANDLE LowPrecedenceKeyHandle', 'HANDLE FileHandle']
 	case 209: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3687,6 +3895,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 210 NTSTATUS NtSecureConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos', 'PPORT_VIEW ClientView', 'PSID RequiredServerSid', 'PREMOTE_PORT_VIEW ServerView', 'PULONG MaxMessageLength', 'PVOID ConnectionInformation', 'PULONG ConnectionInformationLength']
 	case 210: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3714,6 +3923,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 211 NTSTATUS NtSetBootEntryOrder ['PULONG Ids', 'ULONG Count']
 	case 211: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3727,6 +3937,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 212 NTSTATUS NtSetBootOptions ['PBOOT_OPTIONS BootOptions', 'ULONG FieldsToChange']
 	case 212: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3740,6 +3951,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 213 NTSTATUS NtSetContextThread ['HANDLE ThreadHandle', 'PCONTEXT ThreadContext']
 	case 213: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3753,6 +3965,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 214 NTSTATUS NtSetDebugFilterState ['ULONG ComponentId', 'ULONG Level', 'BOOLEAN State']
 	case 214: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3768,6 +3981,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 215 NTSTATUS NtSetDefaultHardErrorPort ['HANDLE DefaultHardErrorPort']
 	case 215: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3779,6 +3993,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 216 NTSTATUS NtSetDefaultLocale ['BOOLEAN UserProfile', 'LCID DefaultLocaleId']
 	case 216: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3792,6 +4007,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 217 NTSTATUS NtSetDefaultUILanguage ['LANGID DefaultUILanguageId']
 	case 217: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3803,6 +4019,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 218 NTSTATUS NtSetEaFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length']
 	case 218: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3820,6 +4037,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 219 NTSTATUS NtSetEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 219: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3833,6 +4051,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 220 NTSTATUS NtSetEventBoostPriority ['HANDLE EventHandle']
 	case 220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3844,6 +4063,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 221 NTSTATUS NtSetHighEventPair ['HANDLE EventPairHandle']
 	case 221: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3855,6 +4075,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 222 NTSTATUS NtSetHighWaitLowEventPair ['HANDLE EventPairHandle']
 	case 222: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3866,6 +4087,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 223 NTSTATUS NtSetInformationDebugObject ['HANDLE DebugObjectHandle', 'DEBUGOBJECTINFOCLASS DebugObjectInformationClass', 'PVOID DebugInformation', 'ULONG DebugInformationLength', 'PULONG ReturnLength']
 	case 223: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3885,6 +4107,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 224 NTSTATUS NtSetInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass']
 	case 224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3904,6 +4127,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 225 NTSTATUS NtSetInformationJobObject ['HANDLE JobHandle', 'JOBOBJECTINFOCLASS JobObjectInformationClass', 'PVOID JobObjectInformation', 'ULONG JobObjectInformationLength']
 	case 225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3921,6 +4145,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 226 NTSTATUS NtSetInformationKey ['HANDLE KeyHandle', 'KEY_SET_INFORMATION_CLASS KeySetInformationClass', 'PVOID KeySetInformation', 'ULONG KeySetInformationLength']
 	case 226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3938,6 +4163,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 227 NTSTATUS NtSetInformationObject ['HANDLE Handle', 'OBJECT_INFORMATION_CLASS ObjectInformationClass', 'PVOID ObjectInformation', 'ULONG ObjectInformationLength']
 	case 227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3955,6 +4181,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 228 NTSTATUS NtSetInformationProcess ['HANDLE ProcessHandle', 'PROCESSINFOCLASS ProcessInformationClass', 'PVOID ProcessInformation', 'ULONG ProcessInformationLength']
 	case 228: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3972,6 +4199,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 229 NTSTATUS NtSetInformationThread ['HANDLE ThreadHandle', 'THREADINFOCLASS ThreadInformationClass', 'PVOID ThreadInformation', 'ULONG ThreadInformationLength']
 	case 229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3989,6 +4217,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 230 NTSTATUS NtSetInformationToken ['HANDLE TokenHandle', 'TOKEN_INFORMATION_CLASS TokenInformationClass', 'PVOID TokenInformation', 'ULONG TokenInformationLength']
 	case 230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4006,6 +4235,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 231 NTSTATUS NtSetIntervalProfile ['ULONG Interval', 'KPROFILE_SOURCE Source']
 	case 231: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4019,6 +4249,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 232 NTSTATUS NtSetIoCompletion ['HANDLE IoCompletionHandle', 'PVOID KeyContext', 'PVOID ApcContext', 'NTSTATUS IoStatus', 'ULONG_PTR IoStatusInformation']
 	case 232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4038,6 +4269,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 233 NTSTATUS NtSetLdtEntries ['ULONG Selector0', 'ULONG Entry0Low', 'ULONG Entry0Hi', 'ULONG Selector1', 'ULONG Entry1Low', 'ULONG Entry1Hi']
 	case 233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4059,6 +4291,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 234 NTSTATUS NtSetLowEventPair ['HANDLE EventPairHandle']
 	case 234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4070,6 +4303,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 235 NTSTATUS NtSetLowWaitHighEventPair ['HANDLE EventPairHandle']
 	case 235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4081,6 +4315,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 236 NTSTATUS NtSetQuotaInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length']
 	case 236: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4098,6 +4333,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 237 NTSTATUS NtSetSecurityObject ['HANDLE Handle', 'SECURITY_INFORMATION SecurityInformation', 'PSECURITY_DESCRIPTOR SecurityDescriptor']
 	case 237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4113,6 +4349,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 238 NTSTATUS NtSetSystemEnvironmentValue ['PUNICODE_STRING VariableName', 'PUNICODE_STRING VariableValue']
 	case 238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4126,6 +4363,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 239 NTSTATUS NtSetSystemEnvironmentValueEx ['PUNICODE_STRING VariableName', 'LPGUID VendorGuid', 'PVOID Value', 'ULONG ValueLength', 'ULONG Attributes']
 	case 239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4145,6 +4383,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 240 NTSTATUS NtSetSystemInformation ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID SystemInformation', 'ULONG SystemInformationLength']
 	case 240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4160,6 +4399,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 241 NTSTATUS NtSetSystemPowerState ['POWER_ACTION SystemAction', 'SYSTEM_POWER_STATE MinSystemState', 'ULONG Flags']
 	case 241: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4175,6 +4415,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 242 NTSTATUS NtSetSystemTime ['PLARGE_INTEGER SystemTime', 'PLARGE_INTEGER PreviousTime']
 	case 242: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4188,6 +4429,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 243 NTSTATUS NtSetThreadExecutionState ['EXECUTION_STATE esFlags', 'PEXECUTION_STATE PreviousFlags']
 	case 243: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4201,6 +4443,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 244 NTSTATUS NtSetTimer ['HANDLE TimerHandle', 'PLARGE_INTEGER DueTime', 'PTIMER_APC_ROUTINE TimerApcRoutine', 'PVOID TimerContext', 'BOOLEAN WakeTimer', 'LONG Period', 'PBOOLEAN PreviousState']
 	case 244: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4224,6 +4467,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 245 NTSTATUS NtSetTimerResolution ['ULONG DesiredTime', 'BOOLEAN SetResolution', 'PULONG ActualTime']
 	case 245: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4239,6 +4483,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 246 NTSTATUS NtSetUuidSeed ['PCHAR Seed']
 	case 246: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4250,6 +4495,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 247 NTSTATUS NtSetValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName', 'ULONG TitleIndex', 'ULONG Type', 'PVOID Data', 'ULONG DataSize']
 	case 247: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4271,6 +4517,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 248 NTSTATUS NtSetVolumeInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FsInformation', 'ULONG Length', 'FS_INFORMATION_CLASS FsInformationClass']
 	case 248: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4290,6 +4537,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 249 NTSTATUS NtShutdownSystem ['SHUTDOWN_ACTION Action']
 	case 249: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4301,6 +4549,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 250 NTSTATUS NtSignalAndWaitForSingleObject ['HANDLE SignalHandle', 'HANDLE WaitHandle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 250: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4318,6 +4567,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 251 NTSTATUS NtStartProfile ['HANDLE ProfileHandle']
 	case 251: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4329,6 +4579,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 252 NTSTATUS NtStopProfile ['HANDLE ProfileHandle']
 	case 252: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4340,6 +4591,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 253 NTSTATUS NtSuspendProcess ['HANDLE ProcessHandle']
 	case 253: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4351,6 +4603,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 254 NTSTATUS NtSuspendThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 254: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4364,6 +4617,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 255 NTSTATUS NtSystemDebugControl ['SYSDBG_COMMAND Command', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength', 'PULONG ReturnLength']
 	case 255: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4385,6 +4639,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 256 NTSTATUS NtTerminateJobObject ['HANDLE JobHandle', 'NTSTATUS ExitStatus']
 	case 256: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4398,6 +4653,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 257 NTSTATUS NtTerminateProcess ['HANDLE ProcessHandle', 'NTSTATUS ExitStatus']
 	case 257: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4411,6 +4667,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 258 NTSTATUS NtTerminateThread ['HANDLE ThreadHandle', 'NTSTATUS ExitStatus']
 	case 258: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4424,11 +4681,13 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 259 NTSTATUS NtTestAlert ['']
 	case 259: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtTestAlert_enter, cpu, pc);
 	}; break;
 	// 260 NTSTATUS NtTraceEvent ['HANDLE TraceHandle', 'ULONG Flags', 'ULONG FieldSize', 'PVOID Fields']
 	case 260: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4446,6 +4705,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 261 NTSTATUS NtTranslateFilePath ['PFILE_PATH InputFilePath', 'ULONG OutputType', 'PFILE_PATH OutputFilePath', 'PULONG OutputFilePathLength']
 	case 261: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4463,6 +4723,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 262 NTSTATUS NtUnloadDriver ['PUNICODE_STRING DriverServiceName']
 	case 262: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4474,6 +4735,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 263 NTSTATUS NtUnloadKey ['POBJECT_ATTRIBUTES TargetKey']
 	case 263: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4485,6 +4747,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 264 NTSTATUS NtUnloadKeyEx ['POBJECT_ATTRIBUTES TargetKey', 'HANDLE Event']
 	case 264: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4498,6 +4761,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 265 NTSTATUS NtUnlockFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER ByteOffset', 'PLARGE_INTEGER Length', 'ULONG Key']
 	case 265: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4517,6 +4781,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 266 NTSTATUS NtUnlockVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG MapType']
 	case 266: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4534,6 +4799,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 267 NTSTATUS NtUnmapViewOfSection ['HANDLE ProcessHandle', 'PVOID BaseAddress']
 	case 267: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4547,6 +4813,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 268 NTSTATUS NtVdmControl ['VDMSERVICECLASS Service', 'PVOID ServiceData']
 	case 268: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4560,6 +4827,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 269 NTSTATUS NtWaitForDebugEvent ['HANDLE DebugObjectHandle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout', 'PDBGUI_WAIT_STATE_CHANGE WaitStateChange']
 	case 269: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4577,6 +4845,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 270 NTSTATUS NtWaitForMultipleObjects ['ULONG Count', 'HANDLE Handles[]', 'WAIT_TYPE WaitType', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 270: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4596,6 +4865,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 271 NTSTATUS NtWaitForSingleObject ['HANDLE Handle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 271: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4611,6 +4881,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 272 NTSTATUS NtWaitHighEventPair ['HANDLE EventPairHandle']
 	case 272: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4622,6 +4893,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 273 NTSTATUS NtWaitLowEventPair ['HANDLE EventPairHandle']
 	case 273: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4633,6 +4905,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 274 NTSTATUS NtWriteFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 274: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4660,6 +4933,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 275 NTSTATUS NtWriteFileGather ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PFILE_SEGMENT_ELEMENT SegmentArray', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 275: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4687,6 +4961,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 276 NTSTATUS NtWriteRequestData ['HANDLE PortHandle', 'PPORT_MESSAGE Message', 'ULONG DataEntryIndex', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesWritten']
 	case 276: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4708,6 +4983,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 277 NTSTATUS NtWriteVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesWritten']
 	case 277: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4727,11 +5003,13 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 278 NTSTATUS NtYieldExecution ['']
 	case 278: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtYieldExecution_enter, cpu, pc);
 	}; break;
 	// 279 NTSTATUS NtCreateKeyedEvent ['PHANDLE KeyedEventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Flags']
 	case 279: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4749,6 +5027,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 280 NTSTATUS NtOpenKeyedEvent ['PHANDLE KeyedEventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 280: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4764,6 +5043,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 281 NTSTATUS NtReleaseKeyedEvent ['HANDLE KeyedEventHandle', 'PVOID KeyValue', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 281: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4781,6 +5061,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 282 NTSTATUS NtWaitForKeyedEvent ['HANDLE KeyedEventHandle', 'PVOID KeyValue', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 282: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4798,6 +5079,7 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 283 NTSTATUS NtQueryPortInformationProcess ['']
 	case 283: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtQueryPortInformationProcess_enter, cpu, pc);
 	}; break;
 	default:

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp3_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp3_x86.cpp
@@ -33,6 +33,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	}
 	ctx.asid = panda_current_asid(cpu);
 	ctx.retaddr = calc_retaddr(cpu, pc);
+	ctx.double_return = false;
 	bool panda_noreturn;	// true if PANDA should not track the return of this system call
 	const syscall_info_t *call = NULL;
 	syscall_info_t zero = {0};
@@ -48,6 +49,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 0 NTSTATUS NtAcceptConnectPort ['PHANDLE PortHandle', 'PVOID PortContext', 'PPORT_MESSAGE ConnectionRequest', 'BOOLEAN AcceptConnection', 'PPORT_VIEW ServerView', 'PREMOTE_PORT_VIEW ClientView']
 	case 0: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -69,6 +71,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 1 NTSTATUS NtAccessCheck ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 1: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -94,6 +97,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 2 NTSTATUS NtAccessCheckAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'ACCESS_MASK DesiredAccess', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 2: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -125,6 +129,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 3 NTSTATUS NtAccessCheckByType ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 3: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -156,6 +161,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 4 NTSTATUS NtAccessCheckByTypeAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 4: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -197,6 +203,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 5 NTSTATUS NtAccessCheckByTypeResultList ['PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'PPRIVILEGE_SET PrivilegeSet', 'PULONG PrivilegeSetLength', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus']
 	case 5: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -228,6 +235,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 6 NTSTATUS NtAccessCheckByTypeResultListAndAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 6: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -269,6 +277,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 7 NTSTATUS NtAccessCheckByTypeResultListAndAuditAlarmByHandle ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'HANDLE ClientToken', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'PSID PrincipalSelfSid', 'ACCESS_MASK DesiredAccess', 'AUDIT_EVENT_TYPE AuditType', 'ULONG Flags', 'POBJECT_TYPE_LIST ObjectTypeList', 'ULONG ObjectTypeListLength', 'PGENERIC_MAPPING GenericMapping', 'BOOLEAN ObjectCreation', 'PACCESS_MASK GrantedAccess', 'PNTSTATUS AccessStatus', 'PBOOLEAN GenerateOnClose']
 	case 7: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -312,6 +321,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 8 NTSTATUS NtAddAtom ['PWSTR AtomName', 'ULONG Length', 'PRTL_ATOM Atom']
 	case 8: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -327,6 +337,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 9 NTSTATUS NtAddBootEntry ['PBOOT_ENTRY BootEntry', 'PULONG Id']
 	case 9: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -340,6 +351,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 10 NTSTATUS NtAdjustGroupsToken ['HANDLE TokenHandle', 'BOOLEAN ResetToDefault', 'PTOKEN_GROUPS NewState', 'ULONG BufferLength', 'PTOKEN_GROUPS PreviousState', 'PULONG ReturnLength']
 	case 10: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -361,6 +373,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 11 NTSTATUS NtAdjustPrivilegesToken ['HANDLE TokenHandle', 'BOOLEAN DisableAllPrivileges', 'PTOKEN_PRIVILEGES NewState', 'ULONG BufferLength', 'PTOKEN_PRIVILEGES PreviousState', 'PULONG ReturnLength']
 	case 11: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -382,6 +395,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 12 NTSTATUS NtAlertResumeThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 12: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -395,6 +409,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 13 NTSTATUS NtAlertThread ['HANDLE ThreadHandle']
 	case 13: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -406,6 +421,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 14 NTSTATUS NtAllocateLocallyUniqueId ['PLUID Luid']
 	case 14: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -417,6 +433,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 15 NTSTATUS NtAllocateUserPhysicalPages ['HANDLE ProcessHandle', 'PULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 15: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -432,6 +449,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 16 NTSTATUS NtAllocateUuids ['PULARGE_INTEGER Time', 'PULONG Range', 'PULONG Sequence', 'PCHAR Seed']
 	case 16: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -449,6 +467,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 17 NTSTATUS NtAllocateVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'ULONG_PTR ZeroBits', 'PSIZE_T RegionSize', 'ULONG AllocationType', 'ULONG Protect']
 	case 17: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -470,6 +489,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 18 NTSTATUS NtAreMappedFilesTheSame ['PVOID File1MappedAsAnImage', 'PVOID File2MappedAsFile']
 	case 18: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -483,6 +503,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 19 NTSTATUS NtAssignProcessToJobObject ['HANDLE JobHandle', 'HANDLE ProcessHandle']
 	case 19: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -496,6 +517,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 20 NTSTATUS NtCallbackReturn ['PVOID OutputBuffer', 'ULONG OutputLength', 'NTSTATUS Status']
 	case 20: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -511,6 +533,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 22 NTSTATUS NtCancelIoFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 22: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -524,6 +547,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 23 NTSTATUS NtCancelTimer ['HANDLE TimerHandle', 'PBOOLEAN CurrentState']
 	case 23: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -537,6 +561,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 24 NTSTATUS NtClearEvent ['HANDLE EventHandle']
 	case 24: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -548,6 +573,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 25 NTSTATUS NtClose ['HANDLE Handle']
 	case 25: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -559,6 +585,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 26 NTSTATUS NtCloseObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'BOOLEAN GenerateOnClose']
 	case 26: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -574,6 +601,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 27 NTSTATUS NtCompactKeys ['ULONG Count', 'HANDLE KeyArray[]']
 	case 27: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -587,6 +615,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 28 NTSTATUS NtCompareTokens ['HANDLE FirstTokenHandle', 'HANDLE SecondTokenHandle', 'PBOOLEAN Equal']
 	case 28: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -602,6 +631,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 29 NTSTATUS NtCompleteConnectPort ['HANDLE PortHandle']
 	case 29: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -613,6 +643,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 30 NTSTATUS NtCompressKey ['HANDLE Key']
 	case 30: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -624,6 +655,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 31 NTSTATUS NtConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos', 'PPORT_VIEW ClientView', 'PREMOTE_PORT_VIEW ServerView', 'PULONG MaxMessageLength', 'PVOID ConnectionInformation', 'PULONG ConnectionInformationLength']
 	case 31: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -649,6 +681,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 32 NTSTATUS NtContinue ['PCONTEXT ContextRecord', 'BOOLEAN TestAlert']
 	case 32: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -662,6 +695,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 33 NTSTATUS NtCreateDebugObject ['PHANDLE DebugObjectHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Flags']
 	case 33: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -679,6 +713,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 34 NTSTATUS NtCreateDirectoryObject ['PHANDLE DirectoryHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 34: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -694,6 +729,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 35 NTSTATUS NtCreateEvent ['PHANDLE EventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'EVENT_TYPE EventType', 'BOOLEAN InitialState']
 	case 35: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -713,6 +749,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 36 NTSTATUS NtCreateEventPair ['PHANDLE EventPairHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 36: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -728,6 +765,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 37 NTSTATUS NtCreateFile ['PHANDLE FileHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER AllocationSize', 'ULONG FileAttributes', 'ULONG ShareAccess', 'ULONG CreateDisposition', 'ULONG CreateOptions', 'PVOID EaBuffer', 'ULONG EaLength']
 	case 37: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -759,6 +797,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 38 NTSTATUS NtCreateIoCompletion ['PHANDLE IoCompletionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Count']
 	case 38: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -776,6 +815,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 39 NTSTATUS NtCreateJobObject ['PHANDLE JobHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 39: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -791,6 +831,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 40 NTSTATUS NtCreateJobSet ['ULONG NumJob', 'PJOB_SET_ARRAY UserJobSet', 'ULONG Flags']
 	case 40: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -806,6 +847,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 41 NTSTATUS NtCreateKey ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG TitleIndex', 'PUNICODE_STRING Class', 'ULONG CreateOptions', 'PULONG Disposition']
 	case 41: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -829,6 +871,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 42 NTSTATUS NtCreateMailslotFile ['PHANDLE FileHandle', 'ULONG DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CreateOptions', 'ULONG MailslotQuota', 'ULONG MaximumMessageSize', 'PLARGE_INTEGER ReadTimeout']
 	case 42: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -854,6 +897,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 43 NTSTATUS NtCreateMutant ['PHANDLE MutantHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'BOOLEAN InitialOwner']
 	case 43: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -871,6 +915,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 44 NTSTATUS NtCreateNamedPipeFile ['PHANDLE FileHandle', 'ULONG DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG ShareAccess', 'ULONG CreateDisposition', 'ULONG CreateOptions', 'ULONG NamedPipeType', 'ULONG ReadMode', 'ULONG CompletionMode', 'ULONG MaximumInstances', 'ULONG InboundQuota', 'ULONG OutboundQuota', 'PLARGE_INTEGER DefaultTimeout']
 	case 44: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -908,6 +953,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 45 NTSTATUS NtCreatePagingFile ['PUNICODE_STRING PageFileName', 'PLARGE_INTEGER MinimumSize', 'PLARGE_INTEGER MaximumSize', 'ULONG Priority']
 	case 45: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -925,6 +971,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 46 NTSTATUS NtCreatePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG MaxConnectionInfoLength', 'ULONG MaxMessageLength', 'ULONG MaxPoolUsage']
 	case 46: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -944,6 +991,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 47 NTSTATUS NtCreateProcess ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ParentProcess', 'BOOLEAN InheritObjectTable', 'HANDLE SectionHandle', 'HANDLE DebugPort', 'HANDLE ExceptionPort']
 	case 47: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -969,6 +1017,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 48 NTSTATUS NtCreateProcessEx ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ParentProcess', 'ULONG Flags', 'HANDLE SectionHandle', 'HANDLE DebugPort', 'HANDLE ExceptionPort', 'ULONG JobMemberLevel']
 	case 48: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -996,6 +1045,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 49 NTSTATUS NtCreateProfile ['PHANDLE ProfileHandle', 'HANDLE Process', 'PVOID RangeBase', 'SIZE_T RangeSize', 'ULONG BucketSize', 'PULONG Buffer', 'ULONG BufferSize', 'KPROFILE_SOURCE ProfileSource', 'KAFFINITY Affinity']
 	case 49: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1023,6 +1073,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 50 NTSTATUS NtCreateSection ['PHANDLE SectionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PLARGE_INTEGER MaximumSize', 'ULONG SectionPageProtection', 'ULONG AllocationAttributes', 'HANDLE FileHandle']
 	case 50: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1046,6 +1097,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 51 NTSTATUS NtCreateSemaphore ['PHANDLE SemaphoreHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'LONG InitialCount', 'LONG MaximumCount']
 	case 51: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1065,6 +1117,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 52 NTSTATUS NtCreateSymbolicLinkObject ['PHANDLE LinkHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PUNICODE_STRING LinkTarget']
 	case 52: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1082,6 +1135,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 53 NTSTATUS NtCreateThread ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'HANDLE ProcessHandle', 'PCLIENT_ID ClientId', 'PCONTEXT ThreadContext', 'PINITIAL_TEB InitialTeb', 'BOOLEAN CreateSuspended']
 	case 53: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1107,6 +1161,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 54 NTSTATUS NtCreateTimer ['PHANDLE TimerHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'TIMER_TYPE TimerType']
 	case 54: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1124,6 +1179,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 55 NTSTATUS NtCreateToken ['PHANDLE TokenHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'TOKEN_TYPE TokenType', 'PLUID AuthenticationId', 'PLARGE_INTEGER ExpirationTime', 'PTOKEN_USER User', 'PTOKEN_GROUPS Groups', 'PTOKEN_PRIVILEGES Privileges', 'PTOKEN_OWNER Owner', 'PTOKEN_PRIMARY_GROUP PrimaryGroup', 'PTOKEN_DEFAULT_DACL DefaultDacl', 'PTOKEN_SOURCE TokenSource']
 	case 55: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1159,6 +1215,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 56 NTSTATUS NtCreateWaitablePort ['PHANDLE PortHandle', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG MaxConnectionInfoLength', 'ULONG MaxMessageLength', 'ULONG MaxPoolUsage']
 	case 56: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1178,6 +1235,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 57 NTSTATUS NtDebugActiveProcess ['HANDLE ProcessHandle', 'HANDLE DebugObjectHandle']
 	case 57: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1191,6 +1249,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 58 NTSTATUS NtDebugContinue ['HANDLE DebugObjectHandle', 'PCLIENT_ID ClientId', 'NTSTATUS ContinueStatus']
 	case 58: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1206,6 +1265,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 59 NTSTATUS NtDelayExecution ['BOOLEAN Alertable', 'PLARGE_INTEGER DelayInterval']
 	case 59: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1219,6 +1279,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 60 NTSTATUS NtDeleteAtom ['RTL_ATOM Atom']
 	case 60: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1230,6 +1291,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 61 NTSTATUS NtDeleteBootEntry ['ULONG Id']
 	case 61: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1241,6 +1303,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 62 NTSTATUS NtDeleteFile ['POBJECT_ATTRIBUTES ObjectAttributes']
 	case 62: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1252,6 +1315,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 63 NTSTATUS NtDeleteKey ['HANDLE KeyHandle']
 	case 63: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1263,6 +1327,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 64 NTSTATUS NtDeleteObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'BOOLEAN GenerateOnClose']
 	case 64: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1278,6 +1343,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 65 NTSTATUS NtDeleteValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName']
 	case 65: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1291,6 +1357,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 66 NTSTATUS NtDeviceIoControlFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG IoControlCode', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 66: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1320,6 +1387,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 67 NTSTATUS NtDisplayString ['PUNICODE_STRING String']
 	case 67: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1331,6 +1399,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 68 NTSTATUS NtDuplicateObject ['HANDLE SourceProcessHandle', 'HANDLE SourceHandle', 'HANDLE TargetProcessHandle', 'PHANDLE TargetHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'ULONG Options']
 	case 68: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1354,6 +1423,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 69 NTSTATUS NtDuplicateToken ['HANDLE ExistingTokenHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'BOOLEAN EffectiveOnly', 'TOKEN_TYPE TokenType', 'PHANDLE NewTokenHandle']
 	case 69: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1375,6 +1445,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 70 NTSTATUS NtEnumerateBootEntries ['PVOID Buffer', 'PULONG BufferLength']
 	case 70: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1388,6 +1459,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 71 NTSTATUS NtEnumerateKey ['HANDLE KeyHandle', 'ULONG Index', 'KEY_INFORMATION_CLASS KeyInformationClass', 'PVOID KeyInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 71: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1409,6 +1481,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 72 NTSTATUS NtEnumerateSystemEnvironmentValuesEx ['ULONG InformationClass', 'PVOID Buffer', 'PULONG BufferLength']
 	case 72: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1424,6 +1497,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 73 NTSTATUS NtEnumerateValueKey ['HANDLE KeyHandle', 'ULONG Index', 'KEY_VALUE_INFORMATION_CLASS KeyValueInformationClass', 'PVOID KeyValueInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 73: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1445,6 +1519,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 74 NTSTATUS NtExtendSection ['HANDLE SectionHandle', 'PLARGE_INTEGER NewSectionSize']
 	case 74: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1458,6 +1533,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 75 NTSTATUS NtFilterToken ['HANDLE ExistingTokenHandle', 'ULONG Flags', 'PTOKEN_GROUPS SidsToDisable', 'PTOKEN_PRIVILEGES PrivilegesToDelete', 'PTOKEN_GROUPS RestrictedSids', 'PHANDLE NewTokenHandle']
 	case 75: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1479,6 +1555,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 76 NTSTATUS NtFindAtom ['PWSTR AtomName', 'ULONG Length', 'PRTL_ATOM Atom']
 	case 76: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1494,6 +1571,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 77 NTSTATUS NtFlushBuffersFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock']
 	case 77: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1507,6 +1585,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 78 NTSTATUS NtFlushInstructionCache ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'SIZE_T Length']
 	case 78: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1522,6 +1601,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 79 NTSTATUS NtFlushKey ['HANDLE KeyHandle']
 	case 79: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1533,6 +1613,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 80 NTSTATUS NtFlushVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'PIO_STATUS_BLOCK IoStatus']
 	case 80: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1550,11 +1631,13 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 81 NTSTATUS NtFlushWriteBuffer ['']
 	case 81: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtFlushWriteBuffer_enter, cpu, pc);
 	}; break;
 	// 82 NTSTATUS NtFreeUserPhysicalPages ['HANDLE ProcessHandle', 'PULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 82: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1570,6 +1653,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 83 NTSTATUS NtFreeVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG FreeType']
 	case 83: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1587,6 +1671,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 84 NTSTATUS NtFsControlFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG IoControlCode', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 84: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1616,6 +1701,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 85 NTSTATUS NtGetContextThread ['HANDLE ThreadHandle', 'PCONTEXT ThreadContext']
 	case 85: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1629,6 +1715,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 86 NTSTATUS NtGetDevicePowerState ['HANDLE Device', 'DEVICE_POWER_STATE *State']
 	case 86: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1642,6 +1729,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 87 NTSTATUS NtGetPlugPlayEvent ['HANDLE EventHandle', 'PVOID Context', 'PPLUGPLAY_EVENT_BLOCK EventBlock', 'ULONG EventBufferSize']
 	case 87: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1659,6 +1747,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 88 NTSTATUS NtGetWriteWatch ['HANDLE ProcessHandle', 'ULONG Flags', 'PVOID BaseAddress', 'SIZE_T RegionSize', 'PVOID *UserAddressArray', 'PULONG_PTR EntriesInUserAddressArray', 'PULONG Granularity']
 	case 88: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1682,6 +1771,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 89 NTSTATUS NtImpersonateAnonymousToken ['HANDLE ThreadHandle']
 	case 89: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1693,6 +1783,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 90 NTSTATUS NtImpersonateClientOfPort ['HANDLE PortHandle', 'PPORT_MESSAGE Message']
 	case 90: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1706,6 +1797,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 91 NTSTATUS NtImpersonateThread ['HANDLE ServerThreadHandle', 'HANDLE ClientThreadHandle', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos']
 	case 91: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1721,6 +1813,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 92 NTSTATUS NtInitializeRegistry ['USHORT BootCondition']
 	case 92: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1732,6 +1825,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 93 NTSTATUS NtInitiatePowerAction ['POWER_ACTION SystemAction', 'SYSTEM_POWER_STATE MinSystemState', 'ULONG Flags', 'BOOLEAN Asynchronous']
 	case 93: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1749,6 +1843,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 94 NTSTATUS NtIsProcessInJob ['HANDLE ProcessHandle', 'HANDLE JobHandle']
 	case 94: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1762,11 +1857,13 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 95 BOOLEAN NtIsSystemResumeAutomatic ['']
 	case 95: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtIsSystemResumeAutomatic_enter, cpu, pc);
 	}; break;
 	// 96 NTSTATUS NtListenPort ['HANDLE PortHandle', 'PPORT_MESSAGE ConnectionRequest']
 	case 96: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1780,6 +1877,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 97 NTSTATUS NtLoadDriver ['PUNICODE_STRING DriverServiceName']
 	case 97: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1791,6 +1889,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 98 NTSTATUS NtLoadKey ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile']
 	case 98: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1804,6 +1903,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 99 NTSTATUS NtLoadKey2 ['POBJECT_ATTRIBUTES TargetKey', 'POBJECT_ATTRIBUTES SourceFile', 'ULONG Flags']
 	case 99: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1819,6 +1919,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 100 NTSTATUS NtLockFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER ByteOffset', 'PLARGE_INTEGER Length', 'ULONG Key', 'BOOLEAN FailImmediately', 'BOOLEAN ExclusiveLock']
 	case 100: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1848,6 +1949,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 101 NTSTATUS NtLockProductActivationKeys ['ULONG *pPrivateVer', 'ULONG *pSafeMode']
 	case 101: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -1861,6 +1963,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 102 NTSTATUS NtLockRegistryKey ['HANDLE KeyHandle']
 	case 102: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1872,6 +1975,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 103 NTSTATUS NtLockVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG MapType']
 	case 103: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1889,6 +1993,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 104 NTSTATUS NtMakePermanentObject ['HANDLE Handle']
 	case 104: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1900,6 +2005,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 105 NTSTATUS NtMakeTemporaryObject ['HANDLE Handle']
 	case 105: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1911,6 +2017,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 106 NTSTATUS NtMapUserPhysicalPages ['PVOID VirtualAddress', 'ULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 106: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1926,6 +2033,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 107 NTSTATUS NtMapUserPhysicalPagesScatter ['PVOID *VirtualAddresses', 'ULONG_PTR NumberOfPages', 'PULONG_PTR UserPfnArray']
 	case 107: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1941,6 +2049,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 108 NTSTATUS NtMapViewOfSection ['HANDLE SectionHandle', 'HANDLE ProcessHandle', 'PVOID *BaseAddress', 'ULONG_PTR ZeroBits', 'SIZE_T CommitSize', 'PLARGE_INTEGER SectionOffset', 'PSIZE_T ViewSize', 'SECTION_INHERIT InheritDisposition', 'ULONG AllocationType', 'WIN32_PROTECTION_MASK Win32Protect']
 	case 108: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -1970,6 +2079,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 109 NTSTATUS NtModifyBootEntry ['PBOOT_ENTRY BootEntry']
 	case 109: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -1981,6 +2091,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 110 NTSTATUS NtNotifyChangeDirectoryFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'ULONG CompletionFilter', 'BOOLEAN WatchTree']
 	case 110: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2008,6 +2119,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 111 NTSTATUS NtNotifyChangeKey ['HANDLE KeyHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CompletionFilter', 'BOOLEAN WatchTree', 'PVOID Buffer', 'ULONG BufferSize', 'BOOLEAN Asynchronous']
 	case 111: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2037,6 +2149,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 112 NTSTATUS NtNotifyChangeMultipleKeys ['HANDLE MasterKeyHandle', 'ULONG Count', 'OBJECT_ATTRIBUTES SlaveObjects[]', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG CompletionFilter', 'BOOLEAN WatchTree', 'PVOID Buffer', 'ULONG BufferSize', 'BOOLEAN Asynchronous']
 	case 112: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2070,6 +2183,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 113 NTSTATUS NtOpenDirectoryObject ['PHANDLE DirectoryHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 113: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2085,6 +2199,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 114 NTSTATUS NtOpenEvent ['PHANDLE EventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 114: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2100,6 +2215,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 115 NTSTATUS NtOpenEventPair ['PHANDLE EventPairHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 115: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2115,6 +2231,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 116 NTSTATUS NtOpenFile ['PHANDLE FileHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PIO_STATUS_BLOCK IoStatusBlock', 'ULONG ShareAccess', 'ULONG OpenOptions']
 	case 116: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2136,6 +2253,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 117 NTSTATUS NtOpenIoCompletion ['PHANDLE IoCompletionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 117: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2151,6 +2269,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 118 NTSTATUS NtOpenJobObject ['PHANDLE JobHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 118: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2166,6 +2285,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 119 NTSTATUS NtOpenKey ['PHANDLE KeyHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 119: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2181,6 +2301,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 120 NTSTATUS NtOpenMutant ['PHANDLE MutantHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 120: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2196,6 +2317,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 121 NTSTATUS NtOpenObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'PUNICODE_STRING ObjectTypeName', 'PUNICODE_STRING ObjectName', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'ACCESS_MASK GrantedAccess', 'PPRIVILEGE_SET Privileges', 'BOOLEAN ObjectCreation', 'BOOLEAN AccessGranted', 'PBOOLEAN GenerateOnClose']
 	case 121: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2229,6 +2351,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 122 NTSTATUS NtOpenProcess ['PHANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PCLIENT_ID ClientId']
 	case 122: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2246,6 +2369,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 123 NTSTATUS NtOpenProcessToken ['HANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'PHANDLE TokenHandle']
 	case 123: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2261,6 +2385,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 124 NTSTATUS NtOpenProcessTokenEx ['HANDLE ProcessHandle', 'ACCESS_MASK DesiredAccess', 'ULONG HandleAttributes', 'PHANDLE TokenHandle']
 	case 124: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2278,6 +2403,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 125 NTSTATUS NtOpenSection ['PHANDLE SectionHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 125: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2293,6 +2419,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 126 NTSTATUS NtOpenSemaphore ['PHANDLE SemaphoreHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 126: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2308,6 +2435,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 127 NTSTATUS NtOpenSymbolicLinkObject ['PHANDLE LinkHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 127: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2323,6 +2451,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 128 NTSTATUS NtOpenThread ['PHANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'PCLIENT_ID ClientId']
 	case 128: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2340,6 +2469,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 129 NTSTATUS NtOpenThreadToken ['HANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'BOOLEAN OpenAsSelf', 'PHANDLE TokenHandle']
 	case 129: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2357,6 +2487,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 130 NTSTATUS NtOpenThreadTokenEx ['HANDLE ThreadHandle', 'ACCESS_MASK DesiredAccess', 'BOOLEAN OpenAsSelf', 'ULONG HandleAttributes', 'PHANDLE TokenHandle']
 	case 130: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2376,6 +2507,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 131 NTSTATUS NtOpenTimer ['PHANDLE TimerHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 131: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2391,6 +2523,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 132 NTSTATUS NtPlugPlayControl ['PLUGPLAY_CONTROL_CLASS PnPControlClass', 'PVOID PnPControlData', 'ULONG PnPControlDataLength']
 	case 132: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2406,6 +2539,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 133 NTSTATUS NtPowerInformation ['POWER_INFORMATION_LEVEL InformationLevel', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength']
 	case 133: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2425,6 +2559,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 134 NTSTATUS NtPrivilegeCheck ['HANDLE ClientToken', 'PPRIVILEGE_SET RequiredPrivileges', 'PBOOLEAN Result']
 	case 134: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2440,6 +2575,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 135 NTSTATUS NtPrivilegeObjectAuditAlarm ['PUNICODE_STRING SubsystemName', 'PVOID HandleId', 'HANDLE ClientToken', 'ACCESS_MASK DesiredAccess', 'PPRIVILEGE_SET Privileges', 'BOOLEAN AccessGranted']
 	case 135: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2461,6 +2597,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 136 NTSTATUS NtPrivilegedServiceAuditAlarm ['PUNICODE_STRING SubsystemName', 'PUNICODE_STRING ServiceName', 'HANDLE ClientToken', 'PPRIVILEGE_SET Privileges', 'BOOLEAN AccessGranted']
 	case 136: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2480,6 +2617,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 137 NTSTATUS NtProtectVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'WIN32_PROTECTION_MASK NewProtectWin32', 'PULONG OldProtect']
 	case 137: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2499,6 +2637,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 138 NTSTATUS NtPulseEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 138: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2512,6 +2651,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 139 NTSTATUS NtQueryAttributesFile ['POBJECT_ATTRIBUTES ObjectAttributes', 'PFILE_BASIC_INFORMATION FileInformation']
 	case 139: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2525,6 +2665,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 140 NTSTATUS NtQueryBootEntryOrder ['PULONG Ids', 'PULONG Count']
 	case 140: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2538,6 +2679,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 141 NTSTATUS NtQueryBootOptions ['PBOOT_OPTIONS BootOptions', 'PULONG BootOptionsLength']
 	case 141: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2551,6 +2693,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 142 NTSTATUS NtQueryDebugFilterState ['ULONG ComponentId', 'ULONG Level']
 	case 142: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2564,6 +2707,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 143 NTSTATUS NtQueryDefaultLocale ['BOOLEAN UserProfile', 'PLCID DefaultLocaleId']
 	case 143: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2577,6 +2721,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 144 NTSTATUS NtQueryDefaultUILanguage ['LANGID *DefaultUILanguageId']
 	case 144: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2588,6 +2733,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 145 NTSTATUS NtQueryDirectoryFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass', 'BOOLEAN ReturnSingleEntry', 'PUNICODE_STRING FileName', 'BOOLEAN RestartScan']
 	case 145: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2619,6 +2765,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 146 NTSTATUS NtQueryDirectoryObject ['HANDLE DirectoryHandle', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'BOOLEAN RestartScan', 'PULONG Context', 'PULONG ReturnLength']
 	case 146: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2642,6 +2789,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 147 NTSTATUS NtQueryEaFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'PVOID EaList', 'ULONG EaListLength', 'PULONG EaIndex', 'BOOLEAN RestartScan']
 	case 147: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2669,6 +2817,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 148 NTSTATUS NtQueryEvent ['HANDLE EventHandle', 'EVENT_INFORMATION_CLASS EventInformationClass', 'PVOID EventInformation', 'ULONG EventInformationLength', 'PULONG ReturnLength']
 	case 148: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2688,6 +2837,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 149 NTSTATUS NtQueryFullAttributesFile ['POBJECT_ATTRIBUTES ObjectAttributes', 'PFILE_NETWORK_OPEN_INFORMATION FileInformation']
 	case 149: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2701,6 +2851,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 150 NTSTATUS NtQueryInformationAtom ['RTL_ATOM Atom', 'ATOM_INFORMATION_CLASS InformationClass', 'PVOID AtomInformation', 'ULONG AtomInformationLength', 'PULONG ReturnLength']
 	case 150: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2720,6 +2871,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 151 NTSTATUS NtQueryInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass']
 	case 151: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2739,6 +2891,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 152 NTSTATUS NtQueryInformationJobObject ['HANDLE JobHandle', 'JOBOBJECTINFOCLASS JobObjectInformationClass', 'PVOID JobObjectInformation', 'ULONG JobObjectInformationLength', 'PULONG ReturnLength']
 	case 152: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2758,6 +2911,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 153 NTSTATUS NtQueryInformationPort ['HANDLE PortHandle', 'PORT_INFORMATION_CLASS PortInformationClass', 'PVOID PortInformation', 'ULONG Length', 'PULONG ReturnLength']
 	case 153: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2777,6 +2931,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 154 NTSTATUS NtQueryInformationProcess ['HANDLE ProcessHandle', 'PROCESSINFOCLASS ProcessInformationClass', 'PVOID ProcessInformation', 'ULONG ProcessInformationLength', 'PULONG ReturnLength']
 	case 154: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2796,6 +2951,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 155 NTSTATUS NtQueryInformationThread ['HANDLE ThreadHandle', 'THREADINFOCLASS ThreadInformationClass', 'PVOID ThreadInformation', 'ULONG ThreadInformationLength', 'PULONG ReturnLength']
 	case 155: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2815,6 +2971,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 156 NTSTATUS NtQueryInformationToken ['HANDLE TokenHandle', 'TOKEN_INFORMATION_CLASS TokenInformationClass', 'PVOID TokenInformation', 'ULONG TokenInformationLength', 'PULONG ReturnLength']
 	case 156: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2834,6 +2991,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 157 NTSTATUS NtQueryInstallUILanguage ['LANGID *InstallUILanguageId']
 	case 157: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -2845,6 +3003,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 158 NTSTATUS NtQueryIntervalProfile ['KPROFILE_SOURCE ProfileSource', 'PULONG Interval']
 	case 158: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2858,6 +3017,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 159 NTSTATUS NtQueryIoCompletion ['HANDLE IoCompletionHandle', 'IO_COMPLETION_INFORMATION_CLASS IoCompletionInformationClass', 'PVOID IoCompletionInformation', 'ULONG IoCompletionInformationLength', 'PULONG ReturnLength']
 	case 159: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2877,6 +3037,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 160 NTSTATUS NtQueryKey ['HANDLE KeyHandle', 'KEY_INFORMATION_CLASS KeyInformationClass', 'PVOID KeyInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 160: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2896,6 +3057,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 161 NTSTATUS NtQueryMultipleValueKey ['HANDLE KeyHandle', 'PKEY_VALUE_ENTRY ValueEntries', 'ULONG EntryCount', 'PVOID ValueBuffer', 'PULONG BufferLength', 'PULONG RequiredBufferLength']
 	case 161: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2917,6 +3079,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 162 NTSTATUS NtQueryMutant ['HANDLE MutantHandle', 'MUTANT_INFORMATION_CLASS MutantInformationClass', 'PVOID MutantInformation', 'ULONG MutantInformationLength', 'PULONG ReturnLength']
 	case 162: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2936,6 +3099,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 163 NTSTATUS NtQueryObject ['HANDLE Handle', 'OBJECT_INFORMATION_CLASS ObjectInformationClass', 'PVOID ObjectInformation', 'ULONG ObjectInformationLength', 'PULONG ReturnLength']
 	case 163: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -2955,6 +3119,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 164 NTSTATUS NtQueryOpenSubKeys ['POBJECT_ATTRIBUTES TargetKey', 'PULONG HandleCount']
 	case 164: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2968,6 +3133,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 165 NTSTATUS NtQueryPerformanceCounter ['PLARGE_INTEGER PerformanceCounter', 'PLARGE_INTEGER PerformanceFrequency']
 	case 165: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -2981,6 +3147,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 166 NTSTATUS NtQueryQuotaInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'BOOLEAN ReturnSingleEntry', 'PVOID SidList', 'ULONG SidListLength', 'PULONG StartSid', 'BOOLEAN RestartScan']
 	case 166: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3008,6 +3175,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 167 NTSTATUS NtQuerySection ['HANDLE SectionHandle', 'SECTION_INFORMATION_CLASS SectionInformationClass', 'PVOID SectionInformation', 'SIZE_T SectionInformationLength', 'PSIZE_T ReturnLength']
 	case 167: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3027,6 +3195,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 168 NTSTATUS NtQuerySecurityObject ['HANDLE Handle', 'SECURITY_INFORMATION SecurityInformation', 'PSECURITY_DESCRIPTOR SecurityDescriptor', 'ULONG Length', 'PULONG LengthNeeded']
 	case 168: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3046,6 +3215,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 169 NTSTATUS NtQuerySemaphore ['HANDLE SemaphoreHandle', 'SEMAPHORE_INFORMATION_CLASS SemaphoreInformationClass', 'PVOID SemaphoreInformation', 'ULONG SemaphoreInformationLength', 'PULONG ReturnLength']
 	case 169: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3065,6 +3235,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 170 NTSTATUS NtQuerySymbolicLinkObject ['HANDLE LinkHandle', 'PUNICODE_STRING LinkTarget', 'PULONG ReturnedLength']
 	case 170: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3080,6 +3251,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 171 NTSTATUS NtQuerySystemEnvironmentValue ['PUNICODE_STRING VariableName', 'PWSTR VariableValue', 'USHORT ValueLength', 'PUSHORT ReturnLength']
 	case 171: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3097,6 +3269,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 172 NTSTATUS NtQuerySystemEnvironmentValueEx ['PUNICODE_STRING VariableName', 'LPGUID VendorGuid', 'PVOID Value', 'PULONG ValueLength', 'PULONG Attributes']
 	case 172: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3116,6 +3289,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 173 NTSTATUS NtQuerySystemInformation ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID SystemInformation', 'ULONG SystemInformationLength', 'PULONG ReturnLength']
 	case 173: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3133,6 +3307,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 174 NTSTATUS NtQuerySystemTime ['PLARGE_INTEGER SystemTime']
 	case 174: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3144,6 +3319,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 175 NTSTATUS NtQueryTimer ['HANDLE TimerHandle', 'TIMER_INFORMATION_CLASS TimerInformationClass', 'PVOID TimerInformation', 'ULONG TimerInformationLength', 'PULONG ReturnLength']
 	case 175: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3163,6 +3339,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 176 NTSTATUS NtQueryTimerResolution ['PULONG MaximumTime', 'PULONG MinimumTime', 'PULONG CurrentTime']
 	case 176: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3178,6 +3355,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 177 NTSTATUS NtQueryValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName', 'KEY_VALUE_INFORMATION_CLASS KeyValueInformationClass', 'PVOID KeyValueInformation', 'ULONG Length', 'PULONG ResultLength']
 	case 177: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3199,6 +3377,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 178 NTSTATUS NtQueryVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'MEMORY_INFORMATION_CLASS MemoryInformationClass', 'PVOID MemoryInformation', 'SIZE_T MemoryInformationLength', 'PSIZE_T ReturnLength']
 	case 178: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3220,6 +3399,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 179 NTSTATUS NtQueryVolumeInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FsInformation', 'ULONG Length', 'FS_INFORMATION_CLASS FsInformationClass']
 	case 179: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3239,6 +3419,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 180 NTSTATUS NtQueueApcThread ['HANDLE ThreadHandle', 'PPS_APC_ROUTINE ApcRoutine', 'PVOID ApcArgument1', 'PVOID ApcArgument2', 'PVOID ApcArgument3']
 	case 180: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3258,6 +3439,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 181 NTSTATUS NtRaiseException ['PEXCEPTION_RECORD ExceptionRecord', 'PCONTEXT ContextRecord', 'BOOLEAN FirstChance']
 	case 181: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3273,6 +3455,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 182 NTSTATUS NtRaiseHardError ['NTSTATUS ErrorStatus', 'ULONG NumberOfParameters', 'ULONG UnicodeStringParameterMask', 'PULONG_PTR Parameters', 'ULONG ValidResponseOptions', 'PULONG Response']
 	case 182: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3294,6 +3477,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 183 NTSTATUS NtReadFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 183: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3321,6 +3505,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 184 NTSTATUS NtReadFileScatter ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PFILE_SEGMENT_ELEMENT SegmentArray', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 184: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3348,6 +3533,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 185 NTSTATUS NtReadRequestData ['HANDLE PortHandle', 'PPORT_MESSAGE Message', 'ULONG DataEntryIndex', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesRead']
 	case 185: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3369,6 +3555,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 186 NTSTATUS NtReadVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesRead']
 	case 186: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3388,6 +3575,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 187 NTSTATUS NtRegisterThreadTerminatePort ['HANDLE PortHandle']
 	case 187: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3399,6 +3587,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 188 NTSTATUS NtReleaseMutant ['HANDLE MutantHandle', 'PLONG PreviousCount']
 	case 188: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3412,6 +3601,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 189 NTSTATUS NtReleaseSemaphore ['HANDLE SemaphoreHandle', 'LONG ReleaseCount', 'PLONG PreviousCount']
 	case 189: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3427,6 +3617,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 190 NTSTATUS NtRemoveIoCompletion ['HANDLE IoCompletionHandle', 'PVOID *KeyContext', 'PVOID *ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER Timeout']
 	case 190: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3446,6 +3637,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 191 NTSTATUS NtRemoveProcessDebug ['HANDLE ProcessHandle', 'HANDLE DebugObjectHandle']
 	case 191: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3459,6 +3651,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 192 NTSTATUS NtRenameKey ['HANDLE KeyHandle', 'PUNICODE_STRING NewName']
 	case 192: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3472,6 +3665,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 193 NTSTATUS NtReplaceKey ['POBJECT_ATTRIBUTES NewFile', 'HANDLE TargetHandle', 'POBJECT_ATTRIBUTES OldFile']
 	case 193: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3487,6 +3681,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 194 NTSTATUS NtReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE ReplyMessage']
 	case 194: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3500,6 +3695,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 195 NTSTATUS NtReplyWaitReceivePort ['HANDLE PortHandle', 'PVOID *PortContext', 'PPORT_MESSAGE ReplyMessage', 'PPORT_MESSAGE ReceiveMessage']
 	case 195: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3517,6 +3713,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 196 NTSTATUS NtReplyWaitReceivePortEx ['HANDLE PortHandle', 'PVOID *PortContext', 'PPORT_MESSAGE ReplyMessage', 'PPORT_MESSAGE ReceiveMessage', 'PLARGE_INTEGER Timeout']
 	case 196: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3536,6 +3733,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 197 NTSTATUS NtReplyWaitReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE ReplyMessage']
 	case 197: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3549,6 +3747,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 199 NTSTATUS NtRequestPort ['HANDLE PortHandle', 'PPORT_MESSAGE RequestMessage']
 	case 199: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3562,6 +3761,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 200 NTSTATUS NtRequestWaitReplyPort ['HANDLE PortHandle', 'PPORT_MESSAGE RequestMessage', 'PPORT_MESSAGE ReplyMessage']
 	case 200: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3577,6 +3777,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 202 NTSTATUS NtResetEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 202: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3590,6 +3791,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 203 NTSTATUS NtResetWriteWatch ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'SIZE_T RegionSize']
 	case 203: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3605,6 +3807,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 204 NTSTATUS NtRestoreKey ['HANDLE KeyHandle', 'HANDLE FileHandle', 'ULONG Flags']
 	case 204: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3620,6 +3823,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 205 NTSTATUS NtResumeProcess ['HANDLE ProcessHandle']
 	case 205: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3631,6 +3835,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 206 NTSTATUS NtResumeThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 206: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3644,6 +3849,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 207 NTSTATUS NtSaveKey ['HANDLE KeyHandle', 'HANDLE FileHandle']
 	case 207: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3657,6 +3863,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 208 NTSTATUS NtSaveKeyEx ['HANDLE KeyHandle', 'HANDLE FileHandle', 'ULONG Format']
 	case 208: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3672,6 +3879,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 209 NTSTATUS NtSaveMergedKeys ['HANDLE HighPrecedenceKeyHandle', 'HANDLE LowPrecedenceKeyHandle', 'HANDLE FileHandle']
 	case 209: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3687,6 +3895,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 210 NTSTATUS NtSecureConnectPort ['PHANDLE PortHandle', 'PUNICODE_STRING PortName', 'PSECURITY_QUALITY_OF_SERVICE SecurityQos', 'PPORT_VIEW ClientView', 'PSID RequiredServerSid', 'PREMOTE_PORT_VIEW ServerView', 'PULONG MaxMessageLength', 'PVOID ConnectionInformation', 'PULONG ConnectionInformationLength']
 	case 210: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3714,6 +3923,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 211 NTSTATUS NtSetBootEntryOrder ['PULONG Ids', 'ULONG Count']
 	case 211: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3727,6 +3937,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 212 NTSTATUS NtSetBootOptions ['PBOOT_OPTIONS BootOptions', 'ULONG FieldsToChange']
 	case 212: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3740,6 +3951,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 213 NTSTATUS NtSetContextThread ['HANDLE ThreadHandle', 'PCONTEXT ThreadContext']
 	case 213: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3753,6 +3965,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 214 NTSTATUS NtSetDebugFilterState ['ULONG ComponentId', 'ULONG Level', 'BOOLEAN State']
 	case 214: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3768,6 +3981,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 215 NTSTATUS NtSetDefaultHardErrorPort ['HANDLE DefaultHardErrorPort']
 	case 215: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3779,6 +3993,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 216 NTSTATUS NtSetDefaultLocale ['BOOLEAN UserProfile', 'LCID DefaultLocaleId']
 	case 216: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3792,6 +4007,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 217 NTSTATUS NtSetDefaultUILanguage ['LANGID DefaultUILanguageId']
 	case 217: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3803,6 +4019,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 218 NTSTATUS NtSetEaFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length']
 	case 218: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3820,6 +4037,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 219 NTSTATUS NtSetEvent ['HANDLE EventHandle', 'PLONG PreviousState']
 	case 219: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -3833,6 +4051,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 220 NTSTATUS NtSetEventBoostPriority ['HANDLE EventHandle']
 	case 220: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3844,6 +4063,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 221 NTSTATUS NtSetHighEventPair ['HANDLE EventPairHandle']
 	case 221: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3855,6 +4075,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 222 NTSTATUS NtSetHighWaitLowEventPair ['HANDLE EventPairHandle']
 	case 222: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -3866,6 +4087,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 223 NTSTATUS NtSetInformationDebugObject ['HANDLE DebugObjectHandle', 'DEBUGOBJECTINFOCLASS DebugObjectInformationClass', 'PVOID DebugInformation', 'ULONG DebugInformationLength', 'PULONG ReturnLength']
 	case 223: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3885,6 +4107,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 224 NTSTATUS NtSetInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FileInformation', 'ULONG Length', 'FILE_INFORMATION_CLASS FileInformationClass']
 	case 224: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3904,6 +4127,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 225 NTSTATUS NtSetInformationJobObject ['HANDLE JobHandle', 'JOBOBJECTINFOCLASS JobObjectInformationClass', 'PVOID JobObjectInformation', 'ULONG JobObjectInformationLength']
 	case 225: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3921,6 +4145,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 226 NTSTATUS NtSetInformationKey ['HANDLE KeyHandle', 'KEY_SET_INFORMATION_CLASS KeySetInformationClass', 'PVOID KeySetInformation', 'ULONG KeySetInformationLength']
 	case 226: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3938,6 +4163,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 227 NTSTATUS NtSetInformationObject ['HANDLE Handle', 'OBJECT_INFORMATION_CLASS ObjectInformationClass', 'PVOID ObjectInformation', 'ULONG ObjectInformationLength']
 	case 227: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3955,6 +4181,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 228 NTSTATUS NtSetInformationProcess ['HANDLE ProcessHandle', 'PROCESSINFOCLASS ProcessInformationClass', 'PVOID ProcessInformation', 'ULONG ProcessInformationLength']
 	case 228: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3972,6 +4199,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 229 NTSTATUS NtSetInformationThread ['HANDLE ThreadHandle', 'THREADINFOCLASS ThreadInformationClass', 'PVOID ThreadInformation', 'ULONG ThreadInformationLength']
 	case 229: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -3989,6 +4217,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 230 NTSTATUS NtSetInformationToken ['HANDLE TokenHandle', 'TOKEN_INFORMATION_CLASS TokenInformationClass', 'PVOID TokenInformation', 'ULONG TokenInformationLength']
 	case 230: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4006,6 +4235,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 231 NTSTATUS NtSetIntervalProfile ['ULONG Interval', 'KPROFILE_SOURCE Source']
 	case 231: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4019,6 +4249,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 232 NTSTATUS NtSetIoCompletion ['HANDLE IoCompletionHandle', 'PVOID KeyContext', 'PVOID ApcContext', 'NTSTATUS IoStatus', 'ULONG_PTR IoStatusInformation']
 	case 232: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4038,6 +4269,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 233 NTSTATUS NtSetLdtEntries ['ULONG Selector0', 'ULONG Entry0Low', 'ULONG Entry0Hi', 'ULONG Selector1', 'ULONG Entry1Low', 'ULONG Entry1Hi']
 	case 233: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4059,6 +4291,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 234 NTSTATUS NtSetLowEventPair ['HANDLE EventPairHandle']
 	case 234: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4070,6 +4303,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 235 NTSTATUS NtSetLowWaitHighEventPair ['HANDLE EventPairHandle']
 	case 235: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4081,6 +4315,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 236 NTSTATUS NtSetQuotaInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length']
 	case 236: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4098,6 +4333,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 237 NTSTATUS NtSetSecurityObject ['HANDLE Handle', 'SECURITY_INFORMATION SecurityInformation', 'PSECURITY_DESCRIPTOR SecurityDescriptor']
 	case 237: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4113,6 +4349,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 238 NTSTATUS NtSetSystemEnvironmentValue ['PUNICODE_STRING VariableName', 'PUNICODE_STRING VariableValue']
 	case 238: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4126,6 +4363,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 239 NTSTATUS NtSetSystemEnvironmentValueEx ['PUNICODE_STRING VariableName', 'LPGUID VendorGuid', 'PVOID Value', 'ULONG ValueLength', 'ULONG Attributes']
 	case 239: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4145,6 +4383,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 240 NTSTATUS NtSetSystemInformation ['SYSTEM_INFORMATION_CLASS SystemInformationClass', 'PVOID SystemInformation', 'ULONG SystemInformationLength']
 	case 240: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4160,6 +4399,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 241 NTSTATUS NtSetSystemPowerState ['POWER_ACTION SystemAction', 'SYSTEM_POWER_STATE MinSystemState', 'ULONG Flags']
 	case 241: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4175,6 +4415,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 242 NTSTATUS NtSetSystemTime ['PLARGE_INTEGER SystemTime', 'PLARGE_INTEGER PreviousTime']
 	case 242: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4188,6 +4429,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 243 NTSTATUS NtSetThreadExecutionState ['EXECUTION_STATE esFlags', 'PEXECUTION_STATE PreviousFlags']
 	case 243: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4201,6 +4443,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 244 NTSTATUS NtSetTimer ['HANDLE TimerHandle', 'PLARGE_INTEGER DueTime', 'PTIMER_APC_ROUTINE TimerApcRoutine', 'PVOID TimerContext', 'BOOLEAN WakeTimer', 'LONG Period', 'PBOOLEAN PreviousState']
 	case 244: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4224,6 +4467,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 245 NTSTATUS NtSetTimerResolution ['ULONG DesiredTime', 'BOOLEAN SetResolution', 'PULONG ActualTime']
 	case 245: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4239,6 +4483,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 246 NTSTATUS NtSetUuidSeed ['PCHAR Seed']
 	case 246: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4250,6 +4495,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 247 NTSTATUS NtSetValueKey ['HANDLE KeyHandle', 'PUNICODE_STRING ValueName', 'ULONG TitleIndex', 'ULONG Type', 'PVOID Data', 'ULONG DataSize']
 	case 247: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4271,6 +4517,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 248 NTSTATUS NtSetVolumeInformationFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID FsInformation', 'ULONG Length', 'FS_INFORMATION_CLASS FsInformationClass']
 	case 248: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4290,6 +4537,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 249 NTSTATUS NtShutdownSystem ['SHUTDOWN_ACTION Action']
 	case 249: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4301,6 +4549,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 250 NTSTATUS NtSignalAndWaitForSingleObject ['HANDLE SignalHandle', 'HANDLE WaitHandle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 250: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4318,6 +4567,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 251 NTSTATUS NtStartProfile ['HANDLE ProfileHandle']
 	case 251: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4329,6 +4579,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 252 NTSTATUS NtStopProfile ['HANDLE ProfileHandle']
 	case 252: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4340,6 +4591,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 253 NTSTATUS NtSuspendProcess ['HANDLE ProcessHandle']
 	case 253: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4351,6 +4603,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 254 NTSTATUS NtSuspendThread ['HANDLE ThreadHandle', 'PULONG PreviousSuspendCount']
 	case 254: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4364,6 +4617,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 255 NTSTATUS NtSystemDebugControl ['SYSDBG_COMMAND Command', 'PVOID InputBuffer', 'ULONG InputBufferLength', 'PVOID OutputBuffer', 'ULONG OutputBufferLength', 'PULONG ReturnLength']
 	case 255: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4385,6 +4639,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 256 NTSTATUS NtTerminateJobObject ['HANDLE JobHandle', 'NTSTATUS ExitStatus']
 	case 256: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4398,6 +4653,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 257 NTSTATUS NtTerminateProcess ['HANDLE ProcessHandle', 'NTSTATUS ExitStatus']
 	case 257: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4411,6 +4667,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 258 NTSTATUS NtTerminateThread ['HANDLE ThreadHandle', 'NTSTATUS ExitStatus']
 	case 258: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4424,11 +4681,13 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 259 NTSTATUS NtTestAlert ['']
 	case 259: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtTestAlert_enter, cpu, pc);
 	}; break;
 	// 260 NTSTATUS NtTraceEvent ['HANDLE TraceHandle', 'ULONG Flags', 'ULONG FieldSize', 'PVOID Fields']
 	case 260: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4446,6 +4705,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 261 NTSTATUS NtTranslateFilePath ['PFILE_PATH InputFilePath', 'ULONG OutputType', 'PFILE_PATH OutputFilePath', 'PULONG OutputFilePathLength']
 	case 261: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4463,6 +4723,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 262 NTSTATUS NtUnloadDriver ['PUNICODE_STRING DriverServiceName']
 	case 262: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4474,6 +4735,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 263 NTSTATUS NtUnloadKey ['POBJECT_ATTRIBUTES TargetKey']
 	case 263: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4485,6 +4747,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 264 NTSTATUS NtUnloadKeyEx ['POBJECT_ATTRIBUTES TargetKey', 'HANDLE Event']
 	case 264: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4498,6 +4761,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 265 NTSTATUS NtUnlockFile ['HANDLE FileHandle', 'PIO_STATUS_BLOCK IoStatusBlock', 'PLARGE_INTEGER ByteOffset', 'PLARGE_INTEGER Length', 'ULONG Key']
 	case 265: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4517,6 +4781,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 266 NTSTATUS NtUnlockVirtualMemory ['HANDLE ProcessHandle', 'PVOID *BaseAddress', 'PSIZE_T RegionSize', 'ULONG MapType']
 	case 266: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4534,6 +4799,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 267 NTSTATUS NtUnmapViewOfSection ['HANDLE ProcessHandle', 'PVOID BaseAddress']
 	case 267: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4547,6 +4813,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 268 NTSTATUS NtVdmControl ['VDMSERVICECLASS Service', 'PVOID ServiceData']
 	case 268: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
@@ -4560,6 +4827,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 269 NTSTATUS NtWaitForDebugEvent ['HANDLE DebugObjectHandle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout', 'PDBGUI_WAIT_STATE_CHANGE WaitStateChange']
 	case 269: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4577,6 +4845,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 270 NTSTATUS NtWaitForMultipleObjects ['ULONG Count', 'HANDLE Handles[]', 'WAIT_TYPE WaitType', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 270: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4596,6 +4865,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 271 NTSTATUS NtWaitForSingleObject ['HANDLE Handle', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 271: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4611,6 +4881,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 272 NTSTATUS NtWaitHighEventPair ['HANDLE EventPairHandle']
 	case 272: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4622,6 +4893,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 273 NTSTATUS NtWaitLowEventPair ['HANDLE EventPairHandle']
 	case 273: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
@@ -4633,6 +4905,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 274 NTSTATUS NtWriteFile ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PVOID Buffer', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 274: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4660,6 +4933,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 275 NTSTATUS NtWriteFileGather ['HANDLE FileHandle', 'HANDLE Event', 'PIO_APC_ROUTINE ApcRoutine', 'PVOID ApcContext', 'PIO_STATUS_BLOCK IoStatusBlock', 'PFILE_SEGMENT_ELEMENT SegmentArray', 'ULONG Length', 'PLARGE_INTEGER ByteOffset', 'PULONG Key']
 	case 275: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4687,6 +4961,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 276 NTSTATUS NtWriteRequestData ['HANDLE PortHandle', 'PPORT_MESSAGE Message', 'ULONG DataEntryIndex', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesWritten']
 	case 276: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4708,6 +4983,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 277 NTSTATUS NtWriteVirtualMemory ['HANDLE ProcessHandle', 'PVOID BaseAddress', 'PVOID Buffer', 'SIZE_T BufferSize', 'PSIZE_T NumberOfBytesWritten']
 	case 277: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4727,11 +5003,13 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 278 NTSTATUS NtYieldExecution ['']
 	case 278: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtYieldExecution_enter, cpu, pc);
 	}; break;
 	// 279 NTSTATUS NtCreateKeyedEvent ['PHANDLE KeyedEventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes', 'ULONG Flags']
 	case 279: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4749,6 +5027,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 280 NTSTATUS NtOpenKeyedEvent ['PHANDLE KeyedEventHandle', 'ACCESS_MASK DesiredAccess', 'POBJECT_ATTRIBUTES ObjectAttributes']
 	case 280: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4764,6 +5043,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 281 NTSTATUS NtReleaseKeyedEvent ['HANDLE KeyedEventHandle', 'PVOID KeyValue', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 281: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4781,6 +5061,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 282 NTSTATUS NtWaitForKeyedEvent ['HANDLE KeyedEventHandle', 'PVOID KeyValue', 'BOOLEAN Alertable', 'PLARGE_INTEGER Timeout']
 	case 282: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
@@ -4798,6 +5079,7 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 	// 283 NTSTATUS NtQueryPortInformationProcess ['']
 	case 283: {
 		panda_noreturn = false;
+		ctx.double_return = false;
 		PPP_RUN_CB(on_NtQueryPortInformationProcess_enter, cpu, pc);
 	}; break;
 	default:

--- a/panda/plugins/syscalls2/generated/syscalls_ext_typedefs.h
+++ b/panda/plugins/syscalls2/generated/syscalls_ext_typedefs.h
@@ -43,6 +43,7 @@ struct syscall_ctx {
     target_ptr_t retaddr; /**< return address */
     uint8_t args[GLOBAL_MAX_SYSCALL_ARGS]
                 [GLOBAL_MAX_SYSCALL_ARG_SIZE]; /**< arguments */
+    bool double_return;
 };
 typedef struct syscall_ctx syscall_ctx_t;
 

--- a/panda/plugins/syscalls2/scripts/syscall_parser.py
+++ b/panda/plugins/syscalls2/scripts/syscall_parser.py
@@ -343,6 +343,8 @@ class SysCall(object):
         self.arch_bits = target_context['arch_conf']['bits']
         panda_noreturn_names = target_context.get('panda_noreturn', {})
         self.panda_noreturn = True if self.name in panda_noreturn_names else False
+        panda_doublereturn_names = target_context.get('panda_doublereturn', {})
+        self.panda_double_return = True if self.name in panda_doublereturn_names else False
 
         # process raw args
         self.args = []

--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -807,7 +807,6 @@ void hook_syscall_return(CPUState *cpu, TranslationBlock *tb, struct hook* h) {
         no = ctx->no;
         syscalls_profile->return_switch(cpu, tb->pc, ctx);
         if (ctx->double_return){
-            printf("double return\n");
             ctx->double_return = false;
             return;
         }else{

--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -798,11 +798,21 @@ void hook_syscall_return(CPUState *cpu, TranslationBlock *tb, struct hook* h) {
     auto k = std::make_pair(tb->pc, panda_current_asid(cpu));
     auto ctxi = running_syscalls.find(k);
     int UNUSED(no) = -1;
+    if (unlikely(ctxi == running_syscalls.end())) {
+        k = std::make_pair(tb->pc, 0);
+        ctxi = running_syscalls.find(k);
+    }
     if (likely(ctxi != running_syscalls.end())) {
         syscall_ctx_t *ctx = &ctxi->second;
         no = ctx->no;
         syscalls_profile->return_switch(cpu, tb->pc, ctx);
-        running_syscalls.erase(ctxi);
+        if (ctx->double_return){
+            printf("double return\n");
+            ctx->double_return = false;
+            return;
+        }else{
+            running_syscalls.erase(ctxi);
+        }
     }
 #if defined(SYSCALL_RETURN_DEBUG)
     if (no >= 0) {


### PR DESCRIPTION
This PR adda another category of special syscalls called "double return". This category represents those syscalls that return twice in potentially different ASIDs to the same program counter. This is mostly just fork, but it could be other things too.

I also added "sys_exit_group" to the `context_target.json` for noreturns, but really that whole file needs a rethink.