### PR TITLE
Fix exported symbol for get_system_memory()

### DIFF
--- a/panda/include/panda/panda_api.h
+++ b/panda/include/panda/panda_api.h
@@ -52,6 +52,8 @@ void panda_setup_signal_handling(void (*f) (int, void*, void *));
 
 void map_memory(char* name, uint64_t size, uint64_t address);
 
+MemoryRegion *get_system_memory(void);
+
 // REDEFINITIONS below here from monitor.h
 
 // Create a monitor for panda


### PR DESCRIPTION
However, there are other pypanda functions with missing  exported functions in libpanda (all the functions of the family ```object_*```, maybe a missing header file?)