### PR TITLE
OSI_linux performance enhancement

### DIFF
--- a/panda/plugins/dynamic_symbols/dynamic_symbols.cpp
+++ b/panda/plugins/dynamic_symbols/dynamic_symbols.cpp
@@ -486,7 +486,7 @@ enum SymUpdateStatus update_symbols_in_space(CPUState* cpu){
     if (!none_missing){
         return READ_FAIL;
     }
-    return SUCCESS;
+    return SYM_SUCCESS;
 }
 
 void bbt(CPUState *env, target_ulong pc){
@@ -496,7 +496,7 @@ void bbt(CPUState *env, target_ulong pc){
         // identify this one needs more scrutiny
         asid_status[asid] = ASID_STATE_FAIL;
         panda_disable_callback(self_ptr, PANDA_CB_BEFORE_BLOCK_TRANSLATE, pcb_bbt);
-    }else if (ret == SUCCESS){
+    }else if (ret == SYM_SUCCESS){
         // failed
         asid_status[asid] = ASID_STATE_SUCCESS;
         panda_disable_callback(self_ptr, PANDA_CB_BEFORE_BLOCK_TRANSLATE, pcb_bbt);

--- a/panda/plugins/dynamic_symbols/dynamic_symbols_int_fns.h
+++ b/panda/plugins/dynamic_symbols/dynamic_symbols_int_fns.h
@@ -40,7 +40,7 @@ struct symbol get_best_matching_symbol(CPUState* cpu, target_ulong address, targ
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 enum SymUpdateStatus {
-    SUCCESS,        // fully read everything
+    SYM_SUCCESS,        // fully read everything
     PRE_READ_FAIL,  // failed to be in the right state
     READ_FAIL,      // failed to read some symbols
 };

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -859,8 +859,12 @@ bool init_plugin(void *self) {
             h.addr = ki.task.switch_task_hook_addr;
             h.asid = 0;
             h.type = PANDA_CB_START_BLOCK_EXEC;
-            h.cb.start_block_exec = [](CPUState *cpu, TranslationBlock *tb, hook *)
-            { notify_task_change(cpu); };
+            h.cb.start_block_exec = [](CPUState *cpu, TranslationBlock *tb, hook *){    
+                bool** out=0;
+                if (osi_guest_is_ready(cpu, (void**)out)){
+                    notify_task_change(cpu); 
+                }
+            };
             h.km = MODE_ANY;
             h.enabled = true;
             dlsym_add_hook(&h);
@@ -869,8 +873,11 @@ bool init_plugin(void *self) {
 
     panda_require("proc_start_linux");
     // Setup exec task change notifications.
-    PPP_REG_CB("proc_start_linux", on_rec_auxv, [](CPUState *cpu, TranslationBlock *tb, struct auxv_values *vals)
-               { notify_task_change(cpu); });
+    PPP_REG_CB("proc_start_linux", on_rec_auxv, [](CPUState *cpu, TranslationBlock *tb, struct auxv_values *vals){
+                bool** out=0;
+                if (osi_guest_is_ready(cpu, (void**)out)){
+                    notify_task_change(cpu); 
+                } });
 
     return true;
 #else


### PR DESCRIPTION
While profiling PANDA I noticed that the `notify_task_change` code (in particular the `exec_check`) is really slow. That's largely due to the fact that it's relatively short code is multiplied by the frequency with which it is called. https://github.com/panda-re/panda/compare/osi_speed?expand=1#diff-2cbdbd9fde9ca83251f09a5c05263f1edbb07069e56916884ece0fdcf6fc2180L738

There are two sets of analysis for `notify_task_change`:
- a check for a static address for `switch_task_hook_addr`
- an `exec_check` which uses `syscalls2` to find execve and check to see when the program starts

Both of these functions are implemented as services in other plugins.

For the first analysis getting a TCG hook on `switch_task_hook_addr` we replace this logic with a hook.

While `exec_check` itself could be dramatically faster if we simply enabled/disabled these callbacks when not actively looking for a `sys_execve` this logic is still not entirely correct. We know this because we had to work on it for `proc_start_linux`. Which is why for the second analysis we make use of `proc_start_linux`. 

Our last change is small. We change `SUCCESS` to `SYM_SUCCESS` in `dynamic_symbols` so that it doesn't overlap with other enums.