### PR TITLE
Bugfix: Enable Werror for GCC/G++ as expected

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,8 +66,8 @@ g++ --version | awk '/g\+\+/ && ($3+0)<7.1{print "Fatal error: G++ too old"; exi
 
 # Untested GCC - it's probably going to have some warnings - Just disable Werror and hope it works
 COMPILER_CONFIG=""
-gcc --version | awk '/gcc/   && ($3+0)>9.3{print "WARNING: Your GCC is too new: disabling -Werror and hoping this builds"; exit 1}' || COMPILER_CONFIG+= "--extra-cflags=-Wno-error"
-g++ --version | awk '/g\+\+/ && ($3+0)>9.3{print "WARNING: Your G++ is too new: disabling -Werror and hoping this builds"; exit 1}' ||  COMPILER_CONFIG +=" --extra-cxxflags=-Wno-error"
+gcc --version | awk '/gcc/   && ($3+0)>9.3{print "WARNING: Your GCC is too new: disabling -Werror and hoping this builds"; exit 1}' || COMPILER_CONFIG+="--extra-cflags=-Wno-error"
+g++ --version | awk '/g\+\+/ && ($3+0)>9.3{print "WARNING: Your G++ is too new: disabling -Werror and hoping this builds"; exit 1}' ||  COMPILER_CONFIG+=" --extra-cxxflags=-Wno-error"
 
 ### Check for protobuf v2.
 if ! pkg-config --exists protobuf; then


### PR DESCRIPTION
Previously the `-Wno-error` flag was never being set for GCC if both gcc and G++ were of supported versions.

#1199 shouldn't have been merged as is, I messed up the auto-merge after tests option.

This might change a bunch of previously-ignored build warnings to errors.