### PR TITLE
Fix pypanda arch i386 string format bug

### DIFF
--- a/panda/python/core/pandare/arch.py
+++ b/panda/python/core/pandare/arch.py
@@ -595,7 +595,7 @@ class X86Arch(PandaArch):
                            "syscall":    "EAX",
                            "linux_kernel":    "EAX"}
         
-        self.call_conventions = {"cdecl": ["stack_{x}" for x in range(20)], # 20: arbitrary but big
+        self.call_conventions = {"cdecl": [f"stack_{x}" for x in range(20)], # 20: arbitrary but big
                                  "syscall": ["EAX", "EBX", "ECX", "EDX", "ESI", "EDI", "EBP"],
                                  "linux_kernel": ["EAX", "EDX", "ECX", "stack_3", "stack_4", "stack_5", "stack_6"]}
         self.call_conventions['default'] = self.call_conventions['cdecl']


### PR DESCRIPTION
Bug found when running "./examples/hook_symbol.py" , Exception log following:
```
panda-re-debug    | Traceback (most recent call last):
panda-re-debug    |   File "main.py", line 46, in <module>
panda-re-debug    |     panda.run()
panda-re-debug    |   File "/usr/local/lib/python3.8/dist-packages/pandare/panda.py", line 541, in run
panda-re-debug    |     raise saved_exception
panda-re-debug    |   File "/usr/local/lib/python3.8/dist-packages/pandare/panda.py", line 3013, in _run_and_catch
panda-re-debug    |     r = fun(*args, **kwargs)
panda-re-debug    |   File "main.py", line 40, in hook_fwrite
panda-re-debug    |     data_ptr, size_t, count = panda.arch.get_args(cpu, 3)
panda-re-debug    |   File "/usr/local/lib/python3.8/dist-packages/pandare/arch.py", line 305, in get_args
panda-re-debug    |     return [self.get_arg(cpu,i, convention) for i in range(num)]
panda-re-debug    |   File "/usr/local/lib/python3.8/dist-packages/pandare/arch.py", line 305, in <listcomp>
panda-re-debug    |     return [self.get_arg(cpu,i, convention) for i in range(num)]
panda-re-debug    |   File "/usr/local/lib/python3.8/dist-packages/pandare/arch.py", line 166, in get_arg
panda-re-debug    |     return self._read_stack(cpu, argloc)
panda-re-debug    |   File "/usr/local/lib/python3.8/dist-packages/pandare/arch.py", line 216, in _read_stack
panda-re-debug    |     stack_idx = int(argloc.split("stack_")[1])
panda-re-debug    | ValueError: invalid literal for int() with base 10: '{x}'
```

I debug and found that variable `panda.arch.call_conventions`  all value are "stack_{x}". Apparently there are some format errors in the code.  And then, I found an "f" missed in line 598 `/panda/python/core/pandare/arch.py:X86Arch` . I fix this, and it seems work properly.