### PR TITLE
Add Dockerhub historical versions

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -21,9 +21,11 @@ jobs:
       # Push both dev and regular container
       run:  DOCKER_BUILDKIT=1 docker build --progress=plain --target=panda -t pandare/panda:${GITHUB_SHA} $GITHUB_WORKSPACE;
             docker tag pandare/panda:${GITHUB_SHA} pandare/panda:latest;
+            docker push pandare/panda:${GITHUB_SHA};
             docker push pandare/panda;
             DOCKER_BUILDKIT=1 docker build --progress=plain --target=developer -t pandare/pandadev:${GITHUB_SHA} $GITHUB_WORKSPACE;
             docker tag pandare/pandadev:${GITHUB_SHA} pandare/pandadev:latest;
+            docker push pandare/pandadev:${GITHUB_SHA};
             docker push pandare/pandadev;
 
     - name: Checkout docs and reset
@@ -65,6 +67,7 @@ jobs:
       # Push both dev and regular container
       run:  DOCKER_BUILDKIT=1 docker build --progress=plain --target=panda -t pandare/panda_stable:${GITHUB_SHA} $GITHUB_WORKSPACE;
             docker tag pandare/panda_stable:${GITHUB_SHA} pandare/panda_stable:latest
+            docker push pandare/panda_stable:${GITHUB_SHA};
             docker push pandare/panda_stable;
             #DOCKER_BUILDKIT=1 docker build --progress=plain --target=developer -t pandare/pandadev:${GITHUB_SHA} $GITHUB_WORKSPACE;
             #docker tag pandare/panadev:${GITHUB_SHA} pandare/pandadev:latest


### PR DESCRIPTION
This PR restores functionality that pushes `$DOCKER_IMAGE:${GITHUB_SHA}` as a tag for each revision. This helps us maintain historical versions of PANDA on dockerhub.