### PR TITLE
OSI_linux bugfix: fix fd_to_filename for big-endian guests

### DIFF
--- a/panda/plugins/osi_linux/default_profile.cpp
+++ b/panda/plugins/osi_linux/default_profile.cpp
@@ -111,7 +111,6 @@ target_ptr_t default_get_file_fds(CPUState *cpu, target_ptr_t files)
         LOG_ERROR("Failed to retrieve file structs (error code: %d)", err);
         return (target_ptr_t)NULL;
     }
-    fixupendian(files_fds);
     return files_fds;
 }
 

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -76,6 +76,8 @@ static char *get_file_name(CPUState *env, target_ptr_t file_struct) {
     // Read addresses for dentry, vfsmnt structs.
     file_dentry = get_file_dentry(env, file_struct);
     file_mnt = get_file_mnt(env, file_struct);
+   OG_printf("(struct dentry *) file_dentry at " TARGET_FMT_lx "\n", file_dentry);
+   OG_printf("(struct vfsmount *) file_mnt at " TARGET_FMT_lx "\n", file_mnt);
 
     if (unlikely(file_dentry == (target_ptr_t)NULL || file_mnt == (target_ptr_t)NULL)) {
         LOG_INFO("failure resolving file struct " TARGET_PTR_FMT "/" TARGET_PTR_FMT, file_dentry, file_mnt);
@@ -85,6 +87,7 @@ static char *get_file_name(CPUState *env, target_ptr_t file_struct) {
     char *s1, *s2;
     s1 = read_vfsmount_name(env, file_mnt);
     s2 = read_dentry_name(env, file_dentry);
+    OG_printf("S1=%s, S2=%s\n", s1, s2);
     name = g_strconcat(s1, s2, NULL);
     g_free(s1);
     g_free(s2);
@@ -99,9 +102,12 @@ static uint64_t get_file_position(CPUState *env, target_ptr_t file_struct) {
 static target_ptr_t get_file_struct_ptr(CPUState *env, target_ptr_t task_struct, int fd) {
     target_ptr_t files = get_files(env, task_struct);
     target_ptr_t fds = kernel_profile->get_files_fds(env, files);
-    target_ptr_t fd_file = NULL;
+    target_ptr_t fd_file = 0;
     // fds is a flat array with struct file pointers.
     // fds+fd*sizeof(target_ptr_t) is the address of the nth pointer that we need to read
+    OG_printf("(struct files_struct*) files at " TARGET_FMT_lx \
+           ", (struct file *(*)[32])fds at " TARGET_FMT_lx "\n", files, fds);
+
     auto err = struct_get(env, &fd_file, fds, fd*sizeof(target_ptr_t));
     if (err != struct_get_ret_t::SUCCESS) {
       LOG_ERROR("Unable to load file descriptor details");
@@ -116,6 +122,7 @@ static target_ptr_t get_file_struct_ptr(CPUState *env, target_ptr_t task_struct,
 static char *get_fd_name(CPUState *env, target_ptr_t task_struct, int fd) {
     target_ptr_t fd_file = get_file_struct_ptr(env, task_struct, fd);
     if (fd_file == (target_ptr_t)NULL) return NULL;
+    OG_printf("Get FDs[%d] name from " TARGET_FMT_lx "\n", fd, fd_file);
     return get_file_name(env, fd_file);
 }
 

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -802,7 +802,8 @@ class Panda():
             err = self.libpanda.panda_virtual_memory_read_external(env, addr_u, buf_a, length_a)
 
         if err < 0:
-            raise ValueError(f"Memory access failed with err={err}") # TODO: make a PANDA Exn class
+            # TODO: We should support a custom error class instead of a generic ValueError
+            raise ValueError(f"Failed to read guest memory at {addr:x} got err={err}")
 
         r = self.ffi.unpack(buf, length)
         if fmt == 'bytearray':


### PR DESCRIPTION
fd_to_filename fixes:
* Remove an incorrect call to the `fixupendian` macro.
* Change `get_file_struct_ptr` to use the standard `struct_get` helper for handling virtual memory reads.

read_dentry_name fixes:
* Support parsing `struct qstr` objects for big endian guests for kernels >=v3.5 when a layout change was introduced.

There's also an unrelated but very minor improvement for pypanda's bad memory read error message in here.