### PR TITLE
Update function prototypes in extern "C" block to match function definitions.

### DIFF
--- a/panda/plugins/wintrospection/wintrospection.cpp
+++ b/panda/plugins/wintrospection/wintrospection.cpp
@@ -51,9 +51,9 @@ extern "C" {
 bool init_plugin(void *);
 void uninit_plugin(void *);
 
-int64_t get_file_handle_pos(uint64_t handle);
-char *get_cwd(void);
-char *get_handle_name(uint64_t handle);
+int64_t get_file_handle_pos(CPUState *cpu, uint64_t handle);
+char *get_cwd(CPUState *cpu);
+char *get_handle_name(CPUState *cpu, uint64_t handle);
 }
 
 void on_get_current_thread(CPUState *cpu, OsiThread *out);


### PR DESCRIPTION
I have some plugins that depend on wintrospection that aren't working with the new version of the wintrospection plugin.

I'm getting a runtime symbol resolution error when my plugin is loaded (get_handle_name).

I tracked it down to a mismatch between the function prototypes in the extern C block in wintrospection.cpp.  These didn't match the actual function definitions.  Updating these to match resulted in the functions not getting name mangled in the target dynamic library and my symbol resolution problems disappeared.