### PR TITLE
MIPS64 Syscalls loadinfo fix

### DIFF
--- a/panda/plugins/syscalls2/syscalls2_info.c
+++ b/panda/plugins/syscalls2/syscalls2_info.c
@@ -18,6 +18,8 @@ int load_syscall_info(void) {
     const gchar *arch = "arm";
 #elif defined(TARGET_ARM) &&defined(TARGET_AARCH64)
     const gchar *arch = "arm64";
+#elif defined(TARGET_MIPS) && defined(TARGET_MIPS64)
+    const gchar *arch = "mips64";
 #elif defined(TARGET_MIPS)
     const gchar *arch = "mips";
 #elif defined(TARGET_X86_64)


### PR DESCRIPTION
This two line fix should make MIPS64 actually use the right shared object.

This error is masked by the fact that we generate these libraries for every architecture for each architecture even though you'll really only use one.