### PR TITLE
Add address_to_ram_offset to pypanda

### DIFF
--- a/panda/include/panda/panda_api.h
+++ b/panda/include/panda/panda_api.h
@@ -291,6 +291,12 @@ int panda_physical_memory_write_external(hwaddr addr, uint8_t *buf, int len);
  */
 target_ulong panda_get_retval_external(const CPUState *cpu);
 
+/**
+ * PandaPhysicalAddressToRamOffset_external() - Translate guest physical to ram offset.
+ * 
+*/
+MemTxResult PandaPhysicalAddressToRamOffset_external(ram_addr_t* out, hwaddr addr, bool is_write);
+
 
 /**
  * panda_in_kernel_external() - Determine if guest is in kernel.

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -2067,6 +2067,27 @@ class Panda():
             return tq
         else:
             return None
+    
+    def address_to_ram_offset(self, hwaddr, is_write):
+        '''
+        Convert physical address to ram offset
+
+        Args:
+            hwaddr (int): physical address
+            is_write (bool): boolean representing if this is a write
+
+        Returns:
+            ram offset (int)
+
+        Raises:
+            ValueError if memory access fails or fmt is unsupported
+        '''
+        
+        out = self.ffi.new("ram_addr_t*", self.ffi.cast("ram_addr_t", 0))
+        value = self.libpanda.PandaPhysicalAddressToRamOffset_external(out, hwaddr, is_write)
+        if value != 0:
+            raise ValueError(f"address_to_ram_offset returned {value}")
+        return out[0]
 
     # enables symbolic tracing
     def taint_sym_enable(self):

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -183,6 +183,10 @@ target_ulong panda_get_retval_external(const CPUState *cpu){
 	return panda_get_retval(cpu);
 }
 
+MemTxResult PandaPhysicalAddressToRamOffset_external(ram_addr_t* out, hwaddr addr, bool is_write){
+    return PandaPhysicalAddressToRamOffset(out, addr, is_write);
+}
+
 void panda_setup_signal_handling(void (*f) (int, void*, void *))
 {
     struct sigaction act;


### PR DESCRIPTION
This PR adds the `address_to_ram_offset` method to PyPANDA as suggested by @MarkMankins https://github.com/panda-re/panda/issues/1355#issuecomment-1732653656