### PR TITLE
Osi mappings api enhancements

### DIFF
--- a/panda/plugins/memorymap/memorymap.cpp
+++ b/panda/plugins/memorymap/memorymap.cpp
@@ -194,20 +194,13 @@ int before_insn_exec_cb(CPUState *cpu, target_ulong pc) {
         }
 
         // dump info on the dynamic library for the current PC, if there is one
-        GArray *ms = get_mappings(cpu, current);
-        if (ms != NULL) {
-            for (int i = 0; i < ms->len; i++) {
-                OsiModule *m = &g_array_index(ms, OsiModule, i);
-                if ((pc >= m->base) && (pc < (m->base + m->size))) {
-                    dump_process_info("false", pc, cur_instr, pname,
-                            current->pid, tid, m->name, m->file, m->base);
-                    found_lib = true;
-                    break;
-                }
-            }
-
+        OsiModule *m = get_mapping_by_addr(cpu, current, pc);
+        if(m) {
+            dump_process_info("false", pc, cur_instr, pname,
+                    current->pid, tid, m->name, m->file, m->base);
+            found_lib = true;
             // cleanup
-            g_array_free(ms, true);
+            free_osimodule(m);
         }
     }
 

--- a/panda/plugins/osi/README.md
+++ b/panda/plugins/osi/README.md
@@ -231,6 +231,100 @@ Implementation behaviour: The implementation should populate a [`GArray`][garray
 
 ---
 
+Name: **on\_get\_file\_mappings**
+
+Signature:
+
+```C
+typedef void (*on_get_file_mappings_t)(CPUState *, OsiProc *, GArray**)
+```
+
+Description: Similar to on\_get\_mappings, but returns only mappings that are backed by a file.  In wintrospection this returns the same results as on\_get\_mappings.  In osi\_linux, this returns a subset of the mappings that on\_get\_mappings returns.
+
+Implementation behaviour: The implementation should populate a [`GArray`][garray] filled with `OsiModule` elements, following the rules described in the *data containers* section above. Results need to be freed using [`g_array_free`][gafree].
+
+---
+
+Name: **on\_get\_heap\_mappings**
+
+Signature:
+
+```C
+typedef void (*on_get_heap_mappings_t)(CPUState *, OsiProc *, GArray**)
+```
+
+Description: Similar to on\_get\_mappings, but returns only mappings that are heap segments.  Implemented only in osi\_linux.
+
+Implementation behaviour: The implementation should populate a [`GArray`][garray] filled with `OsiModule` elements, following the rules described in the *data containers* section above. Results need to be freed using [`g_array_free`][gafree].
+
+---
+
+Name: **on\_get\_stack\_mappings**
+
+Signature:
+
+```C
+typedef void (*on_get_stack_mappings_t)(CPUState *, OsiProc *, GArray**)
+```
+
+Description: Similar to on\_get\_mappings, but returns only mappings that are stack segments.  Implemented only in osi\_linux.
+
+Implementation behaviour: The implementation should populate a [`GArray`][garray] filled with `OsiModule` elements, following the rules described in the *data containers* section above. Results need to be freed using [`g_array_free`][gafree].
+
+---
+
+Name: **on\_get\_unknown\_mappings**
+
+Signature:
+
+```C
+typedef void (*on_get_unknown_mappings_t)(CPUState *, OsiProc *, GArray**)
+```
+
+Description: Similar to on\_get\_mappings, but returns only mappings of an unknown origin.  These can be additional heap segements for processes that have exhausted the primary heap segment.  They can also be memory allocated via mmap() by a process.  Implemented only in osi\_linux.
+
+Implementation behaviour: The implementation should populate a [`GArray`][garray] filled with `OsiModule` elements, following the rules described in the *data containers* section above. Results need to be freed using [`g_array_free`][gafree].
+
+---
+
+Name: **on\_get\_mapping\_by\_addr**
+
+Signature:
+
+```C
+typedef void (*on_get_mapping_by_addr_t)(CPUState *, OsiProc *, target_ptr_t, OsiModule**)
+```
+
+Description: Returns the mapping that contains a specific virtual memory address.
+
+The implementation should allocate memory and fill in the pointer to an `OsiModule` struct. The returned `OsiModule` must be freed with `free_osimodule`.
+
+---
+
+Name: **on\_get\_mapping\_base\_address\_by\_name**
+
+Signature:
+
+```C
+typedef void (*on_get_mapping_base_address_by_name_t)(CPUState *, OsiProc *, char *, target_ptr_t *)
+```
+
+Description: Returns the base address of the mapping with the specified name.
+
+---
+
+Name: **has\_mapping\_prefix**
+
+Signature:
+
+```C
+typedef void (*on_has_mapping_prefix_t)(CPUState *, OsiProc *, char *, bool *)
+```
+
+Description: Returns true if a mapping exists whose name begins with the specified prefix.
+
+---
+
 To implement OS-specific introspection support, an OSI provider should call the following OSI APIs:
 
 ---

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -42,6 +42,13 @@ PPP_PROT_REG_CB(on_get_current_process_handle)
 PPP_PROT_REG_CB(on_get_process)
 PPP_PROT_REG_CB(on_get_modules)
 PPP_PROT_REG_CB(on_get_mappings)
+PPP_PROT_REG_CB(on_get_file_mappings)
+PPP_PROT_REG_CB(on_get_heap_mappings)
+PPP_PROT_REG_CB(on_get_stack_mappings)
+PPP_PROT_REG_CB(on_get_unknown_mappings)
+PPP_PROT_REG_CB(on_get_mapping_by_addr)
+PPP_PROT_REG_CB(on_get_mapping_base_address_by_name)
+PPP_PROT_REG_CB(on_has_mapping_prefix)
 PPP_PROT_REG_CB(on_get_current_thread)
 PPP_PROT_REG_CB(on_get_process_pid)
 PPP_PROT_REG_CB(on_get_process_ppid)
@@ -55,6 +62,13 @@ PPP_CB_BOILERPLATE(on_get_current_process_handle)
 PPP_CB_BOILERPLATE(on_get_process)
 PPP_CB_BOILERPLATE(on_get_modules)
 PPP_CB_BOILERPLATE(on_get_mappings)
+PPP_CB_BOILERPLATE(on_get_file_mappings)
+PPP_CB_BOILERPLATE(on_get_heap_mappings)
+PPP_CB_BOILERPLATE(on_get_stack_mappings)
+PPP_CB_BOILERPLATE(on_get_unknown_mappings)
+PPP_CB_BOILERPLATE(on_get_mapping_by_addr)
+PPP_CB_BOILERPLATE(on_get_mapping_base_address_by_name)
+PPP_CB_BOILERPLATE(on_has_mapping_prefix)
 PPP_CB_BOILERPLATE(on_get_current_thread)
 PPP_CB_BOILERPLATE(on_get_process_pid)
 PPP_CB_BOILERPLATE(on_get_process_ppid)
@@ -105,6 +119,50 @@ GArray *get_mappings(CPUState *cpu, OsiProc *p) {
     GArray *m = NULL;
     PPP_RUN_CB(on_get_mappings, cpu, p, &m);
     return m;
+}
+
+GArray *get_file_mappings(CPUState *cpu, OsiProc *p) {
+    GArray *m = NULL;
+    PPP_RUN_CB(on_get_file_mappings, cpu, p, &m);
+    return m;
+}
+
+GArray *get_heap_mappings(CPUState *cpu, OsiProc *p) {
+    GArray *m = NULL;
+    PPP_RUN_CB(on_get_heap_mappings, cpu, p, &m);
+    return m;
+}
+
+GArray *get_stack_mappings(CPUState *cpu, OsiProc *p) {
+    GArray *m = NULL;
+    PPP_RUN_CB(on_get_stack_mappings, cpu, p, &m);
+    return m;
+}
+
+GArray *get_unknown_mappings(CPUState *cpu, OsiProc *p) {
+    GArray *m = NULL;
+    PPP_RUN_CB(on_get_unknown_mappings, cpu, p, &m);
+    return m;
+}
+
+OsiModule *get_mapping_by_addr(CPUState *cpu, OsiProc *p,
+        const target_ptr_t addr) {
+    OsiModule *osiModule = NULL;
+    PPP_RUN_CB(on_get_mapping_by_addr, cpu, p, addr, &osiModule);
+    return osiModule;
+}
+
+target_ptr_t get_mapping_base_address_by_name(CPUState *cpu, OsiProc *p,
+        const char *name) {
+    target_ptr_t baseAddress = 0;
+    PPP_RUN_CB(on_get_mapping_base_address_by_name, cpu, p, name, &baseAddress);
+    return baseAddress;
+}
+
+bool has_mapping_prefix(CPUState *cpu, OsiProc *p, const char *prefix) {
+    bool found = false;
+    PPP_RUN_CB(on_has_mapping_prefix, cpu, p, prefix, &found);
+    return found;
 }
 
 OsiThread *get_current_thread(CPUState *cpu) {

--- a/panda/plugins/osi/os_intro.h
+++ b/panda/plugins/osi/os_intro.h
@@ -13,6 +13,13 @@ PPP_CB_TYPEDEF(void,on_get_current_process_handle,CPUState *, OsiProcHandle **);
 PPP_CB_TYPEDEF(void,on_get_process,CPUState *, const OsiProcHandle *, OsiProc **);
 PPP_CB_TYPEDEF(void,on_get_modules,CPUState *, GArray **);
 PPP_CB_TYPEDEF(void,on_get_mappings,CPUState *, OsiProc *, GArray**);
+PPP_CB_TYPEDEF(void,on_get_file_mappings,CPUState *, OsiProc *, GArray**);
+PPP_CB_TYPEDEF(void,on_get_heap_mappings,CPUState *, OsiProc *, GArray**);
+PPP_CB_TYPEDEF(void,on_get_stack_mappings,CPUState *, OsiProc *, GArray**);
+PPP_CB_TYPEDEF(void,on_get_unknown_mappings,CPUState *, OsiProc *, GArray**);
+PPP_CB_TYPEDEF(void,on_get_mapping_by_addr,CPUState *, OsiProc *, const target_ptr_t, OsiModule **);
+PPP_CB_TYPEDEF(void,on_get_mapping_base_address_by_name,CPUState *, OsiProc *, const char *, target_ptr_t *);
+PPP_CB_TYPEDEF(void,on_has_mapping_prefix,CPUState *, OsiProc *, const char *, bool *);
 PPP_CB_TYPEDEF(void,on_get_current_thread,CPUState *, OsiThread **);
 
 PPP_CB_TYPEDEF(void,on_get_process_pid,CPUState *, const OsiProcHandle *, target_pid_t *);

--- a/panda/plugins/osi/osi_int.h
+++ b/panda/plugins/osi/osi_int.h
@@ -23,6 +23,7 @@ typedef void OsiProc;
 typedef void OsiModule;
 typedef void GArray;
 typedef void target_pid_t;
+typedef void target_ptr_t;
 
 #include "osi_int_fns.h"
 

--- a/panda/plugins/osi/osi_int_fns.h
+++ b/panda/plugins/osi/osi_int_fns.h
@@ -19,6 +19,33 @@ GArray *get_modules(CPUState *cpu);
 // returns information about the memory mappings of libraries loaded by a guest OS process
 GArray *get_mappings(CPUState *cpu, OsiProc *p);
 
+// like get_mappings, but only return segments backed by files
+// for wintrospection, this is the same as get_mappings
+GArray *get_file_mappings(CPUState *cpu, OsiProc *p);
+
+// like get_mappings, but only return heap segments
+// supported in osi_linux only
+GArray *get_heap_mappings(CPUState *cpu, OsiProc *p);
+
+// like get_mappings, but only return stack segments
+// supported in osi_linux only
+GArray *get_stack_mappings(CPUState *cpu, OsiProc *p);
+
+// like get_mappings, but only return "unknown" segments
+// these can be additional heap areas, but could also be memory segments
+// created by the running process that aren't backed by a file
+// supported in osi_linux only
+GArray *get_unknown_mappings(CPUState *cpu, OsiProc *p);
+
+// get mapping that corresponds to virtual memory address addr
+OsiModule *get_mapping_by_addr(CPUState *cpu, OsiProc *p, const target_ptr_t addr);
+
+// get the base address for the mapping with the specified name
+target_ptr_t get_mapping_base_address_by_name(CPUState *cpu, OsiProc *p, const char *name);
+
+// returns true if a mapping exists whose name begins with prefix
+bool has_mapping_prefix(CPUState *cpu, OsiProc *p, const char *prefix);
+
 // returns operating system introspection info for each process in an array
 GArray *get_processes(CPUState *cpu);
 


### PR DESCRIPTION
Add API calls to allow for optimized retrieval of specific memory mapping
data without requiring the caller to use the expensive get_mappings API call.

Added:
   on_get_file_mappings
   on_get_heap_mappings
   on_get_stack_mappings
   on_get_unknown_mappings
   on_get_mapping_by_addr
   on_get_mapping_base_address_by_name
   on_has_mapping_prefix

Updated fill_osimodule to only populate OsiModules that match specific
module types.

Adding logic to minimize the number of calls to expensive function
read_dentry_name.  Avoids recomputing dentry_name if the answer is already
known from the previous loop iteration.

Updated memorymap plugin to make use of the new api.

This PR depends on https://github.com/panda-re/libosi/pull/9 - CI will fail until the changes in libosi are accepted.