### PR TITLE
Change panda_current_pc to use precise pc if enabled

### DIFF
--- a/cputlb.c
+++ b/cputlb.c
@@ -36,6 +36,9 @@
 #include "panda/rr/rr_log.h"
 #include "panda/callbacks/cb-support.h"
 
+// less frustrating than importing common.h
+extern target_ulong panda_current_pc(CPUState *cpu);
+
 /* DEBUG defines, enable DEBUG_TLB_LOG to log to the CPU_LOG_MMU target */
 /* #define DEBUG_TLB */
 /* #define DEBUG_TLB_LOG */

--- a/memory.c
+++ b/memory.c
@@ -34,6 +34,9 @@
 #include "panda/rr/rr_log_all.h"
 #include "panda/callbacks/cb-support.h"
 
+// less annoying than importing all common.h
+extern target_ulong panda_current_pc(CPUState *cpu);
+
 static unsigned memory_region_transaction_depth;
 static bool memory_region_update_pending;
 static bool ioeventfd_update_pending;
@@ -1103,7 +1106,7 @@ static uint64_t _unassigned_mem_read(void *opaque, hwaddr addr,
     if (current_cpu != NULL) {
         // PANDA callback may create a value. If so, avoid error-handling code
         if (panda_callbacks_unassigned_io_read(current_cpu,
-                    current_cpu->panda_guest_pc, addr, size, &val)) { // Modifies val
+                    panda_current_pc(current_cpu), addr, size, &val)) { // Modifies val
             *changed = true; // Indicates a callback has changed the value
             return val;
         }
@@ -1127,7 +1130,7 @@ static bool _unassigned_mem_write(void *opaque, hwaddr addr,
 #endif
 
     if (current_cpu != NULL) {
-        if (panda_callbacks_unassigned_io_write(current_cpu, current_cpu->panda_guest_pc, addr, size, val)) {
+        if (panda_callbacks_unassigned_io_write(current_cpu, panda_current_pc(current_cpu), addr, size, val)) {
             // A plugin has decided to make this write look like it's valid
             return true;
         }

--- a/panda/docs/manual.md
+++ b/panda/docs/manual.md
@@ -273,7 +273,7 @@ void panda_disable_precise_pc(void);
 ```
 These functions enable or disable precise tracking of the program counter.
 After enabling precise PC tracking, the program counter will be available in
-`env->panda_guest_pc` and can be assumed to accurately reflect the guest state.
+`env->panda_guest_pc` and can be assumed to accurately reflect the guest state. In most cases the helper function `panda_current_pc` should be used. It will provide the precise PC if enabled.
 
 Some plugins (`taint2`, `callstack_instr`, etc) add instrumentation that runs
 *inside* a basic block of emulated code.  If such a plugin is enabled mid-replay
@@ -375,6 +375,10 @@ Possible return values are:
     ```
     Writes a textual representation of disassembly of the guest code
     at virtual address `code` of `size` bytes.
+  * ```C
+    target_ulong panda_current_pc(CPUState *cpu);
+    ```
+    Returns current program counter. If `panda_precise_pc` has been enabled it returns the precise value.
 
 ## Record/Replay Details
 

--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -366,7 +366,7 @@ static inline bool address_in_kernel_code_linux(target_ulong addr){
  * Therefore, certain analysis logic can't rely on panda_in_kernel_mode() alone.
  */
 static inline bool panda_in_kernel_code_linux(CPUState *cpu) {
-    return address_in_kernel_code_linux(cpu->panda_guest_pc);
+    return address_in_kernel_code_linux(panda_current_pc(cpu));
 }
 
 /**

--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -459,7 +459,7 @@ void get_prog_point(CPUState* cpu, prog_point *p) {
 
     }
 
-    p->pc = cpu->panda_guest_pc;
+    p->pc = panda_current_pc(cpu);
 }
 
 // prepare OSI support that is needed for the threaded stack type

--- a/panda/plugins/func_stats/func_stats.cpp
+++ b/panda/plugins/func_stats/func_stats.cpp
@@ -330,7 +330,7 @@ target_ulong get_current_function(CPUState *cpu){
 void initialize_call_obj(CPUState *cpu, Asid curr_asid, target_ulong entrypoint){
     call_infos[entrypoint].asid = curr_asid;
     call_infos[entrypoint].entrypoint =  entrypoint;
-    call_infos[entrypoint].pc = cpu->panda_guest_pc; //same as the passed pc to mem callbacks, get_prog_point, but diferent than tb->pc, since tb->pc is the start of the block, while pc is the trigger
+    call_infos[entrypoint].pc = panda_current_pc(cpu); //same as the passed pc to mem callbacks, get_prog_point, but diferent than tb->pc, since tb->pc is the start of the block, while pc is the trigger
     call_infos[entrypoint].rr_instr_count =  rr_get_guest_instr_count();
 
     // Get the callstack and functionstack for each call.

--- a/panda/plugins/ida_taint2/ida_taint2.cpp
+++ b/panda/plugins/ida_taint2/ida_taint2.cpp
@@ -78,7 +78,7 @@ void taint_state_changed(Addr a, uint64_t size)
 
     // Get current PID (if in user-mode and OSI gave us a process) and PC.
     IDATaintReport report;
-    report.pc = first_cpu->panda_guest_pc;
+    report.pc = panda_current_pc(first_cpu);
     report.pid = 0;
     char *process_name = NULL;
     if (false == panda_in_kernel(first_cpu)) {

--- a/panda/plugins/mmio_trace/mmio_trace.cpp
+++ b/panda/plugins/mmio_trace/mmio_trace.cpp
@@ -34,14 +34,14 @@ extern "C" {
 
 // PANDA_CB_MMIO_AFTER_READ callback
 void buffer_mmio_read(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
-    mmio_event_t new_event{'R', env->panda_guest_pc, physaddr, vaddr, size, *val, default_dev_name};
+    mmio_event_t new_event{'R', panda_current_pc(env), physaddr, vaddr, size, *val, default_dev_name};
     mmio_events.push_back(new_event);
     return;
 }
 
 // PANDA_CB_MMIO_BEFORE_WRITE callback
 void buffer_mmio_write(CPUState *env, target_ptr_t physaddr, target_ptr_t vaddr, size_t size, uint64_t *val) {
-    mmio_event_t new_event{'W', env->panda_guest_pc, physaddr, vaddr, size, *val, default_dev_name};
+    mmio_event_t new_event{'W', panda_current_pc(env), physaddr, vaddr, size, *val, default_dev_name};
     mmio_events.push_back(new_event);
     return;
 }

--- a/panda/plugins/taint2/taint_sym_api.cpp
+++ b/panda/plugins/taint2/taint_sym_api.cpp
@@ -133,7 +133,7 @@ void reg_branch_pc(z3::expr condition, bool concrete) {
     if(!symexEnabled) taint2_enable_sym();
 
     z3::expr pc(context);
-    target_ulong current_pc = first_cpu->panda_guest_pc;
+    target_ulong current_pc = panda_current_pc(first_cpu);
 
     pc = (concrete ? condition : !condition);
 #ifndef SYM_NOOPT

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -306,7 +306,7 @@ void PCB(mem_before_read)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_VIRT_MEM_BEFORE_READ]; plist != NULL;
         plist = panda_cb_list_next(plist)) {
-        if (plist->enabled) plist->entry.virt_mem_before_read(plist->context, env, env->panda_guest_pc, addr,
+        if (plist->enabled) plist->entry.virt_mem_before_read(plist->context, env, panda_current_pc(env), addr,
                                                               data_size);
     }
     if (panda_cbs[PANDA_CB_PHYS_MEM_BEFORE_READ]) {
@@ -314,7 +314,7 @@ void PCB(mem_before_read)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
         if (paddr == -1) return;
         for(plist = panda_cbs[PANDA_CB_PHYS_MEM_BEFORE_READ]; plist != NULL;
             plist = panda_cb_list_next(plist)) {
-            if (plist->enabled) plist->entry.phys_mem_before_read(plist->context, env, env->panda_guest_pc,
+            if (plist->enabled) plist->entry.phys_mem_before_read(plist->context, env, panda_current_pc(env),
                                                                   paddr, data_size);
         }
     }
@@ -327,7 +327,7 @@ void PCB(mem_after_read)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     for(plist = panda_cbs[PANDA_CB_VIRT_MEM_AFTER_READ]; plist != NULL;
         plist = panda_cb_list_next(plist)) {
         /* mstamat: Passing &result as the last cb arg doesn't make much sense. */
-        if (plist->enabled) plist->entry.virt_mem_after_read(plist->context, env, env->panda_guest_pc, addr,
+        if (plist->enabled) plist->entry.virt_mem_after_read(plist->context, env, panda_current_pc(env), addr,
                                          data_size, (uint8_t *)&result);
     }
     if (panda_cbs[PANDA_CB_PHYS_MEM_AFTER_READ]) {
@@ -336,7 +336,7 @@ void PCB(mem_after_read)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
         for(plist = panda_cbs[PANDA_CB_PHYS_MEM_AFTER_READ]; plist != NULL;
             plist = panda_cb_list_next(plist)) {
             /* mstamat: Passing &result as the last cb arg doesn't make much sense. */
-            if (plist->enabled) plist->entry.phys_mem_after_read(plist->context, env, env->panda_guest_pc, paddr,
+            if (plist->enabled) plist->entry.phys_mem_after_read(plist->context, env, panda_current_pc(env), paddr,
                                              data_size, (uint8_t *)&result);
         }
     }
@@ -349,7 +349,7 @@ void PCB(mem_before_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     for(plist = panda_cbs[PANDA_CB_VIRT_MEM_BEFORE_WRITE]; plist != NULL;
         plist = panda_cb_list_next(plist)) {
         /* mstamat: Passing &val as the last arg doesn't make much sense. */
-        if (plist->enabled) plist->entry.virt_mem_before_write(plist->context, env, env->panda_guest_pc, addr,
+        if (plist->enabled) plist->entry.virt_mem_before_write(plist->context, env, panda_current_pc(env), addr,
                                            data_size, (uint8_t *)&val);
     }
     if (panda_cbs[PANDA_CB_PHYS_MEM_BEFORE_WRITE]) {
@@ -358,7 +358,7 @@ void PCB(mem_before_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
         for(plist = panda_cbs[PANDA_CB_PHYS_MEM_BEFORE_WRITE]; plist != NULL;
             plist = panda_cb_list_next(plist)) {
             /* mstamat: Passing &val as the last cb arg doesn't make much sense. */
-            if (plist->enabled) plist->entry.phys_mem_before_write(plist->context, env, env->panda_guest_pc, paddr,
+            if (plist->enabled) plist->entry.phys_mem_before_write(plist->context, env, panda_current_pc(env), paddr,
                                                data_size, (uint8_t *)&val);
         }
     }
@@ -371,7 +371,7 @@ void PCB(mem_after_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
     for (plist = panda_cbs[PANDA_CB_VIRT_MEM_AFTER_WRITE]; plist != NULL;
          plist = panda_cb_list_next(plist)) {
         /* mstamat: Passing &val as the last cb arg doesn't make much sense. */
-        if (plist->enabled) plist->entry.virt_mem_after_write(plist->context, env, env->panda_guest_pc, addr,
+        if (plist->enabled) plist->entry.virt_mem_after_write(plist->context, env, panda_current_pc(env), addr,
                                           data_size, (uint8_t *)&val);
     }
     if (panda_cbs[PANDA_CB_PHYS_MEM_AFTER_WRITE]) {
@@ -380,7 +380,7 @@ void PCB(mem_after_write)(CPUState *env, target_ptr_t pc, target_ptr_t addr,
         for (plist = panda_cbs[PANDA_CB_PHYS_MEM_AFTER_WRITE]; plist != NULL;
              plist = panda_cb_list_next(plist)) {
             /* mstamat: Passing &val as the last cb arg doesn't make much sense. */
-            if (plist->enabled) plist->entry.phys_mem_after_write(plist->context, env, env->panda_guest_pc, paddr,
+            if (plist->enabled) plist->entry.phys_mem_after_write(plist->context, env, panda_current_pc(env), paddr,
                                               data_size, (uint8_t *)&val);
         }
     }

--- a/panda/src/common.c
+++ b/panda/src/common.c
@@ -146,11 +146,16 @@ target_ulong panda_current_pc(CPUState *cpu) {
     if (cpu == NULL) {
         return 0;
     }
-    CPUArchState *env = (CPUArchState *)cpu->env_ptr;
-    target_ulong pc, cs_base;
-    uint32_t flags;
-    cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
-    return pc;
+    // give precise PC if enabled
+    if (panda_update_pc){
+        return cpu->panda_guest_pc;
+    }else{
+        CPUArchState *env = (CPUArchState *)cpu->env_ptr;
+        target_ulong pc, cs_base;
+        uint32_t flags;
+        cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
+        return pc;
+    }
 }
 
 /**

--- a/softmmu_template.h
+++ b/softmmu_template.h
@@ -436,9 +436,9 @@ WORD_TYPE glue(helper_le_ld_name, _panda)(CPUArchState *env, target_ulong addr,
         retaddr = GETPC();
     }
 
-    panda_callbacks_mem_before_read(cpu, cpu->panda_guest_pc, addr, DATA_SIZE, (void *)haddr);
+    panda_callbacks_mem_before_read(cpu, panda_current_pc(cpu), addr, DATA_SIZE, (void *)haddr);
     WORD_TYPE ret = helper_le_ld_name(env, addr, oi, retaddr);
-    panda_callbacks_mem_after_read(cpu, cpu->panda_guest_pc, addr, DATA_SIZE, (uint64_t)ret, (void *)haddr);
+    panda_callbacks_mem_after_read(cpu, panda_current_pc(cpu), addr, DATA_SIZE, (uint64_t)ret, (void *)haddr);
     return ret;
 }
 
@@ -465,9 +465,9 @@ void glue(helper_le_st_name, _panda)(CPUArchState *env, target_ulong addr,
         retaddr = GETPC();
     }
 
-    panda_callbacks_mem_before_write(cpu, cpu->panda_guest_pc, addr, DATA_SIZE, (uint64_t)val, (void *)haddr);
+    panda_callbacks_mem_before_write(cpu, panda_current_pc(cpu), addr, DATA_SIZE, (uint64_t)val, (void *)haddr);
     helper_le_st_name(env, addr, val, oi, retaddr);
-    panda_callbacks_mem_after_write(cpu, cpu->panda_guest_pc, addr, DATA_SIZE, (uint64_t)val, (void *)haddr);
+    panda_callbacks_mem_after_write(cpu, panda_current_pc(cpu), addr, DATA_SIZE, (uint64_t)val, (void *)haddr);
 }
 
 #if DATA_SIZE > 1
@@ -493,9 +493,9 @@ WORD_TYPE glue(helper_be_ld_name, _panda)(CPUArchState *env, target_ulong addr,
         retaddr = GETPC();
     }
 
-    panda_callbacks_mem_before_read(cpu, cpu->panda_guest_pc, addr, DATA_SIZE, (void *)haddr);
+    panda_callbacks_mem_before_read(cpu, panda_current_pc(cpu), addr, DATA_SIZE, (void *)haddr);
     WORD_TYPE ret = helper_be_ld_name(env, addr, oi, retaddr);
-    panda_callbacks_mem_after_read(cpu, cpu->panda_guest_pc, addr, DATA_SIZE, (uint64_t)ret, (void *)haddr);
+    panda_callbacks_mem_after_read(cpu, panda_current_pc(cpu), addr, DATA_SIZE, (uint64_t)ret, (void *)haddr);
     return ret;
 }
 
@@ -522,9 +522,9 @@ void glue(helper_be_st_name, _panda)(CPUArchState *env, target_ulong addr,
         retaddr = GETPC();
     }
 
-    panda_callbacks_mem_before_write(cpu, cpu->panda_guest_pc, addr, DATA_SIZE, (uint64_t)val, (void *)haddr);
+    panda_callbacks_mem_before_write(cpu, panda_current_pc(cpu), addr, DATA_SIZE, (uint64_t)val, (void *)haddr);
     helper_be_st_name(env, addr, val, oi, retaddr);
-    panda_callbacks_mem_after_write(cpu, cpu->panda_guest_pc, addr, DATA_SIZE, (uint64_t)val, (void *)haddr);
+    panda_callbacks_mem_after_write(cpu, panda_current_pc(cpu), addr, DATA_SIZE, (uint64_t)val, (void *)haddr);
 }
 
 #endif /* DATA_SIZE > 1 */


### PR DESCRIPTION
This PR changes the `panda_current_pc` API function to use the precise PC value if it is enabled by `panda_enable_precise_pc`.

It also adjusts several plugins that use the old style to depend on `panda_current_pc` instead.