### PR TITLE
cosi: profile path fix, mips support via hw_proc_id, arm support via current_ksp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,8 @@ COPY --from=installer /lib/libosi.so /lib/libiohal.so /lib/liboffset.so /lib/
 # Workaround issue #901 - ensure LD_LIBRARY_PATH contains the panda plugins directories
 #ARG TARGET_LIST="x86_64-softmmu,i386-softmmu,arm-softmmu,ppc-softmmu,mips-softmmu,mipsel-softmmu"
 ENV LD_LIBRARY_PATH /usr/local/lib/python3.8/dist-packages/pandare/data/x86_64-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/i386-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/arm-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/ppc-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/mips-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/mipsel-softmmu/panda/plugins/
+#PANDA_PATH is used by rust plugins
+ENV PANDA_PATH /usr/local/lib/python3.8/dist-packages/pandare/data
 
 
 # Ensure runtime dependencies are installed for our libpanda objects and panda plugins

--- a/panda/plugins/cosi/src/ffi/core.rs
+++ b/panda/plugins/cosi/src/ffi/core.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn symbol_value_from_name(name: *const c_char) -> target_p
     if let Some(sym) = symbol_from_name(name) {
         sym.address as target_ptr_t
     } else {
-        panic!("Invalid symbol name, could not retrieve volatility symbol")
+        panic!("Invalid symbol name, could not retrieve volatility symbol for '{}'", CStr::from_ptr(name).to_str().expect("could not covert to str"));
     }
 }
 

--- a/panda/plugins/cosi/src/lib.rs
+++ b/panda/plugins/cosi/src/lib.rs
@@ -39,9 +39,9 @@ static ARGS: Lazy<Args> = Lazy::new(Args::from_panda_args);
 #[allow(deprecated)]
 fn symbol_table() -> &'static VolatilityJson {
     SYMBOL_TABLE.get_or_init(|| {
-        let name = get_symtab_name();
 
         let path = if ARGS.profile.is_empty() || !Path::new(&ARGS.profile).exists() {
+            let name = get_symtab_name();
             let filename = if ARGS.profile.is_empty() {
                 &name
             } else {
@@ -99,6 +99,10 @@ fn init(_: &mut PluginHandle) -> bool {
 
             first_syscall.disable();
         });
+    }
+
+    #[cfg(any(feature = "mips", feature = "mipsel"))] {
+        structs::HWPROCID.ensure_init();
     }
 
     true


### PR DESCRIPTION
This PR has two changes for adding MIPS support to COSI:

1. Removes the need for specifying an `-os` parameter to PANDA when specifying a profile with an argument
2. Uses hw_proc_id to get the `current_task` for mips (same as OSI Linux)

Might need to do [something similar for arm](https://github.com/panda-re/panda/blob/dev/panda/plugins/osi_linux/default_profile.cpp#L14-L55)