### PR TITLE
pypanda: added search for osi mapping by addr, other minor tweaks

### DIFF
--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -12,7 +12,6 @@ import socket
 import select
 import threading
 
-
 import readline
 # XXX: readline is unused but necessary. We need to load python
 # readline, to preempt PANDA loading another version. PANDA
@@ -1670,6 +1669,19 @@ class Panda():
             return None
         return self.ffi.string(fname_ptr)
 
+    def get_current_process(self, cpu):
+        '''
+        Get the current process as an OsiProc struct.
+
+        Returns:
+            string: process name
+            None: on failure
+        '''
+        proc = self.plugins['osi'].get_current_process(cpu)
+        if proc == self.ffi.NULL:
+            return None
+        return proc
+
     def get_mappings(self, cpu):
         '''
         Get all active memory mappings in the system.
@@ -1686,6 +1698,30 @@ class Panda():
         maps = self.plugins['osi'].get_mappings(cpu, current)
         map_len = self.garray_len(maps)
         return GArrayIterator(self.plugins['osi'].get_one_module, maps, map_len, self.plugins['osi'].cleanup_garray)
+
+    def get_mapping_by_addr(self, cpu, addr):
+        '''
+        Return the OSI mapping that matches the address specified.
+
+        Requires: OSI
+
+        Args:
+            cpu: CPUState struct
+            addr: int
+
+        Returns:
+            OsiModule: the matching OsiModule structure
+            None: on failure
+        '''
+        mappings = self.get_mappings(cpu)
+        for m in mappings:
+            if m.name != panda.ffi.NULL:
+                name = panda.ffi.string(m.name).decode("utf-8")
+            else:
+                name = "???"
+            if addr >= m.base and addr < m.base+m.size:
+                return m
+        return None
 
     def get_processes(self, cpu):
         '''
@@ -3069,7 +3105,7 @@ class Panda():
     def hook_symbol(self, libraryname, symbol, kernel=False, name=None, cb_type="start_block_exec"):
         '''
         Decorate a function to setup a hook: when a guest goes to execute a basic block beginning with addr,
-        the function will be called with args (CPUState, TranslationBlock)
+        the function will be called with args (CPUState, TranslationBlock, struct hook)
 
         Args:
             libraryname (string): Name of library containing symbol to be hooked. May be None to match any.

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -1715,8 +1715,8 @@ class Panda():
         '''
         mappings = self.get_mappings(cpu)
         for m in mappings:
-            if m.name != panda.ffi.NULL:
-                name = panda.ffi.string(m.name).decode("utf-8")
+            if m.name != self.ffi.NULL:
+                name = self.ffi.string(m.name).decode("utf-8")
             else:
                 name = "???"
             if addr >= m.base and addr < m.base+m.size:

--- a/panda/python/examples/task_change.py
+++ b/panda/python/examples/task_change.py
@@ -6,7 +6,7 @@ Whenever the process changes, print it's ASID and name
 panda = Panda(generic='x86_64')
 
 def _active_proc_name(cpu):
-    proc = panda.plugins['osi'].get_current_process(cpu)
+    proc = panda.get_current_process(cpu)
     if proc == panda.ffi.NULL: return ""
     return panda.ffi.string(proc.name).decode("utf8", errors="ignore")
 

--- a/panda/python/tests/generic_tests.py
+++ b/panda/python/tests/generic_tests.py
@@ -91,7 +91,7 @@ def runner(generic_name, test1=True, test2=True):
             global reverted
             #print("ASID", reverted, panda.arch)
             if reverted and panda.arch_name in osi_supported: # If osi unsupported, bail
-                proc = panda.plugins['osi'].get_current_process(cpu)
+                proc = panda.get_current_process(cpu)
                 name = panda.ffi.string(proc.name)
                 if name not in seen:
                     maps = panda.get_mappings(cpu)


### PR DESCRIPTION
This PR includes a few minor changes to PyPANDA:
1. Adds `get_current_process` so that users don't have to do `panda.plugins['osi']`.

2. Adds a `get_mapping_by_addr` to search for an OSI mapping by a virtual address.

3. Fixes a docstring typo on `hook_symbol`.