### PR TITLE
OSI: add offset field to OsiModule and set in OSI_Linux

### DIFF
--- a/panda/plugins/osi/osi_types.h
+++ b/panda/plugins/osi/osi_types.h
@@ -52,6 +52,7 @@ typedef struct osi_module_struct {
     target_ptr_t size;
     char *file;
     char *name;
+    target_ulong offset; // XXX only set by osi_linux for now
 } OsiModule;
 
 /**

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -211,12 +211,16 @@ static void fill_osimodule(CPUState *env, OsiModule *m, target_ptr_t vma_addr) {
     m->modd = vma_addr;
     m->base = vma_start;
     m->size = vma_end - vma_start;
+    m->offset = 0;
 
     if (vma_vm_file !=
         (target_ptr_t)NULL) {  // Memory area is mapped from a file.
         vma_dentry = get_vma_dentry(env, vma_addr);
         m->file = read_dentry_name(env, vma_dentry);
         m->name = g_strrstr(m->file, "/");
+        // Get offset in pages, then *= with PAGE_SIZE to translate into bytes
+        get_vma_pgoff(env, vma_addr, &m->offset);
+        m->offset *= 4096; // PAGE_SIZE XXX should specify this size in OSI profiles.
         if (m->name != NULL) m->name = g_strdup(m->name + 1);
     } else {  // Other memory areas.
         mm_addr = get_vma_vm_mm(env, vma_addr);

--- a/panda/plugins/osi_linux/osi_linux.h
+++ b/panda/plugins/osi_linux/osi_linux.h
@@ -309,6 +309,13 @@ IMPLEMENT_OFFSET_GET(get_vma_vm_file, vma_struct, target_ptr_t, ki.vma.vm_file_o
 IMPLEMENT_OFFSET_GET2L(get_vma_dentry, vma_struct, target_ptr_t, ki.vma.vm_file_offset, target_ptr_t, ki.fs.f_path_dentry_offset, 0)
 
 /**
+ * @brief Retrieves the pgoff field from a VMA. This contains the offset in pages from the file start for this mapping.
+ * XXX We're basing this on the file_offset and grabbing a pointer before. Linux 2-6 all keep these fields adjacent.
+ * This is not guaranteed to be the case in the future. https://elixir.bootlin.com/linux/v6.5-rc5/source/include/linux/mm_types.h#L562
+ */
+IMPLEMENT_OFFSET_GETN(get_vma_pgoff, vma_struct, target_ulong, page_offset, OG_AUTOSIZE, ki.vma.vm_file_offset-sizeof(target_ptr_t))
+
+/**
  * @brief Retrieves the vfsmount dentry associated with a vma_struct.
  *
  * XXX: Reading the vfsmount dentry is required to get the full pathname of files not located in the root fs.


### PR DESCRIPTION
Some small hacks in here:
* We get to the vma.pgoff field based of the offset we have in our OSI profile for the vm_file field. These fields have been adjacent from Linux 2+
* We use a hardcoded PAGE_SIZE of 4096 when converting the page-based offset to a byte-based offset. It would be useful to add this to our OSI profiles (#651)


Tested with the following script:
```py
from pandare import Panda

panda = Panda(generic="x86_64")

@panda.queue_blocking
def driver():
    panda.revert_sync("root")
    print(panda.run_serial_cmd("cat /proc/self/maps"))
    panda.end_analysis()

@panda.ppp("syscalls2", "on_sys_write_enter")
def pre_write(cpu, pc, *args):
    if panda.get_process_name(cpu) != 'cat':
        return

    for mapping in panda.get_mappings(cpu):
        if mapping.file != panda.ffi.NULL:
            filename = panda.ffi.string(mapping.file).decode()
            offset = mapping.offset
            print(f"{filename} at {mapping.base:x} offset {offset:#x}")

panda.run()
```