### PR TITLE
Expose windows process manager so it can be leveraged by other plugins.

### DIFF
--- a/panda/plugins/wintrospection/wintrospection.cpp
+++ b/panda/plugins/wintrospection/wintrospection.cpp
@@ -54,6 +54,7 @@ void uninit_plugin(void *);
 int64_t get_file_handle_pos(CPUState *cpu, uint64_t handle);
 char *get_cwd(CPUState *cpu);
 char *get_handle_name(CPUState *cpu, uint64_t handle);
+void *get_windows_process_manager(void);
 }
 
 void on_get_current_thread(CPUState *cpu, OsiThread *out);
@@ -91,6 +92,10 @@ static std::map<std::string, uint64_t> system_asid_lookup = {
   {"windows-32-7sp1", 0x185000},
   {"windows-64-7sp1", 0x187000},
 };
+
+void *get_windows_process_manager(void) {
+  return g_process_manager.get();
+}
 
 /* ******************************************************************
  Helpers

--- a/panda/plugins/wintrospection/wintrospection_int_fns.h
+++ b/panda/plugins/wintrospection/wintrospection_int_fns.h
@@ -5,3 +5,5 @@ char *get_handle_name(CPUState *cpu, uint64_t handle);
 char *get_cwd(CPUState *cpu);
 
 int64_t get_file_handle_pos(CPUState *cpu, uint64_t handle);
+
+void *get_windows_process_manager(void);


### PR DESCRIPTION
This works but it seems like there should be a better way, but it wasn't immediately obvious to me what that might be.

I have some plugins that relied on some functions that were in the pre-libosi version of wintrospection.

I was able to repair those plugins by allowing them to get a handle to the WindowsProcessManager object.

This change allows my plugins to call get_windows_process_manager and cast the return value to a WindowsProcessManager *. From there I as able to repair them to replace the logic that wintrospection used to provide.

Happy to change this to something else if there is a better way to achieve the same outcome.