### PR TITLE
copy syscalls2 dso_info files to installation packaging area

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -291,6 +291,10 @@ endif
 			$(INSTALL_DATA) $$f "$(DESTDIR)$(qemu_confdir)/$$p"; \
 		done; \
 	done
+	for f in $$(find panda/plugins/ -type f -name 'syscalls2_dso_info_*.so'); do \
+		echo $$f; \
+		$(INSTALL_LIB) $$f "$(DESTDIR)$(libdir)/panda/$(TARGET_NAME)"; \
+	done
 
 GENERATED_FILES += config-target.h plog_pb2.py
 Makefile: $(GENERATED_FILES)


### PR DESCRIPTION
The missing dso information files prevent the syscalls2 load-info option from working when using an installed build of PANDA instead of a development build. 