### PR TITLE
Add YARA rule Python example

### DIFF
--- a/panda/python/examples/flirt-signatures/run.py
+++ b/panda/python/examples/flirt-signatures/run.py
@@ -44,11 +44,18 @@ class SearchFlirtPlugin(PyPlugin):
 
     def on_call_search_flirt(self, env, addr_func: int) -> None:
         """
-        https://github.com/panda-re/panda/tree/dev/panda/plugins/callstack_instr
+        Checks every call inside a given process against F.L.I.R.T. signatures.
 
-        :param env: t
-        :param addr_func:
-        :return:
+        Based on the PANDA callstack_instr plugin.
+
+        When the callstack_instr detects a call, we read 0x100 bytes of the callee.
+        We then match these bytes against the loaded signatures.
+
+        When a match is found it is printend and if show_function_instructions is set,
+        the first five instructions of the callee are also printed.
+
+        :param env: The current state during the execution.
+        :param addr_func: The address of the callee.
         """
 
         if addr_func in self._seen_function_addresses or self._panda.get_process_name(env) != self._process_name:

--- a/panda/python/examples/yara-rules/Dockerfile
+++ b/panda/python/examples/yara-rules/Dockerfile
@@ -1,0 +1,20 @@
+FROM pandare/panda
+
+RUN apt-get update \
+    && apt-get install -y python3-dev build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && python -m pip install --no-cache-dir yara-python \
+    \
+    && mkdir /data/ \
+    && mkdir /data/recordings/ \
+    && mkdir /data/rules/ \
+    && mkdir /data/binaries/ \
+    && mkdir /data/matches/
+
+WORKDIR /data/
+CMD python run.py
+
+COPY rules/ /data/rules/
+COPY binaries/decrypt /data/binaries/decrypt
+COPY run.py /data/run.py

--- a/panda/python/examples/yara-rules/README.md
+++ b/panda/python/examples/yara-rules/README.md
@@ -1,0 +1,122 @@
+# Searching for YARA rules in memory in PANDA
+
+This example PyPanda plugin checks each buffer written to memory (by a specific process) against provided YARA rules.
+
+To make sure we have the necessary dependencies, we build a custom Docker image based on `pandare/panda`.
+
+### Example
+For testing we use a simple example that simulates a simple malware packer. Our test binary contains a hard-coded, encrypted buffer, which it decrypts and writes to disk. If the decrypted buffer matches a YARA rule, the plugin should detect (and dump) it during execution.
+
+We use [the following YARA rule from Mandiant](https://www.mandiant.com/resources/blog/cosmicenergy-ot-malware-russian-response):
+```YARA
+rule M_Hunting_Disrupt_LIGHTWORK_Strings
+{
+     meta:
+          author = "Mandiant"
+          description = "Searching for strings associated with IEC-104 used in LIGHTWORK."
+          date = "2023-04-19"
+
+     strings:
+          $s1 = "Connecting to: %s:%i\n" ascii wide nocase
+          $s2 = "Connected!" ascii wide nocase
+          $s3 = "Send control command C_SC_NA_1" ascii wide nocase
+          $s4 = "Connect failed!" ascii wide nocase
+          $s5 = "Send time sync command" ascii wide nocase
+          $s6 = "Wait ..." ascii wide nocase
+          $s7 = "exit 0" ascii wide nocase
+
+     condition:
+          filesize < 5MB and
+          uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550 and
+          all of them
+}
+```
+
+We use the following byte sequence as a (benign) buffer that matches the YARA rule.
+```Python
+b"\x4D\x5A"
++ b"\x00" * (0x3c - 2)
++ b"\x40\x00\x00\x00"
++ b"\x50\x45\x00\x00"
++ b"Connecting to: %s:%i\n"
++ b"Connected!"
++ b"Send control command C_SC_NA_1"
++ b"Connect failed!"
++ b"Send time sync command"
++ b"Wait ..."
++ b"exit 0"
++ b"\x00" * 100
+```
+
+We encrypt the buffer by XOR'ing it with `0xFF`.
+
+The following Nim program contains the encrypted buffer. It decrypts it and writes the plaintext to disk. The goal of this demo program is to create a binary that, at some point during execution, has a buffer that matches the YARA rule inside its memory.
+```nim
+proc decrypt(key: byte, ciphertext: seq[byte]): seq[byte] =
+    var plaintext = newSeq[byte](ciphertext.len)
+    for i, c in ciphertext:
+        plaintext[i] = key xor c
+    return plaintext
+
+const KEY = 0xFF
+const PAYLOAD = @[
+    byte 178, 165, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 191, 255,
+    255, 255, 175, 186, 255, 255, 188, 144, 145,
+    145, 154, 156, 139, 150, 145, 152, 223, 139,
+    144, 197, 223, 218, 140, 197, 218, 150, 245,
+    188, 144, 145, 145, 154, 156, 139, 154, 155,
+    222, 172, 154, 145, 155, 223, 156, 144, 145,
+    139, 141, 144, 147, 223, 156, 144, 146, 146,
+    158, 145, 155, 223, 188, 160, 172, 188, 160,
+    177, 190, 160, 206, 188, 144, 145, 145, 154,
+    156, 139, 223, 153, 158, 150, 147, 154, 155,
+    222, 172, 154, 145, 155, 223, 139, 150, 146,
+    154, 223, 140, 134, 145, 156, 223, 156, 144,
+    146, 146, 158, 145, 155, 168, 158, 150, 139,
+    223, 209, 209, 209, 154, 135, 150, 139, 223,
+    207, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255
+]
+
+let plaintext = decrypt(KEY, PAYLOAD)
+writeFile("output.dat", plaintext)
+```
+
+When we run the plugin, it finds and dumps two buffers. As we can see, these buffers perfectly match our original buffer:
+```shell
+$ xxd matches/2023_06_17_14_36_48-M_Hunting_Disrupt_LIGHTWORK_Strings-0x4219597-0x140737353650592-decrypt.dat
+00000000: 4d5a 0000 0000 0000 0000 0000 0000 0000  MZ..............
+00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000020: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000030: 0000 0000 0000 0000 0000 0000 4000 0000  ............@...
+00000040: 5045 0000 436f 6e6e 6563 7469 6e67 2074  PE..Connecting t
+00000050: 6f3a 2025 733a 2569 0a43 6f6e 6e65 6374  o: %s:%i.Connect
+00000060: 6564 2153 656e 6420 636f 6e74 726f 6c20  ed!Send control
+00000070: 636f 6d6d 616e 6420 435f 5343 5f4e 415f  command C_SC_NA_
+00000080: 3143 6f6e 6e65 6374 2066 6169 6c65 6421  1Connect failed!
+00000090: 5365 6e64 2074 696d 6520 7379 6e63 2063  Send time sync c
+000000a0: 6f6d 6d61 6e64 5761 6974 202e 2e2e 6578  ommandWait ...ex
+000000b0: 6974 2030 0000 0000 0000 0000 0000 0000  it 0............
+000000c0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+000000d0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+000000e0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+000000f0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000100: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000110: 0000 0000 0000 0000                      ........
+```

--- a/panda/python/examples/yara-rules/docker-compose.yaml
+++ b/panda/python/examples/yara-rules/docker-compose.yaml
@@ -1,0 +1,11 @@
+---
+
+services:
+  panda:
+    build: "."
+    volumes:
+      - "${PWD}/recordings/:/data/recordings/"
+      - "${PWD}/matches/:/data/matches/"
+
+      # Qcow2 images cache
+      - "${PWD}/images/:/root/.panda/"

--- a/panda/python/examples/yara-rules/run.py
+++ b/panda/python/examples/yara-rules/run.py
@@ -1,0 +1,148 @@
+from datetime import datetime
+
+import yara
+
+from pathlib import Path
+
+from pandare import Panda, PyPlugin
+
+ARCH = "x86_64"
+
+
+class YaraPlugin(PyPlugin):
+    def __init__(self, panda):
+        super().__init__(panda)
+
+        self._panda = panda
+
+        self._process_name: str = self.get_arg("process_name")
+        self._matcher = self.load_rules(self.get_arg("rules_path"))
+        self._output_path: Path = self.get_arg("output_path")
+
+        self._addr_current_buffer = None
+        self._current_buffer_size = 0
+        panda.cb_virt_mem_after_write(self.check_memory)
+
+    def check_memory(self, env, pc, addr_buffer, size_buffer, buffer) -> None:
+        """
+        Match buffers written to memory against YARA rules.
+
+        :param env: The current state during the execution.
+        :param pc: The current program counter.
+        :param addr_buffer: The address where data was written to.
+        :param size_buffer: The size of the written data.
+        :param buffer: The written data.
+
+        We first check that we are looking at the relevant process.
+
+        Buffers are often written to in chunks (e.g. an 80 byte buffer might be written in 10 8 byte writes).
+        To make sure we are checking the full buffer, and not only a single write,
+        we keep track of the start address and size of each buffer.
+        Only when data is written to an address that does not match
+        the current buffer address + the size (i.e. the end of the current buffer),
+        do we check the current buffer against a YARA rule.
+
+        As buffer is checked when a next buffer is written, this approach will miss the last buffer.
+
+        When a buffer matches a YARA rule, we write it to a file for later analysis.
+        """
+        if self._panda.get_process_name(env) != self._process_name:
+            return
+
+        if self._addr_current_buffer is None:
+            self._addr_current_buffer = addr_buffer
+
+        elif self._addr_current_buffer + self._current_buffer_size != addr_buffer and self._current_buffer_size > 0:
+            buffer = panda.virtual_memory_read(
+                env,
+                self._addr_current_buffer,
+                self._current_buffer_size,
+            )
+
+            matches = self._matcher.match(data=buffer)
+            for match in matches:
+                print(f"0x{self._addr_current_buffer:x}: {match.rule} ({self._current_buffer_size})")
+                date_string = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+                match_file_name = (
+                    f"{date_string}"
+                    f"-{match.rule}"
+                    f"-0x{pc}"
+                    f"-0x{self._addr_current_buffer}"
+                    f"-{self._process_name}.dat"
+                )
+                output_path = self._output_path.joinpath(match_file_name)
+                with output_path.open("wb") as h_output:
+                    h_output.write(buffer)
+
+            self._addr_current_buffer = addr_buffer
+            self._current_buffer_size = 0
+
+        self._current_buffer_size += size_buffer
+
+    @staticmethod
+    def load_rules(rules_path: Path) -> yara.Rules:
+        """Read and compile YARA rules from a given directory."""
+        return yara.compile(
+            filepaths={rule_file.name: rule_file.as_posix() for rule_file in rules_path.rglob("*.yara")}
+        )
+
+
+def take_recording(
+    panda: Panda,
+    path_recording: Path,
+    path_binary: Path,
+) -> None:
+    """
+    Recording a binary.
+
+    :param panda: An instance of a panda, giving access to the vm.
+    :param path_recording: The path where the recording should be saved.
+    :param path_binary: The path of the binary to run.
+    """
+
+    panda.revert_sync("root")
+    panda.copy_to_guest(str(path_binary.parent), absolute_paths=True)
+
+    command = str(path_binary)
+
+    print(f"Testing command: '{command}'")
+    command_output = panda.run_serial_cmd(command)
+    print(f"Output: '{command_output}'")
+
+    panda.record_cmd(command, recording_name=str(path_recording), snap_name=None)
+
+    panda.end_analysis()
+
+
+if __name__ == "__main__":
+    # Directories inside Docker
+    directory_binaries = Path("/data/binaries/")
+    directory_recordings = Path("/data/recordings/")
+    directory_rules = Path("/data/rules/")
+    directory_output = Path("/data/matches/")
+
+    binary = "decrypt"
+    path_binary = directory_binaries.joinpath(binary)
+    path_recording = directory_recordings.joinpath(f"{binary}_{ARCH}")
+
+    panda = Panda(generic=ARCH)
+
+    if panda.recording_exists(str(path_recording)):
+        print("Running the plugin")
+
+        panda.pyplugins.load(
+            YaraPlugin,
+            {
+                "process_name": binary,
+                "rules_path": directory_rules,
+                "output_path": directory_output,
+            },
+        )
+
+        panda.enable_memcb()
+        panda.run_replay(str(path_recording))
+
+    else:
+        print("Taking recording")
+        panda.queue_blocking(lambda: take_recording(panda, path_recording, path_binary))
+        panda.run()


### PR DESCRIPTION
### Description

This PR adds Python example code that dumps buffers in memory to disk, if they match a YARA rule.
This is another small example I made to learn more about PANDA. I thought it might be nice to share.

This PR also adds a docstring to my previous example code (#1310). If you want, I can move that to a separate PR.