### PR TITLE
Fix #1345: Errors in pypanda shutdown with multiple SIGINTs

### DIFF
--- a/panda/python/core/pandare/pypluginmanager.py
+++ b/panda/python/core/pandare/pypluginmanager.py
@@ -21,7 +21,7 @@ class _DotGetter(object):
         self.data[k] = v
 
     def __str__(self):
-        return str([x for x in self.data.keys()])
+        return str(list(self.data.keys()))
 
     def __getattr__(self, name):
         raise NotImplementedError("Subclass must implement this virtual method")
@@ -215,7 +215,7 @@ class PyPluginManager:
 
                 bp = self.blueprint(name, __name__, template_folder=template_dir)
                 self.plugins[name].webserver_init(bp)
-                self.app.register_blueprint(bp, url_prefix="/" + name)
+                self.app.register_blueprint(bp, url_prefix=f"/{name}")
 
     def load_all(self, plugin_file, args=None, template_dir=None):
         '''
@@ -249,11 +249,7 @@ class PyPluginManager:
         return names
 
     def unload(self, pluginclass, do_del=True):
-        if isinstance(pluginclass, str):
-            name = pluginclass
-        else:
-            name = pluginclass.__name__
-
+        name = pluginclass if isinstance(pluginclass, str) else pluginclass.__name__
         if callable(getattr(self.plugins[name], "uninit", None)):
             self.plugins[name].uninit()
 
@@ -261,23 +257,17 @@ class PyPluginManager:
             del self.plugins[name]
 
     def unload_all(self):
-        for name in self.plugins.keys():
+        while self.plugins:
+            name, _ = self.plugins.popitem()
             self.unload(name, do_del=False)
-        self.plugins.clear()
 
     def is_loaded(self, pluginclass):
-        if isinstance(pluginclass, str):
-            name = pluginclass
-        else:
-            name = pluginclass.__name__
+        name = pluginclass if isinstance(pluginclass, str) else pluginclass.__name__
         return name in self.plugins
 
     def get_plugin(self, pluginclass):
         # Lookup name
-        if isinstance(pluginclass, str):
-            name = pluginclass
-        else:
-            name = pluginclass.__name__
+        name = pluginclass if isinstance(pluginclass, str) else pluginclass.__name__
         if not self.is_loaded(pluginclass, name):
             raise ValueError(f"Plugin {name} is not loaded")
         return self.plugins[name]


### PR DESCRIPTION
This PR primarily fixes #1345 which indicated that the pypluginmanager `plugins` size may change during iteration due to multiple threads.

This can be fixed by changing to a loop which pops items while there remain items to pop rather than forming an iterator.

https://github.com/panda-re/panda/compare/fix_1345?expand=1#diff-a4f554d6018061dd19f397a13397cc37399a0cc4a602f566ce50f7e462dc9075R260-R261

There are a handful of other code cleanup items as well.

fixes #1345 