### PR TITLE
Make syscalls2 prototype generation reproducible

### DIFF
--- a/panda/plugins/syscalls2/generated/syscalls_ext_typedefs_x64.h
+++ b/panda/plugins/syscalls2/generated/syscalls_ext_typedefs_x64.h
@@ -1654,8 +1654,8 @@ PPP_CB_TYPEDEF(void, on_sys_execve_enter, CPUState* cpu, target_ulong pc, uint64
 PPP_CB_TYPEDEF(void, on_sys_execve_return, CPUState* cpu, target_ulong pc, uint64_t filename, uint64_t argv, uint64_t envp);
 PPP_CB_TYPEDEF(void, on_sys_execveat_enter, CPUState* cpu, target_ulong pc, int32_t dfd, uint64_t filename, uint64_t argv, uint64_t envp, int32_t flags);
 PPP_CB_TYPEDEF(void, on_sys_execveat_return, CPUState* cpu, target_ulong pc, int32_t dfd, uint64_t filename, uint64_t argv, uint64_t envp, int32_t flags);
-PPP_CB_TYPEDEF(void, on_sys_exit_enter, CPUState* cpu, target_ulong pc, int32_t rval);
-PPP_CB_TYPEDEF(void, on_sys_exit_return, CPUState* cpu, target_ulong pc, int32_t rval);
+PPP_CB_TYPEDEF(void, on_sys_exit_enter, CPUState* cpu, target_ulong pc, int32_t error_code);
+PPP_CB_TYPEDEF(void, on_sys_exit_return, CPUState* cpu, target_ulong pc, int32_t error_code);
 PPP_CB_TYPEDEF(void, on_sys_exit_group_enter, CPUState* cpu, target_ulong pc, int32_t error_code);
 PPP_CB_TYPEDEF(void, on_sys_exit_group_return, CPUState* cpu, target_ulong pc, int32_t error_code);
 PPP_CB_TYPEDEF(void, on_sys_faccessat_enter, CPUState* cpu, target_ulong pc, int32_t dfd, uint64_t filename, int32_t mode);

--- a/panda/plugins/syscalls2/scripts/syscall_parser.py
+++ b/panda/plugins/syscalls2/scripts/syscall_parser.py
@@ -453,6 +453,8 @@ if __name__ == '__main__':
             context_target_extra = json.load(args.context_target_file)
     else:
         context_target_extra = {}
+    
+    arch_scs = {arch: {} for arch in KNOWN_ARCH}
 
     # parse system call definitions for all targets
     for _target in args.target:
@@ -550,12 +552,21 @@ if __name__ == '__main__':
                 logging.info("Writing %s", of.name)
                 of.write(j2tpl.render(target_context))
 
+        arch_scs[_arch][_os] = syscalls_to_write
+    
+    for _arch in arch_scs:
+        oss = sorted(arch_scs[_arch].keys())
+        outvals = {}
+        for _os in oss:
+            for ov in arch_scs[_arch][_os]:
+                outvals[ov] = arch_scs[_arch][_os][ov]
+        
         # Make syscalls_ext_typedefs_[arch] files
         j2tpl = j2env.get_template('syscalls_ext_typedefs_arch.tpl')
         of_name = '%s%s' % (args.prefix, 'syscalls_ext_typedefs_' + _arch + '.h')
         with open(os.path.join(args.outdir, of_name), 'w+') as of:
             logging.info("Writing %s", of.name)
-            of.write(j2tpl.render(syscalls=syscalls_to_write))
+            of.write(j2tpl.render(syscalls=outvals))
 
     # Render big files.
     for tpl, ext in GENERATED_FILES:


### PR DESCRIPTION
This PR updates the syscall_parser to combine results from multiple OSes correcting an issue introduced in #1321 where x86 and x86_64 prototypes were not reproducible because of a conflict between Windows and Linux prototypes.

There is one small change in the x64.h file which seems to be an argument rename.