### PR TITLE
Deliver qemupciserial.inf with installation materials

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -276,6 +276,7 @@ endif
 		echo $$f; \
 		$(INSTALL_PROG) $$f "$(DESTDIR)$(qemu_datadir)/scripts"; \
 	done
+	$(INSTALL_DATA) $(SRC_PATH)/docs/qemupciserial.inf "$(DESTDIR)$(qemu_datadir)/qemupciserial.inf"
 # N.B. the new rpath must not be longer than the old rpath or chrpath will fail
 	for p in $(PANDA_PLUGINS) $(EXTRA_PANDA_PLUGINS); do \
 		echo $$p; \

--- a/panda/plugins/osi/README.md
+++ b/panda/plugins/osi/README.md
@@ -10,7 +10,7 @@ Expressed graphically, this arrangement looks like:
     +-------------------+  +-------------------+
     |        osi        |  |        osi        |
     +-------------------+  +-------------------+
-    |     osi_linux     |  |    win7x86intro   |
+    |     osi_linux     |  |  wintrospection   |
     +-------------------+  +-------------------+
 
 The key is that you can swap out the bottom layer to support a new operating system without needing to modify your plugin.


### PR DESCRIPTION
This makes it easier for end-users who don't deal with the source code to find it.
Also removed reference to a deleted plugin from the osi README.md file.