### PR TITLE
proc_start_linux updates; address_in_kernel_code_linux updates

### DIFF
--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -603,8 +603,13 @@ static inline target_ulong panda_current_sp(const CPUState *cpu) {
     // valid on x86 and x86_64
     return env->regs[R_ESP];
 #elif defined(TARGET_ARM)
-    // R13 on ARM.
-    return env->regs[13];
+    if (env->aarch64) {
+        // X31 on AARCH64.
+        return env->xregs[31];
+    } else {
+        // R13 on ARM.
+        return env->regs[13];
+    }
 #elif defined(TARGET_PPC)
     // R1 on PPC.
     return env->gpr[1];

--- a/panda/include/panda/common.h
+++ b/panda/include/panda/common.h
@@ -508,7 +508,7 @@ static inline bool panda_in_kernel(const CPUState *cpu) {
  */
 static inline bool address_in_kernel_code_linux(target_ulong addr){
     // TODO: Find a way to ask QEMU what the permissions are on an area.
-    #if defined(TARGET_ARM) || (defined(TARGET_I386) && !defined(TARGET_X86_64))
+    #if (defined(TARGET_ARM) && !defined(TARGET_AARCH64)) || (defined(TARGET_I386) && !defined(TARGET_X86_64))
     // I386: https://elixir.bootlin.com/linux/latest/source/arch/x86/include/asm/page_32_types.h#L18
     // ARM32: https://people.kernel.org/linusw/how-the-arm32-kernel-starts
     // ARM has a variable VMSPLIT. Technically this can be several values,

--- a/panda/plugins/proc_start_linux/README.md
+++ b/panda/plugins/proc_start_linux/README.md
@@ -25,5 +25,28 @@ The structure currently provides many elements of the auxiliary vector that you 
 
 There is no guarantee a kernel sets each value every time. The `struct auv_values` is set to 0 before it is filled. A value provided should be suspect if it is a zero.
 
-Example
+Python Example
 -------
+
+See [proc_start.py](panda/python/examples/proc_start.py) or [proc_start_linux_demo.py](panda/python/examples/proc_start_linux_demo.py) (copied below):
+```python
+from pandare import Panda
+from sys import argv
+
+arch = "i386" if len(argv) <= 1 else argv[1]
+panda = Panda(generic=arch)
+
+@panda.queue_blocking
+def guest_interaction():
+    panda.revert_sync("root")
+    for cmd in ["ls -la", "whoami", "time ls -la"]:
+        print(f"{cmd} {panda.run_serial_cmd('LD_SHOW_AUXV=1 '+cmd)}")
+    panda.end_analysis()
+
+@panda.ppp("proc_start_linux", "on_rec_auxv")
+def recv_auxv(cpu, tb, auxv):
+    procname = panda.ffi.string(auxv.execfn)
+    print(f"started proc {procname} {auxv.phdr:x} {auxv.entry:x}")
+
+panda.run()
+```

--- a/panda/plugins/proc_start_linux/proc_start_linux.cpp
+++ b/panda/plugins/proc_start_linux/proc_start_linux.cpp
@@ -272,7 +272,7 @@ void sbe(CPUState *cpu, TranslationBlock *tb){
             panda_disable_callback(self_ptr, PANDA_CB_START_BLOCK_EXEC, pcb_sbe_execve);
             free(vals);
         }else{
-            printf("got here and could not read stack\n");
+            log("got here and could not read stack\n");
             // this would be the case where fault_hooks would work well.
         }
     }
@@ -293,6 +293,9 @@ bool init_plugin(void *self) {
 
     #if defined(TARGET_MIPS64)
         fprintf(stderr, "[ERROR] proc_start_linux: mips64 architecture not supported!\n");
+        return false;
+    #elif defined(TARGET_AARCH64)
+        fprintf(stderr, "[ERROR] proc_start_linux: aarch64 architecture not supported!\n");
         return false;
     #elif defined(TARGET_PPC)
         fprintf(stderr, "[ERROR] proc_start_linux: PPC architecture not supported by syscalls2!\n");

--- a/panda/plugins/proc_start_linux/proc_start_linux.cpp
+++ b/panda/plugins/proc_start_linux/proc_start_linux.cpp
@@ -294,9 +294,6 @@ bool init_plugin(void *self) {
     #if defined(TARGET_MIPS64)
         fprintf(stderr, "[ERROR] proc_start_linux: mips64 architecture not supported!\n");
         return false;
-    #elif defined(TARGET_AARCH64)
-        fprintf(stderr, "[ERROR] proc_start_linux: aarch64 architecture not supported!\n");
-        return false;
     #elif defined(TARGET_PPC)
         fprintf(stderr, "[ERROR] proc_start_linux: PPC architecture not supported by syscalls2!\n");
         return false;

--- a/panda/plugins/proc_start_linux/proc_start_linux.cpp
+++ b/panda/plugins/proc_start_linux/proc_start_linux.cpp
@@ -7,8 +7,28 @@
  * See the COPYING file in the top-level directory. 
  * 
 PANDAENDCOMMENT */
-// This needs to be defined before anything is included in order to get
-// the PRIx64 macro
+
+/**
+ * Logic for this plugin:
+ *  On the first execve or execveat the system will transition to the kernel
+ *  and back to userspace. We attempt to catch the very first block of the new
+ *  program by looking for the first block where the stack pointer is in 
+ *  userspace, paged in, and has a value that makes sense for the auxiliary
+ *  vector (described below). Specifically, we check that the first argument,
+ *  the argc value, is a reasonable number. We chose this reasonable number
+ *  to be 0x200000, a common value for ARG_MAX on unix systems.
+ * 
+ *  Once we have established the location of the auxiliary vector we make a PPP
+ *  callback and pass the values of the auxv to the callback.
+ * 
+ * Issues:
+ *  Currently the plugin catches about 95% of the new programs across
+ *  architectures. The remaining 5% are somewhat elusive. It may be that the
+ *  kernel does something like immediately switching to a new program or memory
+ *  is not paged in at the stage we might expect.
+ */
+
+
 #define __STDC_FORMAT_MACROS
 
 #include <linux/auxvec.h>
@@ -22,15 +42,15 @@ using namespace std;
 // These need to be extern "C" so that the ABI is compatible with
 // QEMU/PANDA, which is written in C
 extern "C" {
-bool init_plugin(void *);
-void uninit_plugin(void *);
-#include "syscalls2/syscalls_ext_typedefs.h"
-#include "syscalls2/syscalls2_info.h"
-#include "syscalls2/syscalls2_ext.h"
-#include "proc_start_linux.h"
-#include "proc_start_linux_ppp.h"
-PPP_PROT_REG_CB(on_rec_auxv);
-PPP_CB_BOILERPLATE(on_rec_auxv);
+    bool init_plugin(void *);
+    void uninit_plugin(void *);
+    #include "syscalls2/syscalls_ext_typedefs.h"
+    #include "syscalls2/syscalls2_info.h"
+    #include "syscalls2/syscalls2_ext.h"
+    #include "proc_start_linux.h"
+    #include "proc_start_linux_ppp.h"
+    PPP_PROT_REG_CB(on_rec_auxv);
+    PPP_CB_BOILERPLATE(on_rec_auxv);
 }
 
 // uncomment to look under the hood
@@ -41,7 +61,6 @@ PPP_CB_BOILERPLATE(on_rec_auxv);
 #else
 #define log(...)
 #endif
-
 
 #if defined(TARGET_WORDS_BIGENDIAN)
 #if TARGET_LONG_SIZE == 4
@@ -63,6 +82,12 @@ PPP_CB_BOILERPLATE(on_rec_auxv);
 void *self_ptr;
 panda_cb pcb_sbe_execve;
 
+#define ARG_MAX 0x200000
+
+#define FAIL_READ_ARGV -1
+#define FAIL_READ_ENVP -2
+#define FAIL_READ_AUXV -3
+
 string read_str(CPUState* cpu, target_ulong ptr){
     string buf = "";
     char tmp;
@@ -79,11 +104,6 @@ string read_str(CPUState* cpu, target_ulong ptr){
     }
     return buf;
 }
-
-#define FAIL_READ_ARGV -1
-#define FAIL_READ_ENVP -2
-#define FAIL_READ_AUXV -3
-
 
 /**
  * 
@@ -122,6 +142,7 @@ int read_aux_vals(CPUState *cpu, struct auxv_values *vals){
         if (panda_virtual_memory_read(cpu, sp + (ptrlistpos * sizeof(target_ulong)), (uint8_t *)&ptr, sizeof(ptr)) != MEMTX_OK){
             return FAIL_READ_ARGV;
         }
+        fixupendian(ptr);
         ptrlistpos++;
         if (ptr == 0){
             break;
@@ -146,6 +167,7 @@ int read_aux_vals(CPUState *cpu, struct auxv_values *vals){
         if (panda_virtual_memory_read(cpu, sp + (ptrlistpos * sizeof(target_ulong)), (uint8_t *)&ptr, sizeof(ptr)) != MEMTX_OK){
             return FAIL_READ_ENVP;
         }
+        fixupendian(ptr);
         ptrlistpos++;
         if (ptr == 0){
             break;
@@ -223,15 +245,18 @@ int read_aux_vals(CPUState *cpu, struct auxv_values *vals){
     return 0;
 }
 
-bool has_been_in_kernel = false;
 
 void sbe(CPUState *cpu, TranslationBlock *tb){
-    bool in_kernel = panda_in_kernel_code_linux(cpu);
-    if (unlikely(!panda_in_kernel_code_linux(cpu) && has_been_in_kernel)){
-        // check that we can read the stack
-        target_ulong sp = panda_current_sp(cpu);
+    target_ulong sp = panda_current_sp(cpu);
+    bool sp_in_kernel = address_in_kernel_code_linux(sp);
+    if (!sp_in_kernel){ 
         target_ulong argc;
         if (panda_virtual_memory_read(cpu, sp, (uint8_t *)&argc, sizeof(argc)) == MEMTX_OK){
+            fixupendian(argc);
+            if (argc > ARG_MAX){
+                log("argc is incorrect " TARGET_FMT_lx "\n", argc);
+                return;
+            }
             struct auxv_values *vals = (struct auxv_values*)malloc(sizeof(struct auxv_values));
             memset(vals, 0, sizeof(struct auxv_values));
             int status = read_aux_vals(cpu, vals);
@@ -246,21 +271,20 @@ void sbe(CPUState *cpu, TranslationBlock *tb){
             }
             panda_disable_callback(self_ptr, PANDA_CB_START_BLOCK_EXEC, pcb_sbe_execve);
             free(vals);
-            has_been_in_kernel = false;
         }else{
+            printf("got here and could not read stack\n");
             // this would be the case where fault_hooks would work well.
-            // printf("got here and could not read stack\n");
         }
-    } else if (in_kernel){
-        has_been_in_kernel = true;
     }
 }
 
 void execve_cb(CPUState *cpu, target_ptr_t pc, target_ptr_t filename, target_ptr_t argv, target_ptr_t envp) {
+    log("execve\n");
     panda_enable_callback(self_ptr, PANDA_CB_START_BLOCK_EXEC, pcb_sbe_execve);
 }
 
 void execveat_cb (CPUState* cpu, target_ptr_t pc, int dfd, target_ptr_t filename, target_ptr_t argv, target_ptr_t envp, int flags) {
+    log("execveat\n");
     panda_enable_callback(self_ptr, PANDA_CB_START_BLOCK_EXEC, pcb_sbe_execve);
 }
 
@@ -293,10 +317,10 @@ bool init_plugin(void *self) {
 void uninit_plugin(void *self) {
 #if defined(TARGET_PPC) or defined(TARGET_MIPS64)
 #else
-  void* syscalls = panda_get_plugin_by_name("syscalls2");
-  if (syscalls != NULL){
-    PPP_REMOVE_CB("syscalls2", on_sys_execve_enter, execve_cb);
-    PPP_REMOVE_CB("syscalls2", on_sys_execveat_enter, execveat_cb);
-  }
+    void* syscalls = panda_get_plugin_by_name("syscalls2");
+    if (syscalls != NULL){
+        PPP_REMOVE_CB("syscalls2", on_sys_execve_enter, execve_cb);
+        PPP_REMOVE_CB("syscalls2", on_sys_execveat_enter, execveat_cb);
+    }
 #endif
 }

--- a/panda/plugins/proc_start_linux/proc_start_linux.h
+++ b/panda/plugins/proc_start_linux/proc_start_linux.h
@@ -41,6 +41,7 @@ struct auxv_values {
     target_ulong random;
     target_ulong platform;
     target_ulong program_header; // this is just PHDR - sizeof(ehdr). it's a best guess
+    target_ulong minsigstksz;
 };
 
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!

--- a/panda/python/examples/proc_start_linux_demo.py
+++ b/panda/python/examples/proc_start_linux_demo.py
@@ -13,7 +13,7 @@ def guest_interaction():
 
 @panda.ppp("proc_start_linux", "on_rec_auxv")
 def recv_auxv(cpu, tb, auxv):
-    procname = panda.ffi.string(auxv.procname)
+    procname = panda.ffi.string(auxv.execfn)
     print(f"started proc {procname} {auxv.phdr:x} {auxv.entry:x}")
 
 panda.run()


### PR DESCRIPTION
This PR makes the following changes:
- updates `address_in_kernel_code_linux` with more precise values for regions for different architectures
- fixes endianness issues in `proc_start_linux`
- switches `proc_start_linux` to stack based access model. This seems to improve auxiliary vector detection success.