### PR TITLE
Some minor PyPANDA enhancements 

### DIFF
--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -2327,7 +2327,9 @@ class Panda():
     @blocking
     def type_serial_cmd(self, cmd):
         #Can send message into socket without guest running (no self.running.wait())
-        self.serial_console.send(cmd.encode("utf8")) # send, not sendline
+        if isinstance(cmd, str):
+            cmd = cmd.encode('utf8')
+        self.serial_console.send(cmd) # send, not sendline
 
     def finish_serial_cmd(self):
         result = self.serial_console.send_eol()

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -1643,6 +1643,17 @@ class Panda():
         os_name_new = self.ffi.new("char[]", bytes(os_name, "utf-8"))
         self.libpanda.panda_set_os_name(os_name_new)
 
+    def get_os_family(self):
+        '''
+        Get the current OS family name. Valid values are the entries in `OSFamilyEnum`
+
+        Returns:
+            string: one of OS_UNKNOWN, OS_WINDOWS, OS_LINUX, OS_FREEBSD
+        '''
+
+        family_num = self.libpanda.panda_os_familyno
+        family_name = self.ffi.string(self.ffi.cast("PandaOsFamily", family_num))
+        return family_name
 
     def get_mappings(self, cpu):
         '''

--- a/panda/python/core/pandare/panda_expect.py
+++ b/panda/python/core/pandare/panda_expect.py
@@ -440,8 +440,8 @@ class Expect(object):
             self.consumed_first = True
 
         # Newlines will call problems
-        assert len(msg.decode().split("\n")) <= 2, "Multiline cmds unsupported"
-        self.last_msg = msg.decode().replace("\n", "")
+        assert len(msg.decode(errors='ignore').split("\n")) <= 2, "Multiline cmds unsupported"
+        self.last_msg = msg.decode(errors='ignore').replace("\n", "")
         os.write(self.fd, msg)
         if self.logfile:
             self.logfile.write(msg)

--- a/panda/python/core/pandare/pypluginmanager.py
+++ b/panda/python/core/pandare/pypluginmanager.py
@@ -29,7 +29,7 @@ class _PppFuncs(_DotGetter):
         method = self.data.get(name, None)
         if method is None:
             raise AttributeError(f"No method {name}: available options are {self}")
-        return lambda *args: method(*args)
+        return lambda *args, **kwargs: method(*args, **kwargs)
 
 class _PppPlugins(_DotGetter):
     def __getattr__(self, name):

--- a/panda/scripts/scgen.py
+++ b/panda/scripts/scgen.py
@@ -34,6 +34,7 @@ def gen_syscalls(os_arch):
     if not path.isfile(target):
         raise ValueError(f"Unsupported os_arch: {os_arch} - could not find {target}")
 
+    seen = {} # name -> [entry details]
     with open(target) as f:
         for line in f.readlines():
             if not len(line):
@@ -47,17 +48,38 @@ def gen_syscalls(os_arch):
             sys_name = line.split(" ")[2].split("(")[0]
 
             sys_name = sys_name.replace("sys_", "")
-            if sys_name.startswith("do_"):
-                sys_name.replace("do_", "")
+            if sys_name.startswith("do_"): # Unify names
+                sys_name = sys_name.replace("do_", "")
+
+            if sys_name.startswith("*"): # Parser put type into name
+                sys_name = sys_name.replace("*", "")
+
+            if sys_name not in seen:
+                seen[sys_name] = []
+            seen[sys_name].append(line)
+
             syscalls[sys_name] = sys_no
             num_sc[sys_no] = sys_name
 
-    #return syscalls
+    # Duplicates only show up in FreeBSD. It seems like we want to generally take the maximum value we see
+    # though this will cause some issues for older OSes. Is there a way to get the OS version -> syscall name details
+    # and then incorporate those?
+
+    # Print a warning, then drop all but the highest number
+    for name, dups in seen.items():
+        if len(dups) > 1:
+            print(f"WARNING dupliate entries for {name}:\n\t" + '\t'.join([x for x in dups]))
+
+            nums = [x for x,s_name in num_sc.items() if s_name == name]
+            non_max = [x for x in nums if x != max(nums)]
+            for x in non_max:
+                del num_sc[x]
+
     return num_sc
 
 if __name__ == '__main__':
     results = {}
-    for arch in ['linux_arm', 'linux_mips', 'linux_x64', 'linux_x86']:
+    for arch in ['linux_arm', 'linux_mips', 'linux_x64', 'linux_x86', 'freebsd_x64']:
         results[arch] = gen_syscalls(arch)
     with open("syscalls.json", 'w') as f:
         json.dump(results, f)


### PR DESCRIPTION
* Pandare.arch: represent syscall errors consistently as a negative number
* Add get_os_family() to get name of current OS family
* Support kwargs for PyPlugins
* Support sending bytes with panda.expect

Also fixes a bug in the (non-pypanda) python script SCGen.py to not generate invalid JSON (with duplicate keys) when the same syscall has multiple numbers.