### PR TITLE
Add panda_break_exec which will jump out of execution from SBE CBs

### DIFF
--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -92,9 +92,13 @@ extern PandaOsFamily panda_os_familyno; // numeric identifier for family
 
 
 
+/* Internal callback functions that plugins shouldn't use. These unset the flag when called so must be handled */
+bool panda_break_exec(void);
 bool panda_flush_tb(void);
 
+/* Regular functions plugins should use */
 void panda_do_flush_tb(void);
+void panda_do_break_exec(void);
 void panda_enable_precise_pc(void);
 void panda_disable_precise_pc(void);
 void panda_enable_memcb(void);

--- a/panda/plugins/forcedexec/forcedexec.cpp
+++ b/panda/plugins/forcedexec/forcedexec.cpp
@@ -71,14 +71,14 @@ void tcg_parse(CPUState *env, TranslationBlock *tb) {
 void enable_forcedexec() {
     assert(self != NULL);
     panda_enable_callback(self, PANDA_CB_BEFORE_TCG_CODEGEN, tcg_cb);
-    panda_flush_tb();
+    panda_do_flush_tb();
 }
 
 void disable_forcedexec() {
     assert(self != NULL);
     panda_disable_callback(self, PANDA_CB_BEFORE_TCG_CODEGEN, tcg_cb);
-    panda_flush_tb(); // Really we only need to flush blocks we flipped-
-                      // we could track that and then optimize this.
+    panda_do_flush_tb(); // Really we only need to flush blocks we flipped-
+                         // we could track that and then optimize this.
 }
 
 

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -1177,6 +1177,13 @@ class Panda():
         '''
         return self.libpanda.panda_do_flush_tb()
 
+    def break_exec(self):
+        '''
+        If called from a start block exec callback, will cause the emulation to bail *before* executing
+        the rest of the current block.
+        '''
+        return self.libpanda.panda_do_break_exec()
+
     def enable_precise_pc(self):
         '''
         By default, QEMU does not update the program counter after every instruction.

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -64,6 +64,7 @@ int nb_panda_plugins_loaded = 0;
 char *panda_plugins_loaded[MAX_PANDA_PLUGINS];
 
 bool panda_please_flush_tb = false;
+bool panda_please_break_exec = false;
 bool panda_update_pc = false;
 bool panda_use_memcb = false;
 bool panda_tb_chaining = true;
@@ -780,6 +781,20 @@ panda_cb_list *panda_cb_list_next(panda_cb_list *plist)
             return node;
     }
     return NULL;
+}
+
+void panda_do_break_exec(void) {
+  panda_please_break_exec = true;
+}
+
+bool panda_break_exec(void) {
+    if (panda_please_break_exec) {
+        panda_please_break_exec = false;
+        return true;
+    } else {
+        return false;
+    }
+
 }
 
 bool panda_flush_tb(void)


### PR DESCRIPTION
This logic mirrors the existing panda_flush_tb code, only it's checked at the end of SBE callbacks.

This allows for a user to change program counter in an SBE callback and immediately redirect control flow without running the original block. Similarly, the block can be modified and dropped from the tcg cache and it will then be retranslated before being executed. This may make before_block_invalidate_opt redundant.

Also updates forcedexecution plugin to use panda_flush_tb instead of the internal panda_do_flush_tb.