### PR TITLE
Fix RR2-related regression in checkpoint restore

### DIFF
--- a/panda/src/checkpoint.c
+++ b/panda/src/checkpoint.c
@@ -196,7 +196,11 @@ void panda_restore(void *opaque) {
     first_cpu->rr_guest_instr_count = checkpoint->guest_instr_count;
     first_cpu->panda_guest_pc = panda_current_pc(first_cpu);
     rr_nondet_log->bytes_read = checkpoint->nondet_log_position;
-    rrfile_fseek_set(&rr_nondet_log->file.replay_rr, rr_nondet_log->name, checkpoint->nondet_log_position);
+    if (rr_nondet_log->rr2){
+        rrfile_fseek_set(&rr_nondet_log->file.replay_rr, rr_nondet_log->name, checkpoint->nondet_log_position);
+    }else{
+        fseek(rr_nondet_log->file.fp, checkpoint->nondet_log_position, SEEK_SET);
+    }
     rr_queue_head = rr_queue_tail = NULL;
 
     memcpy(rr_number_of_log_entries, checkpoint->number_of_log_entries,


### PR DESCRIPTION
In #1194 many record/replay related file functions were replaced with equivalent functions supporting the RR2 format with care to ensure that RR1 support remained.

In `checkpoint.c` our changes do not maintain support for RR1 resulting in a segmentation fault: https://github.com/panda-re/panda/pull/1194/files#diff-b559907e401ac3b65e17bad5551e724edc5c3740cc46de90b16271bbac513a81R199

This PR seeks to add back support for RR1 functionality in the same manner that `fseek` is handled in `rr_print.c`:
https://github.com/panda-re/panda/pull/1194/files#diff-08cc650562b2d2414fec98c0fcb5669d59b75b54a5d83cb26e449e3c0a04e734R178
