### PR TITLE
panda_*_memory_write now raises an exception in PyPANDA

### DIFF
--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -199,8 +199,7 @@ class PandaArch():
         stack_idx = int(argloc.split("stack_")[1])
         stack_base = self.get_reg(cpu, self.reg_sp)
         offset = reg_sz * (stack_idx+1)
-        if self.panda.virtual_memory_write(cpu, stack_base + offset, val):
-            raise ValueError
+        self.panda.virtual_memory_write(cpu, stack_base + offset, val)
 
     def _read_stack(self, cpu, argloc):
         '''

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -863,9 +863,12 @@ class Panda():
             buf (bytestring):  byte string to write into memory
 
         Returns:
-            bool: error
+            None
+
+        Raises:
+            ValueError if the call to panda.physical_memory_write fails (e.g., if you pass a pointer to an invalid memory region)
         '''
-        return self._memory_write(None, addr, buf, physical=True)
+        self._memory_write(None, addr, buf, physical=True)
 
     def virtual_memory_write(self, cpu, addr, buf):
         '''
@@ -877,10 +880,12 @@ class Panda():
             buf (bytestr): byte string to write into memory
 
         Returns:
-            bool: error
+            None
 
+        Raises:
+            ValueError if the call to panda.virtual_memory_write fails (e.g., if you pass a pointer to an unmapped page)
         '''
-        return self._memory_write(cpu, addr, buf, physical=False)
+        self._memory_write(cpu, addr, buf, physical=False)
 
     def _memory_write(self, cpu, addr, buf, physical=False):
         '''
@@ -895,9 +900,12 @@ class Panda():
             self.enable_memcb()
 
         if physical:
-            return self.libpanda.panda_physical_memory_write_external(addr, buf_a, length_a)
+            err = self.libpanda.panda_physical_memory_write_external(addr, buf_a, length_a)
         else:
-            return self.libpanda.panda_virtual_memory_write_external(cpu, addr, buf_a, length_a)
+            err = self.libpanda.panda_virtual_memory_write_external(cpu, addr, buf_a, length_a)
+
+        if err < 0:
+            raise ValueError(f"Memory write failed with err={err}") # TODO: make a PANDA Exn class
 
     def callstack_callers(self, lim, cpu): # XXX move into new directory, 'callstack' ?
         '''

--- a/panda/python/tests/enabled_tests.txt
+++ b/panda/python/tests/enabled_tests.txt
@@ -1,5 +1,6 @@
 file_fake.py
 file_hook.py
+memory_tests.py
 monitor_cmds.py
 multi_proc_cbs.py
 sleep_in_cb.py

--- a/panda/python/tests/memory_tests.py
+++ b/panda/python/tests/memory_tests.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+#REMOVE FOR COMMIT vv
+import sys
+sys.path.insert(1, '/out/panda/panda/panda/python/core')
+#REMOVE FOR COMMIT ^^
+
+from pandare import Panda
+from sys import argv
+
+#Tests for memory_read/memory_write functions
+#There are many implicit uses of those functions in this code as well
+
+arch = argv[1] if len(argv) > 1 else "i386"
+panda = Panda(generic=arch)
+
+virt_mem_write=False
+virt_mem_read=False
+virt_mem_write_bad=False
+virt_mem_read_bad=False
+phys_mem_write=False
+phys_mem_read=False
+
+@panda.ppp("syscalls2", "on_sys_write_enter")
+def on_sys_write(cpu, pc, fd, buf, count):
+    global virt_mem_write
+    global virt_mem_read
+    global virt_mem_write_bad
+    global virt_mem_read_bad
+    global phys_mem_write
+    global phys_mem_read
+
+    proc = panda.plugins['osi'].get_current_process(cpu)
+    if b'ls' not in panda.ffi.string(proc.name):
+        return
+
+    try:
+        b = panda.virtual_memory_read(cpu, buf, count)
+        s = b.decode('utf8')
+    except ValueError:
+        print("Failed to read virtual memory at 0x{buf:x}")
+        return
+
+    if "root" in s:
+        #Assumes image has a /root and not a /woot
+        virt_mem_read = True
+        s = s.replace("root", "woot")
+        try:
+            panda.virtual_memory_write(cpu, buf, s.encode())
+            b = panda.virtual_memory_read(cpu, buf, count)
+            if "woot" in b.decode('utf8'):
+                virt_mem_write = True
+
+        except ValueError:
+            print("Failed to write virtual memory at 0x{buf:x}")
+            return
+
+        phys_addr = panda.virt_to_phys(cpu, buf)
+         
+        try:
+            b = panda.physical_memory_read(phys_addr, count)
+            s = b.decode('utf8')
+        except ValueError:
+            print("Failed to read physical memory at 0x{phys_addr:x}")
+            return
+
+        #The value we wrote should be present
+        if "woot" in s:
+            phys_mem_read = True
+            s = s.replace("woot", "root")
+            try:
+                panda.physical_memory_write(phys_addr, s.encode())
+                b = panda.physical_memory_read(phys_addr, count)
+                if "woot" not in b.decode('utf8'):
+                    phys_mem_write = True
+
+            except ValueError:
+                print("Failed to write physical memory at 0x{phys_addr:x}")
+                return
+
+        #Now try bad accesses and look for appropriate exceptions
+        *_, last_mapping = panda.get_mappings(cpu) 
+        bad_virt_addr = last_mapping.base + last_mapping.size + 4096
+
+        try:
+            b = panda.virtual_memory_read(cpu, bad_virt_addr, 1)
+        except ValueError:
+            virt_mem_read_bad = True
+
+        try:
+            panda.virtual_memory_write(cpu, bad_virt_addr, b'\x00')
+        except ValueError:
+            virt_mem_write_bad = True
+
+        panda.disable_ppp("on_sys_write")
+
+
+@panda.queue_blocking
+def driver():
+    print(panda.revert_sync("root"))
+    panda.run_serial_cmd("ls /")
+    panda.end_analysis()
+
+panda.run()
+
+assert(virt_mem_read), "Virtual memory read failed"
+assert(virt_mem_write), "Virtual memory write failed"
+assert(phys_mem_read), "Physical memory read failed"
+assert(phys_mem_write), "Physical memory write failed"
+assert(virt_mem_read_bad), "Bad virtual memory read failed to raise exception"
+assert(virt_mem_write_bad), "Bad virtual memory write failed to raise exception"


### PR DESCRIPTION
PyPANDA documentation states that {virtual,physical}_memory_write return a bool, but those functions pass the value returned by the libpanda memory_write_external functions back to the caller. The memory_write_external functions return err < 0 on failure and 0 on success, however. This PR changes the PyPANDA _memory_write function to instead check the return value from the libpanda memory_write_external function and raise an exception on failure, similar to _memory_read.

Tried to do my due diligence by searching for existing code that expects the behavior prior to this PR. Only example I could find of a return value getting checked in the panda code itself was when set_arg attempts a write to the stack in arch.py (corrected in the same commit here).  On failure, set_arg raises a ValueError exception so the proposed change preserves behavior.

These plugins would technically need to be updated:
https://github.com/panda-re/pypanda-plugins/blob/main/src/pandarepyplugins/FileHallucinator.py
https://github.com/panda-re/pypanda-plugins/blob/main/src/pandarepyplugins/rwreplace.py