### PR TITLE
Make rr_control.name available via plugin API

### DIFF
--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -113,6 +113,7 @@ uintptr_t panda_get_current_llvm_module(void);
 void panda_enable_tb_chaining(void);
 void panda_disable_tb_chaining(void);
 void panda_memsavep(FILE *f);
+char* panda_get_rr_name(void);
 
 // Struct for holding a parsed key/value pair from
 // a -panda-arg plugin:key=value style argument.

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -996,6 +996,15 @@ int panda_replay_end(void) {
     return RRCTRL_OK;
 }
 
+/**
+ * @brief Return the name of the current PANDA record/replay
+ * 
+ * @return char* 
+ */
+char* panda_get_rr_name(void){
+    return rr_control.name;
+}
+
 // Parse out arguments and return them to caller
 static panda_arg_list *panda_get_args_internal(const char *plugin_name, bool check_only) {
     panda_arg_list *ret = NULL;

--- a/vl.c
+++ b/vl.c
@@ -3093,10 +3093,6 @@ void main_panda_run(void) {
     panda_in_main_loop = 0;
 }
 
-void set_replay_name(char *name) {
-    replay_name = name;
-}
-
 int main_aux(int argc, char **argv, char **envp, PandaMainMode pmm)
  {
     if (pmm == PANDA_RUN)    goto PANDA_MAIN_RUN;

--- a/vl.h
+++ b/vl.h
@@ -17,6 +17,4 @@ void main_loop(void);
 
 int main_aux(int argc, char **argv, char **envp, PandaMainMode pmm);
 
-void set_replay_name(char *name);
-
 #endif


### PR DESCRIPTION
Inspired by #1227 and @zacogen we add a method to make rr_control.name available.

This differers from #1227 by exposing the global state from `rr_control` instead of the argument provided in `vl.c` to the local variable `replay_name`.

It also gets rid of `set_replay_name`, which it appears no one was using (and shouldn't use really).