### PR TITLE
Fixes for pandare.qcows (add -os flag, behave correctly after running install) + fix GCC 11.2 warning

### DIFF
--- a/panda/python/core/pandare/qcows.py
+++ b/panda/python/core/pandare/qcows.py
@@ -319,10 +319,11 @@ class Qcows():
     @staticmethod
     def cli(target):
         from .panda import Panda
+        from os import environ
         q = Qcows.get_qcow_info(target)
         qcow = Qcows.get_qcow(target)
         arch = q.arch
-        build_dir = Panda._find_build_dir(arch)
+        build_dir = Panda._find_build_dir(arch, find_executable=True)
         panda_args = [build_dir + f"/{arch}-softmmu/panda-system-{arch}"]
         biospath = path.realpath(path.join(build_dir, "pc-bios"))
         panda_args.extend(["-L", biospath])
@@ -349,6 +350,10 @@ class Qcows():
 
         if "-display none" in ret:
             ret = ret.replace("-display none", "-nographic")
+
+        # Repalce /home/username with ~ when we can
+        if 'HOME' in environ:
+            ret = ret.replace(environ['HOME'], '~')
         return ret
 
 if __name__ == "__main__":

--- a/panda/python/core/pandare/qcows.py
+++ b/panda/python/core/pandare/qcows.py
@@ -326,6 +326,7 @@ class Qcows():
         panda_args = [build_dir + f"/{arch}-softmmu/panda-system-{arch}"]
         biospath = path.realpath(path.join(build_dir, "pc-bios"))
         panda_args.extend(["-L", biospath])
+        panda_args.extend(["-os", q.os])
 
         if arch == 'mips64':
             panda_args.extend(["-drive", f"file={qcow},if=virtio"])

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -106,7 +106,7 @@ static void panda_args_set_help_wanted(const char *);
 static char* attempt_normalize_path(char* path){
     char* new_path = g_malloc(PATH_MAX); 
     if (realpath(path, new_path) == NULL) {
-        strncpy(new_path, path, PATH_MAX);
+        strncpy(new_path, path, PATH_MAX-1);
     }
     g_free((char*)path);
     return new_path;


### PR DESCRIPTION
Update pandare.qcows to work with our Docker container (path was incorrect as described in #1174)  and set the `-os` flag since we're already storing that information

Also fixes the following warning:
```
      CC      x86_64-softmmu/panda/src/callbacks.o
    In file included from /usr/include/string.h:535,
                     from /home/andrew/git/panda/panda/src/callbacks.c:15:
    In function ‘strncpy’,
        inlined from ‘attempt_normalize_path’ at /home/andrew/git/panda/panda/src/callbacks.c:109:9:
    /usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin_strncpy’ specified bound 4096 equals destination size [-Werror=stringop-truncation]
       95 |   return __builtin___strncpy_chk (__dest, __src, __len,
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       96 |                                   __glibc_objsize (__dest));
          |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
```