### PR TITLE
osi/osi_linux: expose start_brk and brk

### DIFF
--- a/panda/plugins/osi/README.md
+++ b/panda/plugins/osi/README.md
@@ -82,6 +82,12 @@ The following data structures are defined in the [`osi_types.h` header][osi_type
         OsiPage *pages;     // TODO in osi_linux
     } OsiProc;
 
+    // Represents process memory details
+    typedef struct osi_proc_mem {
+        target_ptr_t start_brk;
+        target_ptr_t brk;
+    } OsiProcMem;
+
 ```
 
 ### Data allocation
@@ -188,6 +194,18 @@ typedef void (*on_get_process_t)(CPUState *, OsiProcHandle *, OsiProc **)
 ```
 
 Description: Called to retrieve full process information about the process pointed to by `OsiProcHandle`. Implementation should allocate memory and fill in the pointer to an `OsiProc` struct. The returned `OsiProc` can be freed with `free_osiproc`.
+
+---
+
+Name: **on\_get\_proc\_mem**
+
+Signature:
+
+```C
+typedef void (*on_get_proc_mem_t)(CPUState *, OsiProc *, OsiProcMem **)
+```
+
+Description: Called to retrieve process memory details.  Currently only implemented in osi\_linux.  Returns a pointer to a static memory address, which will be overwritten on the next call to this function.
 
 ---
 

--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -40,6 +40,7 @@ PPP_PROT_REG_CB(on_get_process_handles)
 PPP_PROT_REG_CB(on_get_current_process)
 PPP_PROT_REG_CB(on_get_current_process_handle)
 PPP_PROT_REG_CB(on_get_process)
+PPP_PROT_REG_CB(on_get_proc_mem)
 PPP_PROT_REG_CB(on_get_modules)
 PPP_PROT_REG_CB(on_get_mappings)
 PPP_PROT_REG_CB(on_get_file_mappings)
@@ -60,6 +61,7 @@ PPP_CB_BOILERPLATE(on_get_process_handles)
 PPP_CB_BOILERPLATE(on_get_current_process)
 PPP_CB_BOILERPLATE(on_get_current_process_handle)
 PPP_CB_BOILERPLATE(on_get_process)
+PPP_CB_BOILERPLATE(on_get_proc_mem)
 PPP_CB_BOILERPLATE(on_get_modules)
 PPP_CB_BOILERPLATE(on_get_mappings)
 PPP_CB_BOILERPLATE(on_get_file_mappings)
@@ -107,6 +109,12 @@ OsiProc *get_process(CPUState *cpu, const OsiProcHandle *h) {
     OsiProc *p = NULL;
     PPP_RUN_CB(on_get_process, cpu, h, &p);
     return p;
+}
+
+OsiProcMem *get_proc_mem(CPUState *cpu, const OsiProc *p) {
+    OsiProcMem *pm = NULL;
+    PPP_RUN_CB(on_get_proc_mem, cpu, p, &pm);
+    return pm;
 }
 
 GArray *get_modules(CPUState *cpu) {

--- a/panda/plugins/osi/os_intro.h
+++ b/panda/plugins/osi/os_intro.h
@@ -11,6 +11,7 @@ PPP_CB_TYPEDEF(void,on_get_process_handles,CPUState *, GArray **);
 PPP_CB_TYPEDEF(void,on_get_current_process,CPUState *, OsiProc **);
 PPP_CB_TYPEDEF(void,on_get_current_process_handle,CPUState *, OsiProcHandle **);
 PPP_CB_TYPEDEF(void,on_get_process,CPUState *, const OsiProcHandle *, OsiProc **);
+PPP_CB_TYPEDEF(void,on_get_proc_mem,CPUState *cpu, const OsiProc *p, OsiProcMem **);
 PPP_CB_TYPEDEF(void,on_get_modules,CPUState *, GArray **);
 PPP_CB_TYPEDEF(void,on_get_mappings,CPUState *, OsiProc *, GArray**);
 PPP_CB_TYPEDEF(void,on_get_file_mappings,CPUState *, OsiProc *, GArray**);

--- a/panda/plugins/osi/osi_int.h
+++ b/panda/plugins/osi/osi_int.h
@@ -20,6 +20,7 @@ typedef void CPUState;
 typedef void OsiProcHandle;
 typedef void OsiThread;
 typedef void OsiProc;
+typedef void OsiProcMem;
 typedef void OsiModule;
 typedef void GArray;
 typedef void target_pid_t;

--- a/panda/plugins/osi/osi_int_fns.h
+++ b/panda/plugins/osi/osi_int_fns.h
@@ -19,6 +19,10 @@ GArray *get_modules(CPUState *cpu);
 // returns information about the memory mappings of libraries loaded by a guest OS process
 GArray *get_mappings(CPUState *cpu, OsiProc *p);
 
+// returns process specific memory parameters (start_brk/brk)
+// supported in osi_linux only
+OsiProcMem *get_proc_mem(CPUState *cpu, const OsiProc *p);
+
 // like get_mappings, but only return segments backed by files
 // for wintrospection, this is the same as get_mappings
 GArray *get_file_mappings(CPUState *cpu, OsiProc *p);

--- a/panda/plugins/osi/osi_types.h
+++ b/panda/plugins/osi/osi_types.h
@@ -11,6 +11,16 @@
 // between this and END_PYPANDA_NEEDS_THIS except includes of other
 // files in this directory that contain subsections like this one.
 
+/**
+ * @brief start_brk (end of bss) and brk (program break) for a process.
+ *
+ * @note Only meaningful for linux guests.
+ */
+
+typedef struct osi_proc_mem {
+    target_ptr_t start_brk;
+    target_ptr_t brk;
+} OsiProcMem;
 
 /**
  * @brief Minimal handle for a process. Contains a unique identifier \p asid


### PR DESCRIPTION
osi_linux computes "start_brk" (end of bss segment) and "brk" (program break) for internal use but doesn't provide that information to consumers.

Added an extension to osi to allow plugins that leverage osi to get to these process-specific addresses.

a739