### PR TITLE
adding physical_mem_r/w wrappers

### DIFF
--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -96,6 +96,23 @@ static inline int panda_physical_memory_rw(hwaddr addr, uint8_t *buf, int len,
 }
 
 /**
+ * @brief Reads data into \p buf from guest physical address \p addr.
+ */
+static inline int panda_physical_memory_read(hwaddr addr,
+                                            uint8_t *buf, int len) {
+    return panda_physical_memory_rw(addr, buf, len, 0);
+}
+
+/**
+ * @brief Writes data from \p buf data to guest physical address \p addr.
+ */
+static inline int panda_physical_memory_write(hwaddr addr,
+                                             uint8_t *buf, int len) {
+    return panda_physical_memory_rw(addr, buf, len, 1);
+}
+
+
+/**
  * @brief Translates guest virtual addres \p addr to a guest physical address.
  */
 static inline hwaddr panda_virt_to_phys(CPUState *env, target_ulong addr) {

--- a/panda/plugins/memsavep/memsavep.c
+++ b/panda/plugins/memsavep/memsavep.c
@@ -49,7 +49,7 @@ static void actually_dump_physical_memory(FILE* out, size_t len)
         size_t l = sizeof(block);
         if (l > len)
             l = len;
-        if (panda_physical_memory_rw(addr, block, l, false) == MEMTX_OK)
+        if (panda_physical_memory_read(addr, block, l) == MEMTX_OK)
             fwrite(block, 1, l, out);
         else
             fwrite(_zero_block, 1, l, out);

--- a/panda/plugins/pri_taint/pri_taint.cpp
+++ b/panda/plugins/pri_taint/pri_taint.cpp
@@ -129,7 +129,7 @@ void lava_taint_query(target_ulong buf, LocType loc_t, target_ulong buf_len, con
     uint8_t bytes[LAVA_TAINT_QUERY_MAX_LEN] = {0};
     uint32_t len = std::min(buf_len, LAVA_TAINT_QUERY_MAX_LEN);
     if (is_strnlen) {
-        panda_physical_memory_rw(phys, bytes, LAVA_TAINT_QUERY_MAX_LEN, false);
+        panda_physical_memory_read(phys, bytes, LAVA_TAINT_QUERY_MAX_LEN);
         for (int i = 0; i < LAVA_TAINT_QUERY_MAX_LEN; i++) {
             if (bytes[i] == '\0') {
                 len = i;

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -144,11 +144,11 @@ int panda_virtual_memory_write_external(CPUState *env, target_ulong addr, char *
 }
 
 int panda_physical_memory_read_external(hwaddr addr, uint8_t *buf, int len){
-	return panda_physical_memory_rw(addr, buf, len, 0);
+	return panda_physical_memory_read(addr, buf, len);
 }
 
 int panda_physical_memory_write_external(hwaddr addr, uint8_t *buf, int len){
-	return panda_physical_memory_rw(addr,buf,len, 1);
+	return panda_physical_memory_write(addr,buf,len);
 }
 
 bool panda_in_kernel_external(const CPUState *cpu){


### PR DESCRIPTION
This adds `panda_physical_mem_read` and `panda_physical_mem_read` methods as inlines in the style of `panda_virtual_mem_(r/w)`.

I'm honestly just surprised it doesn't already exist. I think that's because we use it extensively this way in pypanda.