### PR TITLE
MIPS Hypercalls

### DIFF
--- a/panda/include/panda/callbacks/cb-helper-defs.h
+++ b/panda/include/panda/callbacks/cb-helper-defs.h
@@ -14,6 +14,6 @@ PANDAENDCOMMENT */
 DEF_HELPER_1(panda_insn_exec, void, tl)
 DEF_HELPER_1(panda_after_insn_exec, void, tl)
 
-#if defined(TARGET_ARM)
+#if defined(TARGET_ARM) || defined(TARGET_MIPS)
 DEF_HELPER_1(panda_guest_hypercall, void, env)
 #endif

--- a/panda/include/panda/callbacks/cb-helper-impl.h
+++ b/panda/include/panda/callbacks/cb-helper-impl.h
@@ -35,7 +35,7 @@ void HELPER(panda_after_insn_exec)(target_ulong pc) {
     }
 }
 
-#if defined(TARGET_ARM)
+#if defined(TARGET_ARM) || defined(TARGET_MIPS)
 void HELPER(panda_guest_hypercall)(CPUArchState *cpu_env) {
     panda_callbacks_guest_hypercall(ENV_GET_CPU(cpu_env));
 }

--- a/target/mips/translate.c
+++ b/target/mips/translate.c
@@ -2846,6 +2846,7 @@ static void gen_cond_move(DisasContext *ctx, uint32_t opc,
 
     if (rd == 0) {
         /* If no destination, treat it as a NOP. */
+        gen_helper_panda_guest_hypercall(cpu_env);
         return;
     }
 

--- a/target/mips/translate.c
+++ b/target/mips/translate.c
@@ -8050,6 +8050,7 @@ static void gen_cp0 (CPUMIPSState *env, DisasContext *ctx, uint32_t opc, int rt,
     case OPC_MFC0:
         if (rt == 0) {
             /* Treat as NOP. */
+            gen_helper_panda_guest_hypercall(cpu_env);
             return;
         }
         gen_mfc0(ctx, cpu_gpr[rt], rd, ctx->opcode & 0x7);


### PR DESCRIPTION
Adds hypercalls to MIPS.

hypercalls are defined for two sets of instructions:

Conditional movs whose destination is register 0. For example:
```
movz $0, $1, $2
```

This instruction works in MIPS ISA V4 onward in all privilege levels. 

We also support mfc0, but this only works in some privilege levels.
```
mfc0 $0, $#
```

This is an attempt to move from any coprocessor register into register zero. In QEMU this is represented as a NOP (with no side effects) because the zero register ($0) is hardcoded to always have the value 0.

This makes the operation highly effective as a mechanism to indicate from the guest that a message is available for the host.
