### PR TITLE
Have qcows.py lazily import argv

### DIFF
--- a/panda/python/core/pandare/qcows.py
+++ b/panda/python/core/pandare/qcows.py
@@ -5,7 +5,6 @@ Module for fetching generic PANDA images and managing their metadata.
 
 import logging
 from os import path, remove, makedirs
-from sys import argv
 from subprocess import check_call
 from collections import namedtuple
 from shlex import split as shlex_split
@@ -310,6 +309,8 @@ class Qcows():
         Returns:
             string: Path to qcow
         '''
+        from sys import argv
+
         if len(argv) > idx:
             return Qcows.get_qcow(argv[idx])
         else:


### PR DESCRIPTION
Currently pandare eagerly imports sys.argv, however in some setups (python version <=3.6, used as library) sys.argv will not be created (on modern python versions the behavior is to have argv be empty in these situations) and thus will cause an import error

Rather than import it without using it most of the time this PR only imports it if the from_args API is used