### PR TITLE
PR for Issue #1219

### DIFF
--- a/panda/include/panda/panda_api.h
+++ b/panda/include/panda/panda_api.h
@@ -31,7 +31,7 @@ void panda_register_callback_helper(void* plugin, panda_cb_type type, panda_cb* 
 void panda_enable_callback_helper(void *plugin, panda_cb_type, panda_cb* cb);
 void panda_disable_callback_helper(void *plugin, panda_cb_type, panda_cb* cb);
 
-int rr_get_guest_instr_count_external(void);
+uint64_t rr_get_guest_instr_count_external(void);
 
 int panda_virtual_memory_read_external(CPUState *env, target_ulong addr, char *buf, int len);
 int panda_virtual_memory_write_external(CPUState *env, target_ulong addr, char *buf, int len);

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -129,7 +129,7 @@ void panda_disable_callback_helper(void *plugin, panda_cb_type type, panda_cb* c
 
 //int panda_replay(char *replay_name) -> Now use panda_replay_being(char * replay_name)
 
-int rr_get_guest_instr_count_external(void){
+uint64_t rr_get_guest_instr_count_external(void){
 	return rr_get_guest_instr_count();
 }
 


### PR DESCRIPTION
This is a pull request for issue #1219 where the instruction count can overflow for large replay files when using the pyPANDA Python API. 