### PR TITLE
osi_linux: get flags from vm_area_struct

### DIFF
--- a/panda/plugins/osi/osi_types.h
+++ b/panda/plugins/osi/osi_types.h
@@ -53,6 +53,7 @@ typedef struct osi_module_struct {
     char *file;
     char *name;
     target_ulong offset; // XXX only set by osi_linux for now
+    target_ulong flags; // XXX only set by osi_linux for now
 } OsiModule;
 
 /**

--- a/panda/plugins/osi_linux/osi_linux.cpp
+++ b/panda/plugins/osi_linux/osi_linux.cpp
@@ -286,6 +286,7 @@ static bool fill_osimodule(CPUState *env, OsiModule *m, target_ptr_t vma_addr,
         m->modd = vma_addr;
         m->base = vma_start;
         m->size = vma_end - vma_start;
+        m->flags = get_vma_flags(env, vma_addr);
     }
 
     return populated;

--- a/panda/plugins/osi_linux/osi_linux.h
+++ b/panda/plugins/osi_linux/osi_linux.h
@@ -291,7 +291,8 @@ IMPLEMENT_OFFSET_GET(get_vma_start, vma_struct, target_ulong, ki.vma.vm_start_of
 IMPLEMENT_OFFSET_GET(get_vma_end, vma_struct, target_ulong, ki.vma.vm_end_offset, 0)
 
 /**
- * @todo Retrieves the address of the following vm_area_struct.
+ * @brief Retrieves the flags of the following vm_area_struct.
+ * https://elixir.bootlin.com/linux/v6.5/source/include/linux/mm.h#L260
  */
 IMPLEMENT_OFFSET_GET(get_vma_flags, vma_struct, target_ulong, ki.vma.vm_flags_offset, 0)
 


### PR DESCRIPTION
This PR adds the `flags` field from a vm_area_struct to OSI Linux. The [getter](https://github.com/panda-re/panda/blob/dev/panda/plugins/osi_linux/osi_linux.h#L293-L296) already exists in the osi_linux plugin and kernelinfo, this PR just appends the flags to `OsiModule`.

Motivated by the fact that upstream symbion now [has permissions](https://github.com/angr/angr-targets/pull/28) in MemoryMaps