### PR TITLE
Fix docker container snake_hooks + qcows regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG BASE_IMAGE
 
 # Copy dependencies lists into container. Note this
 #  will rarely change so caching should still work well
-COPY ./panda/dependencies/${BASE_IMAGE}*.txt /tmp/
+COPY ./panda/dependencies/${BASE_IMAGE}*.txt /tmp/ 
 
 # Base image just needs runtime dependencies
 RUN [ -e /tmp/${BASE_IMAGE}_base.txt ] && \
@@ -80,6 +80,7 @@ RUN  make -C /panda/build install
 # Install pypanda
 RUN cd /panda/panda/python/core && \
     python3 setup.py install
+RUN python3 -m pip install --ignore-install pycparser && python3 -m pip install --force-reinstall --no-binary :all: cffi
 
 ### Copy files for panda+pypanda from installer  - Stage 5
 FROM base as panda

--- a/panda/python/core/pandare/qcows_internal.py
+++ b/panda/python/core/pandare/qcows_internal.py
@@ -347,6 +347,10 @@ class Qcows():
                     raise ValueError(f"{url} has hash {computed_hash} vs expected hash {sha1hash}")
                 # Hash matches, move .tmp file to actual path
                 move(output_path+".tmp", output_path)
+            else:
+                # No hash, move .tmp file to actual path
+                move(output_path+".tmp", output_path)
+                
 
         except Exception as e:
             logger.info("Download failed, deleting partial file: %s", output_path)


### PR DESCRIPTION
In this PR we hopefully fix an issue related to CFFI builtin. See here: https://stackoverflow.com/questions/62658237/it-seems-that-the-version-of-the-libffi-library-seen-at-runtime-is-different-fro


We also fix a regression related to qcows without hashes.