### PR TITLE
callbacks: normalize plugin name path

### DIFF
--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -99,19 +99,18 @@ bool panda_add_arg(const char *plugin_name, const char *plugin_arg) {
 // Forward declaration
 static void panda_args_set_help_wanted(const char *);
 
-static char* attempt_normalize_path(char* path){
+char* attempt_normalize_path(static char* path){
     char* new_path = g_malloc(PATH_MAX); 
     if (realpath(path, new_path) == NULL) {
-        g_free(new_path);
-        return path;
-    }else{
-        return new_path;
+        strncpy(new_path, path, PATH_MAX);
     }
+    g_free(path);
+    return new_path;
 }
 
 bool panda_load_external_plugin(const char *filename, const char *plugin_name, void *plugin_uuid, void *init_fn_ptr) {
     // don't load the same plugin twice
-    const char* rfilename = attempt_normalize_path((char*)filename);
+    char* rfilename = attempt_normalize_path(strdup(filename));
     uint32_t i;
     for (i=0; i<nb_panda_plugins_loaded; i++) {
         if (0 == (strcmp(rfilename, panda_plugins_loaded[i]))) {
@@ -134,7 +133,7 @@ bool panda_load_external_plugin(const char *filename, const char *plugin_name, v
     if (plugin_name) {
         strncpy(panda_plugins[nb_panda_plugins].name, plugin_name, 256);
     } else {
-        char *pn = g_path_get_basename((char *) rfilename);
+        char *pn = g_path_get_basename(rfilename);
         *g_strrstr(pn, HOST_DSOSUF) = '\0';
         strncpy(panda_plugins[nb_panda_plugins].name, pn, 256);
         g_free(pn);

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -99,7 +99,7 @@ bool panda_add_arg(const char *plugin_name, const char *plugin_arg) {
 // Forward declaration
 static void panda_args_set_help_wanted(const char *);
 
-char* attempt_normalize_path(static char* path){
+static char* attempt_normalize_path(static char* path){
     char* new_path = g_malloc(PATH_MAX); 
     if (realpath(path, new_path) == NULL) {
         strncpy(new_path, path, PATH_MAX);

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -99,7 +99,10 @@ bool panda_add_arg(const char *plugin_name, const char *plugin_arg) {
 // Forward declaration
 static void panda_args_set_help_wanted(const char *);
 
-static char* attempt_normalize_path(const char* path){
+/*
+* This function takes ownership of path.
+*/
+static char* attempt_normalize_path(char* path){
     char* new_path = g_malloc(PATH_MAX); 
     if (realpath(path, new_path) == NULL) {
         strncpy(new_path, path, PATH_MAX);

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -104,7 +104,7 @@ static char* attempt_normalize_path(const char* path){
     if (realpath(path, new_path) == NULL) {
         strncpy(new_path, path, PATH_MAX);
     }
-    g_free(path);
+    g_free((char*)path);
     return new_path;
 }
 

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -99,7 +99,7 @@ bool panda_add_arg(const char *plugin_name, const char *plugin_arg) {
 // Forward declaration
 static void panda_args_set_help_wanted(const char *);
 
-static char* attempt_normalize_path(static char* path){
+static char* attempt_normalize_path(const char* path){
     char* new_path = g_malloc(PATH_MAX); 
     if (realpath(path, new_path) == NULL) {
         strncpy(new_path, path, PATH_MAX);


### PR DESCRIPTION
This PR normalizes the panda path to plugins such that the realpath is provided back. This resolves an issue whereby plugins could be loaded from different sources with different visible paths that resolve to the same path. Because our comparison for the plugin loaded is done by the abolute path this can lead to a situation where the same plugin is loaded multiple times.