### PR TITLE
proc_start_linux: Fix ASID reading management after system process execution

### DIFF
--- a/panda/plugins/proc_start_linux/proc_start_linux.cpp
+++ b/panda/plugins/proc_start_linux/proc_start_linux.cpp
@@ -260,15 +260,11 @@ int read_aux_vals(CPUState *cpu, struct auxv_values *vals){
 }
 
 
-target_ulong saved_sp = 0;
-
-
 bool try_run_auxv(CPUState *cpu, TranslationBlock *tb, target_ulong sp){
     log("checking sp " TARGET_FMT_lx "\n", sp);
     target_ulong argc;
     if (panda_virtual_memory_read(cpu, sp, (uint8_t *)&argc, sizeof(argc)) != MEMTX_OK){
         log("got here and could not read stack " TARGET_FMT_lx "\n", sp);
-        saved_sp = sp;
         return false;
     }
     fixupendian(argc);

--- a/panda/plugins/proc_start_linux/proc_start_linux.cpp
+++ b/panda/plugins/proc_start_linux/proc_start_linux.cpp
@@ -54,10 +54,10 @@ extern "C" {
 }
 
 // uncomment to look under the hood
-#define DEBUG
+// #define DEBUG
 
 #ifdef DEBUG
-#define log(...) //printf(__VA_ARGS__)
+#define log(...) printf(__VA_ARGS__)
 #else
 #define log(...)
 #endif

--- a/panda/plugins/proc_start_linux/proc_start_linux.cpp
+++ b/panda/plugins/proc_start_linux/proc_start_linux.cpp
@@ -34,7 +34,6 @@ PANDAENDCOMMENT */
 #include <linux/auxvec.h>
 #include <linux/elf.h>
 #include <string>
-#include <unordered_set>
 #include "panda/plugin.h"
 #include "panda/plugin_plugin.h"
 
@@ -58,7 +57,7 @@ extern "C" {
 #define DEBUG
 
 #ifdef DEBUG
-#define log(...) printf(__VA_ARGS__)
+#define log(...) //printf(__VA_ARGS__)
 #else
 #define log(...)
 #endif


### PR DESCRIPTION
This fixes proc_start_linux analysis by letting it move to the next ASID if it can't read the aux vector from the initial candidate.