### PR TITLE
Hotfix for MIPS32 syscalls2

### DIFF
--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -784,7 +784,9 @@ uint64_t get_64_linux_mips(CPUState *cpu, uint32_t argnum) {
         // Mask off the upper 32 bits
         result &= 0xFFFFFFFF;
     }else if (syscall_abi == ABI_MIPS_O32) {
-        assert(0);
+        //assert(0); // XXX this happens: see panda issues 1337, 1338
+        printf("WARNING: no support for reading 64-bit arguments on 32-bit guest\n");
+        return 0;
     }
     return result;
 #else


### PR DESCRIPTION
Temporary solution to #1337 to just ignore mips32 syscalls that pass 64-bit arguments.

This doesn't resolve the underlying issue of #1338 but makes syscalls2 usable for mips32 where results will be as right as they previously were (i.e., wrong for 64-bit args).