### PR TITLE
Set replay_name in rr_do_begin_replay

### DIFF
--- a/panda/src/rr/rr_log.c
+++ b/panda/src/rr/rr_log.c
@@ -63,6 +63,8 @@
 /******************************************************************************************/
 /* GLOBALS */
 /******************************************************************************************/
+extern const char *replay_name;
+
 // record/replay state
 rr_control_t rr_control = {.mode = RR_OFF, .next = RR_NOCHANGE};
 
@@ -1529,6 +1531,7 @@ int rr_do_begin_replay(const char* file_name_full, CPUState* cpu_state)
 #endif
 
 #ifdef CONFIG_SOFTMMU
+    replay_name = file_name_full;
     char name_buf[1024];
     // decompose file_name_base into path & file.
     char* rr_path = g_strdup(file_name_full);


### PR DESCRIPTION
replay_name is set in vl.c, but could be used in other places, such as in plugins. By setting it in `rr_do_begin_replay` we make it available to use for the CLI and PyPANDA.