### PR TITLE
On Taint Propagation, Convert Network Transfer Taint RAM Addresses to Offsets

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -468,9 +468,9 @@ bool setup_osi() {
     // moved out of init_plugin case statement to mollify SonarQube
 #if defined(TARGET_I386) || defined(TARGET_ARM) || defined(TARGET_MIPS)
     #if defined(TARGET_X86_64)
-    if (panda_os_familyno != OS_LINUX) {
+    if ((panda_os_familyno != OS_LINUX) && (0 != strncmp(panda_os_variant, "7", 1))) {
         fprintf(stderr,
-            "ERROR:  threaded stack_type is not supported on Windows 64-bit\n");
+            "ERROR:  threaded stack_type is not supported on Windows 64-bit except for Windows 7\n");
         return false;
     }
     #endif

--- a/panda/plugins/taint2/taint2.cpp
+++ b/panda/plugins/taint2/taint2.cpp
@@ -190,7 +190,7 @@ void replay_hd_transfer_callback(CPUState *cpu, uint32_t type,
     }
 
     taint_log("hd xfer (copy): %s[%lx+%lx] <- %s[%lx] ", dst_shad->name(),
-    		(uint64_t)dst_addr, num_bytes, src_shad->name(), (uint64_t)src_addr);
+            (uint64_t)dst_addr, num_bytes, src_shad->name(), (uint64_t)src_addr);
     taint_log_labels(src_shad, (uint64_t)src_addr, num_bytes);
     Shad::copy(dst_shad, dst_addr, src_shad, src_addr, num_bytes);
 
@@ -217,12 +217,12 @@ void on_replay_net_transfer(CPUState *cpu, uint32_t type, uint64_t src_addr,
         src_shad = &shadow->ram;
         dst_shad = &shadow->io;
         if (PandaPhysicalAddressToRamOffset(&src_addr_offset, src_addr, false)
-        		!= MEMTX_OK)
+                != MEMTX_OK)
         {
-        	fprintf(stderr,
-        			"Cannot convert source address 0x%lx to RAM Offset\n",
-        			src_addr);
-        	return;
+            fprintf(stderr,
+                    "Cannot convert source address 0x%lx to RAM Offset\n",
+                    src_addr);
+            return;
         }
         dst_addr_offset = dst_addr;
         break;
@@ -231,12 +231,12 @@ void on_replay_net_transfer(CPUState *cpu, uint32_t type, uint64_t src_addr,
         dst_shad = &shadow->ram;
         src_addr_offset = src_addr;
         if (PandaPhysicalAddressToRamOffset(&dst_addr_offset, dst_addr, true)
-        		!= MEMTX_OK)
+                != MEMTX_OK)
         {
-        	fprintf(stderr,
-        			"Cannot convert destination address 0x%lx to RAM Offset\n",
-					dst_addr);
-        	return;
+            fprintf(stderr,
+                    "Cannot convert destination address 0x%lx to RAM Offset\n",
+                    dst_addr);
+            return;
         }
 
         break;
@@ -252,7 +252,7 @@ void on_replay_net_transfer(CPUState *cpu, uint32_t type, uint64_t src_addr,
     }
 
     taint_log("net xfer (copy): %s[%lx+%lx] <- %s[%lx] ", dst_shad->name(),
-    		dst_addr_offset, num_bytes, src_shad->name(), src_addr_offset);
+            dst_addr_offset, num_bytes, src_shad->name(), src_addr_offset);
     taint_log_labels(src_shad, src_addr_offset, num_bytes);
     Shad::copy(dst_shad, dst_addr_offset, src_shad, src_addr_offset, num_bytes);
     return;
@@ -289,7 +289,7 @@ void on_replay_before_dma(CPUState *cpu, const uint8_t *src_addr,
         ds_addr = (uint64_t)src_addr;
     }
     taint_log("dma (copy): %s[%lx+%lx] <- %s[%lx] ", dst_shad->name(),
-    		ds_addr, num_bytes, src_shad->name(), ss_addr);
+            ds_addr, num_bytes, src_shad->name(), ss_addr);
     taint_log_labels(src_shad, ss_addr, num_bytes);
     Shad::copy(dst_shad, ds_addr, src_shad, ss_addr, num_bytes);
     return;

--- a/panda/plugins/taint2/taint2.cpp
+++ b/panda/plugins/taint2/taint2.cpp
@@ -189,6 +189,9 @@ void replay_hd_transfer_callback(CPUState *cpu, uint32_t type,
         return;
     }
 
+    taint_log("hd xfer (copy): %s[%lx+%lx] <- %s[%lx] ", dst_shad->name(),
+    		(uint64_t)dst_addr, num_bytes, src_shad->name(), (uint64_t)src_addr);
+    taint_log_labels(src_shad, (uint64_t)src_addr, num_bytes);
     Shad::copy(dst_shad, dst_addr, src_shad, src_addr, num_bytes);
 
     return;
@@ -222,6 +225,10 @@ void on_replay_net_transfer(CPUState *cpu, uint32_t type, uint64_t src_addr,
         fprintf(stderr, "Invalid network transfer type (%d)\n", type);
         return;
     }
+
+    taint_log("net xfer (copy): %s[%lx+%lx] <- %s[%lx] ", dst_shad->name(),
+    		dst_addr, num_bytes, src_shad->name(), src_addr);
+    taint_log_labels(src_shad, src_addr, num_bytes);
     Shad::copy(dst_shad, dst_addr, src_shad, src_addr, num_bytes);
     return;
 } // end of function on_replay_net_transfer
@@ -256,6 +263,9 @@ void on_replay_before_dma(CPUState *cpu, const uint8_t *src_addr,
         ss_addr = dest_addr;
         ds_addr = (uint64_t)src_addr;
     }
+    taint_log("dma (copy): %s[%lx+%lx] <- %s[%lx] ", dst_shad->name(),
+    		ds_addr, num_bytes, src_shad->name(), ss_addr);
+    taint_log_labels(src_shad, ss_addr, num_bytes);
     Shad::copy(dst_shad, ds_addr, src_shad, ss_addr, num_bytes);
     return;
 }  // end of function on_replay_before_dma

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -416,7 +416,8 @@ void detaint_on_cb0(Shad *shad, uint64_t addr, uint64_t size)
         if ((td.cb_mask == 0) && (td.ls != NULL) && (td.ls->size() > 0))
         {
             taint_delete(shad, curAddr, 1);
-            taint_log("detaint: control bits 0 for 0x%lx\n", curAddr);
+            taint_log("detaint: control bits 0 for %s[%lx]\n", shad->name(),
+            		curAddr);
         }
     }
 }

--- a/panda/plugins/taint2/taint_ops.cpp
+++ b/panda/plugins/taint2/taint_ops.cpp
@@ -417,7 +417,7 @@ void detaint_on_cb0(Shad *shad, uint64_t addr, uint64_t size)
         {
             taint_delete(shad, curAddr, 1);
             taint_log("detaint: control bits 0 for %s[%lx]\n", shad->name(),
-            		curAddr);
+                    curAddr);
         }
     }
 }


### PR DESCRIPTION
This pull request is mainly about fixing a problem with propagating taint in the taint2 plugin that occurs sometimes when the guest has more than 4G of RAM.  We have a 64-bit Windows 7 guest with 4G RAM that does not have contiguous RAM, which results in the raw RAM addresses needing to be converted to RAM offsets before they can be used to propagate taint on network transfers.
These changes also enhance the taint2 debug output, as that was invaluable in tracking down this issue.
Also, now that someone added OSI support for 64-bit Windows 7, there is no reason for the callstack_instr plugin to forbid the use of the threaded stack type for recordings from such a guest.  As it was useful in testing these changes, that update was made too in this pull request.