### PR TITLE
FIX callback enable flag not checked on some callbacks

### DIFF
--- a/panda/include/panda/callbacks/cb-helper-impl.h
+++ b/panda/include/panda/callbacks/cb-helper-impl.h
@@ -19,7 +19,9 @@ void HELPER(panda_insn_exec)(target_ulong pc) {
     // PANDA instrumentation: before basic block
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_INSN_EXEC]; plist != NULL; plist = panda_cb_list_next(plist)) {
-        plist->entry.insn_exec(plist->context, first_cpu, pc);
+        if (plist->enabled) {
+            plist->entry.insn_exec(plist->context, first_cpu, pc);
+        }
     }
 }
 
@@ -27,7 +29,9 @@ void HELPER(panda_after_insn_exec)(target_ulong pc) {
     // PANDA instrumentation: after basic block
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_AFTER_INSN_EXEC]; plist != NULL; plist = panda_cb_list_next(plist)) {
-        plist->entry.after_insn_exec(plist->context, first_cpu, pc);
+        if (plist->enabled){
+            plist->entry.after_insn_exec(plist->context, first_cpu, pc);
+        }
     }
 }
 

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -1446,7 +1446,9 @@ void hmp_panda_plugin_cmd(Monitor *mon, const QDict *qdict) {
     panda_cb_list *plist;
     const char *cmd = qdict_get_try_str(qdict, "cmd");
     for(plist = panda_cbs[PANDA_CB_MONITOR]; plist != NULL; plist = panda_cb_list_next(plist)) {
-        plist->entry.monitor(plist->context, mon, cmd);
+        if (plist->enabled){
+            plist->entry.monitor(plist->context, mon, cmd);
+        }
     }
 }
 


### PR DESCRIPTION
The following callbacks did not properly check that the `enabled` flag before executing:
- `insn_exec`
- `after_insn_exec`
- `monitor`

This PR simply adds in that check.