### PR TITLE
Fix windows 7 os naming convention in examples

### DIFF
--- a/panda/plugins/syscalls2/README.md
+++ b/panda/plugins/syscalls2/README.md
@@ -172,7 +172,7 @@ And then invoke it as:
 
 ```sh
 $PANDA_PATH/x86_64-softmmu/panda-system-x86_64 -replay foo \
-    -os windows-32-7 -panda syscalls2 -panda filereadmon
+    -os windows-32-7sp1 -panda syscalls2 -panda filereadmon
 ```
 
 If you'd like more examples, you can have a look at `loaded`, `filereadmon` and `file_taint`, all of which use `syscalls2`.

--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -1026,7 +1026,7 @@ bool init_plugin(void *self) {
 // Don't bother if we're not on a supported target
 #if defined(TARGET_I386) || defined(TARGET_ARM) || defined(TARGET_MIPS)
     if(panda_os_familyno == OS_UNKNOWN){
-        std::cerr << PANDA_MSG "ERROR No OS profile specified. You can choose one with the -os switch, eg: '-os linux-32-debian-3.2.81-486' or '-os  windows-32-7' " << std::endl;
+        std::cerr << PANDA_MSG "ERROR No OS profile specified. You can choose one with the -os switch, eg: '-os linux-32-debian-3.2.81-486' or '-os  windows-32-7sp[01]' " << std::endl;
         return false;
     }
     else if (panda_os_familyno == OS_LINUX) {

--- a/panda/python/examples/example_win.py
+++ b/panda/python/examples/example_win.py
@@ -12,7 +12,7 @@ rec = False
 if rec:
     panda = Panda(qcow="win7pro_x86.qcow2",mem="4G", extra_args=["-vnc", "127.0.0.1:5900", "-monitor","telnet:127.0.0.1:55555,server,nowait"])
 else:
-    panda = Panda(qcow="win7pro_x86.qcow2",mem="4G", extra_args=["-nographic"],os_version="windows-32-7")
+    panda = Panda(qcow="win7pro_x86.qcow2",mem="4G", extra_args=["-nographic"],os_version="windows-32-7sp1")
 
 first = True
 


### PR DESCRIPTION
In PR #1138 the windows-32-7 profile was split into windows-32-7sp[01].
This PR simply updates the examples accordingly.