### PR TITLE
Explicitly enable taint for python unicorn examples

### DIFF
--- a/panda/python/examples/unicorn/taint_sym_x86_64.py
+++ b/panda/python/examples/unicorn/taint_sym_x86_64.py
@@ -63,6 +63,9 @@ def setup(cpu):
     # Set starting pc
     panda.arch.set_pc(cpu, ADDRESS)
 
+    # Enable tainting
+    panda.taint_enable()
+
     # Taint buffer using PHYSICAL addresses
     for idx in range(len(buf)):
         panda.taint_label_ram(buf_src+idx, idx)

--- a/panda/python/examples/unicorn/taint_x86_64.py
+++ b/panda/python/examples/unicorn/taint_x86_64.py
@@ -60,6 +60,9 @@ def setup(cpu):
     # Set starting pc
     panda.arch.set_pc(cpu, ADDRESS)
 
+    # Enable tainting
+    panda.taint_enable()
+
     # Taint buffer using PHYSICAL addresses
     for idx in range(len(buf)):
         panda.taint_label_ram(buf_src+idx, idx)


### PR DESCRIPTION
It seems pypanda now requires that tainting is explicitly enabled, at least for the unicorn samples - this PR adds the according lines of code, to prevent error messages like:

```
[...]
    raise Exception("taint2 must be loaded before tainting values")
Exception: taint2 must be loaded before tainting values
```