### PR TITLE
Revert syscalls hooks to BTC to fix performance bug

### DIFF
--- a/panda/plugins/syscalls2/generated-tpl/syscall_switch_enter.tpl
+++ b/panda/plugins/syscalls2/generated-tpl/syscall_switch_enter.tpl
@@ -77,8 +77,10 @@ void syscall_enter_switch_{{os}}_{{arch}}(CPUState *cpu, target_ptr_t pc, int st
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_freebsd_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_freebsd_x64.cpp
@@ -6749,8 +6749,10 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm.cpp
@@ -5377,8 +5377,10 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm64.cpp
@@ -4461,8 +4461,10 @@ void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_mips.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_mips.cpp
@@ -6079,8 +6079,10 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x64.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x64.cpp
@@ -4905,8 +4905,10 @@ void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_c
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x86.cpp
@@ -5469,8 +5469,10 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_2000_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_2000_x86.cpp
@@ -4431,8 +4431,10 @@ void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int s
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_7_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_7_x86.cpp
@@ -7177,8 +7177,10 @@ void syscall_enter_switch_windows_7_x86(CPUState *cpu, target_ptr_t pc, int stat
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp2_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp2_x86.cpp
@@ -5093,8 +5093,10 @@ void syscall_enter_switch_windows_xpsp2_x86(CPUState *cpu, target_ptr_t pc, int 
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp3_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_windows_xpsp3_x86.cpp
@@ -5093,8 +5093,10 @@ void syscall_enter_switch_windows_xpsp3_x86(CPUState *cpu, target_ptr_t pc, int 
 		struct hook h;
 		h.addr = ctx.retaddr;
 		h.asid = ctx.asid;
-		h.cb.start_block_exec = hook_syscall_return;
-		h.type = PANDA_CB_START_BLOCK_EXEC;
+		//h.cb.start_block_exec = hook_syscall_return;
+		//h.type = PANDA_CB_START_BLOCK_EXEC;
+		h.cb.before_tcg_codegen = hook_syscall_return;
+		h.type = PANDA_CB_BEFORE_TCG_CODEGEN;
 		h.enabled = true;
 		h.km = MODE_ANY; //you'd expect this to be user only
 		hooks_add_hook(&h);


### PR DESCRIPTION
I believe @lacraig2 is working on a better solution for #1167, so maybe we want to wait for that - but this PR just reverts the change from #1003 that made syscalls2 use before_tcg_codegen over start_block_exec.


Fixes #1167