### PR TITLE
Handle rep (repeat) instructions in coverage plugin edge mode

### DIFF
--- a/panda/plugins/coverage/EdgeInstrumentationDelegate.h
+++ b/panda/plugins/coverage/EdgeInstrumentationDelegate.h
@@ -31,6 +31,9 @@ public:
 
     void task_changed(const std::string& process_name, target_pid_t pid, target_pid_t tid) override;
 
+protected:
+    void insert_block_callback(TranslationBlock *tb);
+
 private:
     std::shared_ptr<RecordProcessor<Edge>> edge_processor;
     std::unique_ptr<EdgeState> edge_state;


### PR DESCRIPTION
With this fix, blocks that end with a rep instruction are instrumented, and so the edges are logged when the destination edge is executed.
Also fixed a problem with instrumenting blocks that contain exactly one instruction which is a flow control instruction.