### PR TITLE
New command line option - RR fix

### DIFF
--- a/include/migration/savevm.h
+++ b/include/migration/savevm.h
@@ -1,4 +1,5 @@
 extern int panda_is_in_record;
+extern int panda_complete_rr_snapshot;
 
 void set_rr_snapshot(void);
 void unset_rr_snapshot(void);

--- a/migration/savevm.c
+++ b/migration/savevm.c
@@ -1178,7 +1178,7 @@ void qemu_savevm_state_complete_precopy(QEMUFile *f, bool iterable_only)
     json_start_array(vmdesc, "devices");
     QTAILQ_FOREACH(se, &savevm_state.handlers, entry) {
 
-        if (panda_is_in_record && !idstr_is_important(se->idstr)) {
+        if (panda_is_in_record && !panda_complete_rr_snapshot && !idstr_is_important(se->idstr)) {
             continue;
         }
 

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -4188,6 +4188,10 @@ DEF("os", HAS_ARG, QEMU_OPTION_panda_os_name,
     "-os os_name\n"
     "               inform panda about guest operating system\n", QEMU_ARCH_ALL)
 
+DEF("complete-rr-snapshot", 0, QEMU_OPTION_complete_rr_snapshot,
+    "-complete-rr-snapshot\n"
+    "       record all SaveStateEntry in the snapshot when a new recording is created\n", QEMU_ARCH_ALL)
+
 HXCOMM This is the last statement. Insert new options before this line!
 STEXI
 @end table

--- a/vl.c
+++ b/vl.c
@@ -144,6 +144,7 @@ int main(int argc, char **argv)
 #include "sysemu/replay.h"
 #include "qapi/qmp/qerror.h"
 #include "sysemu/iothread.h"
+#include "migration/savevm.h"
 
 #include "vl.h"
 
@@ -163,6 +164,7 @@ int panda_in_main_loop = 0;
 extern bool panda_abort_requested; // When set, we exit in after printing a help message
 bool panda_break_vl_loop_req = false; // When set, we break the main loop in vl.c
 bool panda_aborted = false; // Set if panda was terminated abnormally (e.g., Ctrl-C)
+int panda_complete_rr_snapshot = 0;
 
 char *panda_snap_name = NULL;
 const char* replay_name = NULL;
@@ -4313,6 +4315,10 @@ int main_aux(int argc, char **argv, char **envp, PandaMainMode pmm)
                 // NB: this will complain if we provide an os name that panda doesnt know about
                 panda_set_os_name(os_name);
                 break;
+            }
+            case QEMU_OPTION_complete_rr_snapshot:
+            {
+                panda_complete_rr_snapshot = 1;
             }
             default:
                 os_parse_cmd_args(popt->index, optarg);


### PR DESCRIPTION
Added new command line option -complete-rr-snapshot , which enables requires the writing of all peripheral device state to snapshot when a recording is initiated.