### PR TITLE
pypanda: Bugfix, ensure pc-bios/keymaps directory is installed

### DIFF
--- a/panda/python/core/setup.py
+++ b/panda/python/core/setup.py
@@ -165,6 +165,7 @@ setup(name='pandare',
           'data/*-softmmu/panda/plugins/**/*',# All plugin files
           'data/pypanda/include/*.h',         # Includes files
           'data/pc-bios/*',                   # BIOSes
+          'data/pc-bios/**/*',                # Keymaps
           ]},
       install_requires=[ 'cffi>=1.14.3', 'colorama', 'protobuf=='+pc_version],
       python_requires='>=3.6',


### PR DESCRIPTION
If PyPANDA doesn't copy the `keymaps` directory from `build/pc-bios/keymaps` into the data directory during pypanda install, errors are raised trying to run Windows guests from PyPANDA.