### PR TITLE
Configurable Machine: Additional Features

### DIFF
--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -253,7 +253,7 @@ static void init_memory_area(QDict *mapping, const char *kernel_filename)
     char * data = NULL;
     const char * name;
     MemoryRegion * ram;
-    uint64_t address;
+    uint64_t address, alias_address;
     int is_rom;
     MemoryRegion *sysmem = get_system_memory();
 
@@ -287,6 +287,17 @@ static void init_memory_area(QDict *mapping, const char *kernel_filename)
     printf("Configurable: Adding memory region %s (size: 0x%"
            PRIx64 ") at address 0x%" PRIx64 "\n", name, size, address);
     memory_region_add_subregion(sysmem, address, ram);
+
+    if(qdict_haskey(mapping, "alias_at")) {
+        QDICT_ASSERT_KEY_TYPE(mapping, "alias_at", QTYPE_QINT);
+        alias_address = qdict_get_int(mapping, "alias_at");
+
+        printf("Configurable: Adding alias to region %s at address 0x%" PRIx64 "\n", name, alias_address);
+        MemoryRegion *alias;
+        alias =  g_new(MemoryRegion, 1);
+        memory_region_init_alias(alias, NULL, name, ram, 0, size);
+        memory_region_add_subregion(sysmem, alias_address, alias);
+    }
 
     if (qdict_haskey(mapping, "file"))
     {


### PR DESCRIPTION
This PR includes two features for the configurable machine:
1) reading only parts of a file, at specified offset, as contents to memory regions. (Feature was available in upstream-qemu since quite a while, but never ported to panda).
2) Allowing to create aliases to memory ranges, by adding an "alias_at" entry to the range in the configuration json. (new feature, thanks to @noopwafel!)