### PR TITLE
Fallback to using ASID change heuristic to detect task changes on win…

### DIFF
--- a/panda/plugins/wintrospection/wintrospection.cpp
+++ b/panda/plugins/wintrospection/wintrospection.cpp
@@ -650,6 +650,12 @@ void initialize_introspection(CPUState *cpu) {
       std::unique_ptr<WindowsProcessManager>(new WindowsProcessManager());
   task_change(cpu);
 
+  // Hooking SwapContext on windows 2000 doesn't seem to be enough to detect
+  // all tasks changes, fallback to ASID change heuristic for now.
+  if (strncmp(panda_os_name, "windows-32-2000", 15) == 0) {
+    return;
+  }
+
   uint64_t swapcontext_offset = g_kernel_manager->get_swapcontext_offset();
 
   // we do not know exactly when a nt!SwapContext executes, and we must use the


### PR DESCRIPTION
…dows 2000.

There are couple of problems with detecting task changes on windows 2000.

First, there are at least five different common versions of the windows 2000
kernel, each with its own unique SwapContext address.  libosi currently
includes the correct offset for windows 2000 service pack 4.

Secondly, for some reason, task changes in Windows 2000 seem to occur in other
places in the kernel outside of SwapContext.

With the older version of wintrosepection, this wasn't a problem as this
was only noticed if one was using task change notifications.

The updated wintrospection brought with it a change that task change
detection must work if one wants to use on_get_current_thread.

If task change detection isn't working, on_get_current_thread will return
the currently running thread id, and the process id of the process running
when the last task change was detected.  Sometimes a thread id would be
returned and 0 for the process id.

I'm seeing this behavior in windows 2000 with plugins that rely on
on_get_current_thread such as callstack_trace, asidstory, and proc_trace.

When using the fallback method the results more closely match the old behavior
of wintrospection.