### PR TITLE
apigen support no args for function

### DIFF
--- a/panda/scripts/apigen.py
+++ b/panda/scripts/apigen.py
@@ -28,9 +28,12 @@ def get_arglists(pf):
             #print "function name = [%s]" % function_name
             fundec = d.children()[0][1]
             args[function_name] = []
-            for arg in fundec.args.params:
-                if not (arg.name is None):
-                    args[function_name].append(arg.name)
+            # if a function does not have args it will not have params
+            # member
+            if hasattr(fundec.args,"params"):
+                for arg in fundec.args.params:
+                    if not (arg.name is None):
+                        args[function_name].append(arg.name)
     return args
 
 


### PR DESCRIPTION
apigen.py currently throws an error for any function similar to:

```
int fn();
void fn();
target_ulong fn();
```

The generally solution to this has been to change the function to:

```
int fn(void);
void fn(void);
target_ulong fn(void);
```

Which is fine, but it'd be better to just support the full range of options. Here I add an if statement that allows the first case.
