### PR TITLE
PyPlugin Context Managers

### DIFF
--- a/panda/python/core/pandare/pyplugin.py
+++ b/panda/python/core/pandare/pyplugin.py
@@ -80,6 +80,7 @@ class PyPlugin:
         def f(*args, **kwargs):
             return method(*args, **kwargs)
         f.__is_pyplugin_ppp = True
+        f.__original_method = method
         return f
 
     # Argument loading

--- a/panda/python/core/pandare/pypluginmanager.py
+++ b/panda/python/core/pandare/pypluginmanager.py
@@ -35,7 +35,7 @@ class _PppPlugins(_DotGetter):
     def __getattr__(self, name):
         plugin = self.data.get(name, None)
         if plugin is None:
-            raise AttributeError(f"No plugin named {plugin}")
+            raise AttributeError(f"No plugin named {name}")
         return plugin
 
     def add(self, plugin_name, func_name, func):

--- a/panda/python/examples/pyplugin_ctx.py
+++ b/panda/python/examples/pyplugin_ctx.py
@@ -1,0 +1,43 @@
+from threading import Lock
+from time import sleep
+from pandare import PyPlugin, Panda
+
+class Server(PyPlugin):
+    def __init__(self, panda):
+        self.x = 0
+        self.lock = Lock()
+    
+    @PyPlugin.ppp_export
+    def __enter__(self):
+        self.lock.acquire()
+
+    @PyPlugin.ppp_export
+    def __exit__(self, *args):
+        self.lock.release()
+
+    @PyPlugin.ppp_export
+    def do_add(self, x):
+        self.x += x
+        sleep(5)
+        return self.x
+
+class Consumer1(PyPlugin):
+    def __init__(self, panda):
+        print(f"Consumer1 init. Getting server lock")
+        with self.ppp.Server as server:
+            print(f"Consumer1: got lock. Calling do_add")
+            print(server.do_add(1))
+            print(f"Consumer1: finished with do_add")
+
+class Consumer2(PyPlugin):
+    def __init__(self, panda):
+        print(f"Consumer2 init. Getting server lock")
+        with self.ppp.Server as server:
+            print(f"Consumer2: got lock. Calling do_add")
+            print(server.do_add(1))
+            print(f"Consumer2: finished with do_add")
+
+panda = Panda(generic="x86_64")
+panda.pyplugins.load(Server)
+panda.pyplugins.load(Consumer1)
+panda.pyplugins.load(Consumer2)


### PR DESCRIPTION
To allow PyPlugins to function as a Context Managers we need to special case the `__enter__` and `__exit__` methods. This  PR adds support for that and an example.

Also fixes a bug where if you tried to use a PyPlugin that didn't exist the error message would say the plugin "None" isn't loaded, instead of the actual name.