### PR TITLE
added py3 bytestring fix to rrpack scripts

### DIFF
--- a/panda/scripts/rrpack.py
+++ b/panda/scripts/rrpack.py
@@ -5,7 +5,7 @@ import subprocess
 import struct
 import hashlib
 
-RRPACK_MAGIC = "PANDA_RR"
+RRPACK_MAGIC = b"PANDA_RR"
 
 # PANDA Packed RR file format (all integers are little-endian):
 # 0x00: magic "PANDA_RR"
@@ -38,7 +38,7 @@ print("Packing RR log %s with %d instructions..." % (base, num_guest_insns))
 outf = open(outfname, 'wb')
 outf.write(RRPACK_MAGIC)
 outf.write(struct.pack("<Q", num_guest_insns))
-outf.write("\0" * 16) # Placeholder for checksum
+outf.write(b"\0" * 16) # Placeholder for checksum
 outf.flush()
 subprocess.check_call(['tar', 'cJf', '-', base + '-rr-snp', base + '-rr-nondet.log'], stdout=outf)
 outf.close()

--- a/panda/scripts/rrunpack.py
+++ b/panda/scripts/rrunpack.py
@@ -5,7 +5,7 @@ import subprocess
 import struct
 import hashlib
 
-RRPACK_MAGIC = "PANDA_RR"
+RRPACK_MAGIC = b"PANDA_RR"
 
 # PANDA Packed RR file format (all integers are little-endian):
 # 0x00: magic "PANDA_RR"


### PR DESCRIPTION
Tested on Python 3.8.10 in Ubuntu 20.04 WSL2.

The `rr*pack.py` scripts required some small fixes changing strings -> byte-strings in order for the scripts to run using `python3`.

```sh
$ python3 rrpack.py poc
Packing RR log poc with 1048580 instructions...
Traceback (most recent call last):
  File "rrpack.py", line 39, in <module>
    outf.write(RRPACK_MAGIC)
TypeError: a bytes-like object is required, not 'str'
```

The lack of byte-string prefix makes the check `if magic != RRPACK_MAGIC:` fail because `b"PANDA_RR" != "PANDA_RR"`

```sh
$ python3 rrunpack.py poc.rr
poc.rr is not in PANDA Record/Replay format
```