### PR TITLE
Handle 64-bit syscall arguments on 32 bit architectures

### DIFF
--- a/panda/plugins/syscalls2/generated-tpl/syscall_switch_enter.tpl
+++ b/panda/plugins/syscalls2/generated-tpl/syscall_switch_enter.tpl
@@ -53,9 +53,7 @@ void syscall_enter_switch_{{os}}_{{arch}}(CPUState *cpu, target_ptr_t pc, int st
 		panda_noreturn = {{ 'true' if syscall.panda_noreturn else 'false' }};
 		ctx.double_return = {{ 'true' if syscall.panda_double_return else 'false' }};
 		{%- if syscall.args|length > 0 %}
-		{%- for arg in syscall.args %}
-		{{arg.emit_temp_assignment()}}
-		{%- endfor %}
+		{{syscall.temp_assignments()}}
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_{{syscall.name}}_return)))) {

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_arm.cpp
@@ -2034,7 +2034,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 5) << 32 | (uint64_t)get_32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_pread64_return)))) {
@@ -2052,7 +2052,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 5) << 32 | (uint64_t)get_32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_pwrite64_return)))) {
@@ -2200,7 +2200,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_truncate64_return)))) {
@@ -2214,7 +2214,7 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_ftruncate64_return)))) {
@@ -2594,8 +2594,8 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
-		uint32_t arg2 = get_32(cpu, 2);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		uint32_t arg2 = get_32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_readahead_return)))) {
@@ -2989,9 +2989,9 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 	case 249: {
 		panda_noreturn = false;
 		ctx.double_return = false;
-		uint64_t arg0 = get_64(cpu, 0);
-		uint32_t arg1 = get_32(cpu, 1);
-		uint32_t arg2 = get_32(cpu, 2);
+		uint64_t arg0 = (uint64_t)get_32(cpu, 1) << 32 | (uint64_t)get_32(cpu, 0);
+		uint32_t arg1 = get_32(cpu, 2);
+		uint32_t arg2 = get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_lookup_dcookie_return)))) {
@@ -3281,8 +3281,8 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 5) << 32 | (uint64_t)get_32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_arm_fadvise64_64_return)))) {
@@ -4479,8 +4479,8 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 5) << 32 | (uint64_t)get_32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_sync_file_range2_return)))) {
@@ -4671,8 +4671,8 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 5) << 32 | (uint64_t)get_32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fallocate_return)))) {
@@ -4937,9 +4937,9 @@ void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_c
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		int32_t arg3 = get_s32(cpu, 3);
-		uint32_t arg4 = get_32(cpu, 4);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		int32_t arg3 = get_s32(cpu, 4);
+		uint32_t arg4 = get_32(cpu, 5);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fanotify_mark_return)))) {

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_mips.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_mips.cpp
@@ -2622,7 +2622,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 4) << 32 | (uint64_t)get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_pread64_return)))) {
@@ -2640,7 +2640,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 4) << 32 | (uint64_t)get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_pwrite64_return)))) {
@@ -2768,7 +2768,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		panda_noreturn = false;
 		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_truncate64_return)))) {
@@ -2782,7 +2782,7 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		panda_noreturn = false;
 		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_ftruncate64_return)))) {
@@ -2922,8 +2922,8 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		panda_noreturn = false;
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
-		uint32_t arg2 = get_32(cpu, 2);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
+		uint32_t arg2 = get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_readahead_return)))) {
@@ -3317,9 +3317,9 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 	case 4247: {
 		panda_noreturn = false;
 		ctx.double_return = false;
-		uint64_t arg0 = get_64(cpu, 0);
-		uint32_t arg1 = get_32(cpu, 1);
-		uint32_t arg2 = get_32(cpu, 2);
+		uint64_t arg0 = (uint64_t)get_32(cpu, 1) << 32 | (uint64_t)get_32(cpu, 0);
+		uint32_t arg1 = get_32(cpu, 2);
+		uint32_t arg2 = get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_lookup_dcookie_return)))) {
@@ -3420,9 +3420,9 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		panda_noreturn = false;
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		int32_t arg3 = get_s32(cpu, 3);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 4) << 32 | (uint64_t)get_32(cpu, 3);
+		int32_t arg3 = get_s32(cpu, 5);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fadvise64_64_return)))) {
@@ -4236,9 +4236,9 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		panda_noreturn = false;
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		uint32_t arg3 = get_32(cpu, 3);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 4) << 32 | (uint64_t)get_32(cpu, 3);
+		uint32_t arg3 = get_32(cpu, 5);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_sync_file_range_return)))) {
@@ -4481,8 +4481,8 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 5) << 32 | (uint64_t)get_32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fallocate_return)))) {
@@ -4761,9 +4761,9 @@ void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		int32_t arg3 = get_s32(cpu, 3);
-		uint32_t arg4 = get_32(cpu, 4);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		int32_t arg3 = get_s32(cpu, 4);
+		uint32_t arg4 = get_32(cpu, 5);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fanotify_mark_return)))) {

--- a/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x86.cpp
+++ b/panda/plugins/syscalls2/generated/syscall_switch_enter_linux_x86.cpp
@@ -2272,7 +2272,7 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 4) << 32 | (uint64_t)get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_pread64_return)))) {
@@ -2290,7 +2290,7 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		uint32_t arg0 = get_32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
 		uint32_t arg2 = get_32(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 4) << 32 | (uint64_t)get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_pwrite64_return)))) {
@@ -2438,7 +2438,7 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_truncate64_return)))) {
@@ -2452,7 +2452,7 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		uint32_t arg0 = get_32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_ftruncate64_return)))) {
@@ -2832,8 +2832,8 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
-		uint32_t arg2 = get_32(cpu, 2);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
+		uint32_t arg2 = get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_readahead_return)))) {
@@ -3240,9 +3240,9 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
-		uint32_t arg2 = get_32(cpu, 2);
-		int32_t arg3 = get_s32(cpu, 3);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
+		uint32_t arg2 = get_32(cpu, 3);
+		int32_t arg3 = get_s32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fadvise64_return)))) {
@@ -3269,9 +3269,9 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 	case 253: {
 		panda_noreturn = false;
 		ctx.double_return = false;
-		uint64_t arg0 = get_64(cpu, 0);
-		uint32_t arg1 = get_32(cpu, 1);
-		uint32_t arg2 = get_32(cpu, 2);
+		uint64_t arg0 = (uint64_t)get_32(cpu, 1) << 32 | (uint64_t)get_32(cpu, 0);
+		uint32_t arg1 = get_32(cpu, 2);
+		uint32_t arg2 = get_32(cpu, 3);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_lookup_dcookie_return)))) {
@@ -3560,9 +3560,9 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		int32_t arg3 = get_s32(cpu, 3);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 4) << 32 | (uint64_t)get_32(cpu, 3);
+		int32_t arg3 = get_s32(cpu, 5);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fadvise64_64_return)))) {
@@ -4248,9 +4248,9 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		panda_noreturn = false;
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
-		uint64_t arg1 = get_64(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		uint32_t arg3 = get_32(cpu, 3);
+		uint64_t arg1 = (uint64_t)get_32(cpu, 2) << 32 | (uint64_t)get_32(cpu, 1);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 4) << 32 | (uint64_t)get_32(cpu, 3);
+		uint32_t arg3 = get_32(cpu, 5);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_sync_file_range_return)))) {
@@ -4423,8 +4423,8 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		int32_t arg1 = get_s32(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		uint64_t arg3 = get_64(cpu, 3);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		uint64_t arg3 = (uint64_t)get_32(cpu, 5) << 32 | (uint64_t)get_32(cpu, 4);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fallocate_return)))) {
@@ -4671,9 +4671,9 @@ void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_c
 		ctx.double_return = false;
 		int32_t arg0 = get_s32(cpu, 0);
 		uint32_t arg1 = get_32(cpu, 1);
-		uint64_t arg2 = get_64(cpu, 2);
-		int32_t arg3 = get_s32(cpu, 3);
-		uint32_t arg4 = get_32(cpu, 4);
+		uint64_t arg2 = (uint64_t)get_32(cpu, 3) << 32 | (uint64_t)get_32(cpu, 2);
+		int32_t arg3 = get_s32(cpu, 4);
+		uint32_t arg4 = get_32(cpu, 5);
 		if (PPP_CHECK_CB(on_all_sys_enter2) ||
 			(!panda_noreturn && (PPP_CHECK_CB(on_all_sys_return2) ||
 					PPP_CHECK_CB(on_sys_fanotify_mark_return)))) {

--- a/panda/plugins/syscalls2/scripts/syscall_parser.py
+++ b/panda/plugins/syscalls2/scripts/syscall_parser.py
@@ -8,6 +8,7 @@
 # *  Michael Zhivich          mzhivich@ll.mit.edu
 # *  Brendan Dolan-Gavitt     brendandg@gatech.edu
 # *  Manolis Stamatogiannakis manolis.stamatogiannakis@vu.nl
+# *  Luke Craig               luke.craig@ll.mit.edu
 # *
 # * This work is licensed under the terms of the GNU GPL, version 2.
 # * See the COPYING file in the top-level directory.
@@ -20,8 +21,8 @@
 
 import jinja2
 import json
-import sys
 import os
+import contextlib
 import re
 import logging
 import argparse
@@ -270,7 +271,7 @@ class Argument(object):
             return 'int64_t'
         elif self.type == 'U16':
             return 'uint16_t'
-        assert False, 'Unknown type for argument %s: %s' % (self.name, self.type)
+        assert False, f'Unknown type for argument {self.name}: {self.type}'
 
     def emit_local_declaration(self, ctxp, prefix, unused=True):
         ''' Returns a snippet declaring a local variable for this
@@ -302,16 +303,17 @@ class Argument(object):
         '''
         return '{0} arg{1} = 0;'.format(self.ctype, self.no)
 
-    def emit_temp_assignment(self):
-        ''' Returns a snippet declaring an appropriate temp
-            variable for this argument and assigning its
-            runtime value to it.
-        '''
-        ctype = self.ctype
-        ctype_bits = int(''.join(filter(str.isdigit, ctype)))
-        assert ctype_bits in [32, 64], 'Invalid number of bits for type %s' % ctype
-        ctype_get = 'get_%d' % ctype_bits if ctype.startswith('uint') else 'get_s%d' % ctype_bits
-        return '{0} arg{1} = {2}(cpu, {1});'.format(ctype, self.no, ctype_get)
+    # no longer in use. see syscall.temp_assignments()
+    # def emit_temp_assignment(self):
+    #     ''' Returns a snippet declaring an appropriate temp
+    #         variable for this argument and assigning its
+    #         runtime value to it.
+    #     '''
+    #     ctype = self.ctype
+    #     ctype_bits = int(''.join(filter(str.isdigit, ctype)))
+    #     assert ctype_bits in [32, 64], 'Invalid number of bits for type %s' % ctype
+    #     ctype_get = 'get_%d' % ctype_bits if ctype.startswith('uint') else 'get_s%d' % ctype_bits
+    #     return '{0} arg{1} = {2}(cpu, {1});'.format(ctype, self.no, ctype_get)
 
     def emit_memcpy_temp_to_ref(self):
         ''' Returns a snippet that copies this argument from its
@@ -360,17 +362,18 @@ class SysCall(object):
 
         # set properties inferred from prototype
         self.nos = [int(fields.group(1))] # "nos' is a list of syscall numbers, often 1 element
-        self.generic = False if max(self.nos) > max_generic_syscall else True
+        self.generic = max(self.nos) <= max_generic_syscall
         self.rettype = fields.group(2)
         self.name = fields.group(3)
         self.args_raw = [[arg.strip() for arg in fields.group(4).split(',')]]
+        self.target_context = target_context
 
         # set properties inferred from target context
         self.arch_bits = target_context['arch_conf']['bits']
         panda_noreturn_names = target_context.get('panda_noreturn', {})
-        self.panda_noreturn = True if self.name in panda_noreturn_names else False
+        self.panda_noreturn = self.name in panda_noreturn_names
         panda_doublereturn_names = target_context.get('panda_doublereturn', {})
-        self.panda_double_return = True if self.name in panda_doublereturn_names else False
+        self.panda_double_return = self.name in panda_doublereturn_names
 
         # process raw args at construction
         self.args = []
@@ -396,7 +399,35 @@ class SysCall(object):
         ''' Returns the system call arguments.
             declaration info (type and name) for each arg passed to C++ and C callbacks
         '''
-        return ', '.join(['CPUState* cpu', 'target_ulong pc'] + ['%s %s' % (x.ctype, x.name) for x in self.args])
+        return ', '.join(
+            ['CPUState* cpu', 'target_ulong pc']
+            + [f'{x.ctype} {x.name}' for x in self.args]
+        )
+    
+    def temp_assignments(self):
+        values = []
+        argnum, argpos = 0, 0
+        while argnum < len(self.args):
+            ctype = self.args[argnum].ctype
+            ctype_bits = int(''.join(filter(str.isdigit, ctype)))
+            assert ctype_bits in {32, 64}, f'Invalid number of bits for type {ctype}'
+            ctype_get = 'get_%d' % ctype_bits if ctype.startswith('uint') else 'get_s%d' % ctype_bits
+            if self.arch_bits == 32 and ctype in ['uint64_t', 'int64_t']:
+                if self.target_context['arch'] == 'arm' and argpos % 2 != 0:
+                    # in this case, a zero is placed in this register in 
+                    # in order to make 64-bit arguments aligned on even 
+                    # registers
+                    argpos += 1
+                values.append(
+                        f'{ctype} arg{argnum} = ({ctype})get_32(cpu, {argpos+1}) << 32 | ({ctype})get_32(cpu, {argpos});'
+                )
+                argpos += 2
+            else:
+                values.append(f'{ctype} arg{argnum} = {ctype_get}(cpu, {argpos});')
+                argpos += 1
+            argnum += 1
+
+        return '\n\t\t'.join(values)
 
 
 ##############################################################################
@@ -415,10 +446,16 @@ if __name__ == '__main__':
     logging.debug(args)
 
     # Sanity checks.
-    assert os.path.isdir(args.outdir), 'Output directory %s does not exist.' % args.outdir
-    assert os.path.isdir(args.prototypes), 'Output directory %s does not exist.' % args.prototypes
-    assert os.path.isdir(args.templates), 'Template directory %s does not exist.' % args.templates
-    
+    assert os.path.isdir(
+        args.outdir
+    ), f'Output directory {args.outdir} does not exist.'
+    assert os.path.isdir(
+        args.prototypes
+    ), f'Output directory {args.prototypes} does not exist.'
+    assert os.path.isdir(
+        args.templates
+    ), f'Template directory {args.templates} does not exist.'
+
     # Fields: <no> <return-type> <name><signature with spaces>
     prototype_linere = re.compile("(\d+) (.+) (\w+) ?\((.*)\);")
 
@@ -456,14 +493,26 @@ if __name__ == '__main__':
     
     arch_scs = {arch: {} for arch in KNOWN_ARCH}
 
+    # delete old typedefs when we run this
+    for _target in args.target:
+        _os, _arch = _target.split(':')
+        assert (_os in KNOWN_OS and _arch in KNOWN_ARCH), 'Unknown os or arch. Please read help message.'
+
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(f'{args.prefix}syscalls_ext_typedefs_*.h')
+
+    
+
     # parse system call definitions for all targets
     for _target in args.target:
         _os, _arch = _target.split(':')
         assert (_os in KNOWN_OS and _arch in KNOWN_ARCH), 'Unknown os or arch. Please read help message.'
         logging.info('Processing system calls for %s', _target)
 
-        protofile_name = os.path.join(args.prototypes, '%s_%s_prototypes.txt' % (_os, _arch))
-        assert os.path.isfile(protofile_name), 'Missing prototype file %s' % protofile_name
+        protofile_name = os.path.join(args.prototypes, f'{_os}_{_arch}_prototypes.txt')
+        assert os.path.isfile(
+            protofile_name
+        ), f'Missing prototype file {protofile_name}'
 
         syscalls = global_context['syscalls'][_target]
         syscalls_arch = global_context['syscalls_arch'][_arch]
@@ -475,8 +524,10 @@ if __name__ == '__main__':
         }
         if _target in context_target_extra:
             d = context_target_extra[_target]
-            assert all([k not in target_context for k in list(d.keys())]), 'target context for %s overwrites values' % (_target)
-            target_context.update(d)
+            assert all(
+                k not in target_context for k in list(d.keys())
+            ), f'target context for {_target} overwrites values'
+            target_context |= d
 
         # Parse prototype file contents. Extra context is passed to set
         # properties that are not defined by the prototype definition.
@@ -499,7 +550,7 @@ if __name__ == '__main__':
                 if fields is None:
                     logging.debug('Bad prototype line in %s:%d: %s', protofile.name, lineno, line.rstrip())
                     continue
-                sc_name = fields.group(3)
+                sc_name = fields[3]
 
                 new_syscall = SysCall(fields, target_context)
                 new_args = str(new_syscall.args)
@@ -523,9 +574,11 @@ if __name__ == '__main__':
         logging.info('Loaded %d system calls from %s.', len(syscalls), protofile_name)
 
         # Calculate the maximum number of arguments and system call number for this os/arch.
-        target_context['max_syscall_args'] = max([len(s.args) for s in syscalls])
-        target_context['max_syscall_no'] = max([max(s.nos) for s in syscalls])
-        target_context['max_syscall_generic_no'] = max([max(s.nos) for s in syscalls if s.generic])
+        target_context['max_syscall_args'] = max(len(s.args) for s in syscalls)
+        target_context['max_syscall_no'] = max(max(s.nos) for s in syscalls)
+        target_context['max_syscall_generic_no'] = max(
+            max(s.nos) for s in syscalls if s.generic
+        )
 
         # Update the global maximum number of arguments and system call number.
         global_context['global_max_syscall_args'] = max(
@@ -537,18 +590,18 @@ if __name__ == '__main__':
 
         # Render per-target output files.
         j2tpl = j2env.get_template('syscall_switch_enter.tpl')
-        with open(os.path.join(args.outdir, "%ssyscall_switch_enter_%s_%s.cpp" % (args.prefix, _os, _arch)), "w+") as of:
+        with open(os.path.join(args.outdir, f"{args.prefix}syscall_switch_enter_{_os}_{_arch}.cpp"), "w+") as of:
             logging.info("Writing %s", of.name)
             of.write(j2tpl.render(target_context))
         j2tpl = j2env.get_template('syscall_switch_return.tpl')
-        with open(os.path.join(args.outdir, "%ssyscall_switch_return_%s_%s.cpp" % (args.prefix, _os, _arch)), "w+") as of:
+        with open(os.path.join(args.outdir, f"{args.prefix}syscall_switch_return_{_os}_{_arch}.cpp"), "w+") as of:
             logging.info("Writing %s", of.name)
             of.write(j2tpl.render(target_context))
 
         # Generate syscall info dynamic libraries.
         if args.generate_info:
             j2tpl = j2env.get_template('syscalls_info.tpl')
-            with open(os.path.join(args.outdir, "%sdso_info_%s_%s.c" % (args.prefix, _os, _arch)), "w+") as of:
+            with open(os.path.join(args.outdir, f"{args.prefix}dso_info_{_os}_{_arch}.c"), "w+") as of:
                 logging.info("Writing %s", of.name)
                 of.write(j2tpl.render(target_context))
 
@@ -563,15 +616,15 @@ if __name__ == '__main__':
         
         # Make syscalls_ext_typedefs_[arch] files
         j2tpl = j2env.get_template('syscalls_ext_typedefs_arch.tpl')
-        of_name = '%s%s' % (args.prefix, 'syscalls_ext_typedefs_' + _arch + '.h')
-        with open(os.path.join(args.outdir, of_name), 'w+') as of:
+        of_name = f'{args.prefix}syscalls_ext_typedefs_{_arch}.h'
+        with open(os.path.join(args.outdir, of_name), 'w') as of:
             logging.info("Writing %s", of.name)
             of.write(j2tpl.render(syscalls=outvals))
 
     # Render big files.
     for tpl, ext in GENERATED_FILES:
         j2tpl = j2env.get_template(tpl)
-        of_name = '%s%s%s' % (args.prefix, os.path.splitext(os.path.basename(tpl))[0], ext)
+        of_name = f'{args.prefix}{os.path.splitext(os.path.basename(tpl))[0]}{ext}'
         with open(os.path.join(args.outdir, of_name), 'w+') as of:
             logging.info("Writing %s", of.name)
             of.write(j2tpl.render(global_context))


### PR DESCRIPTION
This PR resolves the problems with 64-bit syscall arguments as described in #1338. 

It does so by forcing syscalls to follow the standard set out by their ABI and combining 32-bit results into 64-bit values when appropriate.

This PR must be merged after #1341 