### PR TITLE
Add shared library path API

### DIFF
--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -154,7 +154,9 @@ char** str_split(char *a_str, const char a_delim);
 extern gchar *panda_argv[MAX_PANDA_PLUGIN_ARGS];
 extern int panda_argc;
 
+char* resolve_file_from_plugin_directory(const char* file_name_fmt, const char* name);
 char *panda_plugin_path(const char *name);
+char* panda_shared_library_path(const char* name);
 void panda_require_from_library(const char *plugin_name, char **plugin_args, uint32_t num_args);
 void panda_require(const char *plugin_name);
 bool panda_is_callback_enabled(void *plugin, panda_cb_type type, panda_cb cb);

--- a/panda/plugins/syscalls2/syscalls2_info.c
+++ b/panda/plugins/syscalls2/syscalls2_info.c
@@ -42,7 +42,14 @@ int load_syscall_info(void) {
     }
 
     dlerror();  // clear errors
-    void *syscall_info_dl = dlopen(syscall_info_dlname, RTLD_NOW|RTLD_NODELETE);
+
+    char* sys_info_dlname_path = panda_shared_library_path(syscall_info_dlname);
+    if (sys_info_dlname_path == NULL) {
+        fprintf(stderr, "Could not find %s\n", syscall_info_dlname);
+        return -1;
+    }
+
+    void *syscall_info_dl = dlopen(sys_info_dlname_path, RTLD_NOW|RTLD_NODELETE);
     if (syscall_info_dl == NULL) {
         LOG_ERROR("%s", dlerror());
         g_free(syscall_info_dlname);


### PR DESCRIPTION
- Generalize  `panda_plugin_path` into new `resolve_file_from_plugin_directory`
- Add `panda_shared_library_path` method using new `resolve_file_from_plugin_directory`
- Add logic to syscalls2_info.c to use `panda_shared_library_path`.

CLOSES: #901 