### PR TITLE
Name mismatch in mips64n32 target

### DIFF
--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -908,7 +908,7 @@ void syscall_enter_linux_mips64(CPUState *cpu, target_ptr_t pc, int static_calln
 	}else if (static_callno >= 5000 && static_callno <= 5999) {
         syscall_enter_switch_linux_mips64(cpu, pc, static_callno);
     }else if (static_callno >= 6000 && static_callno <= 6999) {
-        syscall_enter_switch_linux_mipsn32(cpu, pc, static_callno);
+        syscall_enter_switch_linux_mips64n32(cpu, pc, static_callno);
     }else{
         assert("syscall_enter_linux_mips64: static_callno not found");
     }
@@ -923,7 +923,7 @@ void syscall_return_linux_mips64(CPUState *cpu, target_ptr_t pc, const syscall_c
 	}else if (ctx->no >= 5000 && ctx->no <= 5999) {
         syscall_return_switch_linux_mips64(cpu, pc, ctx);
     }else if (ctx->no >= 6000 && ctx->no <= 6999) {
-        syscall_return_switch_linux_mipsn32(cpu, pc, ctx);
+        syscall_return_switch_linux_mips64n32(cpu, pc, ctx);
     }else{
         assert("syscall_return_linux_mips64: ctx->no not found");
     }

--- a/panda/plugins/syscalls2/syscalls2.h
+++ b/panda/plugins/syscalls2/syscalls2.h
@@ -14,8 +14,8 @@ void syscall_enter_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, int static
 void syscall_enter_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, int static_callno);
 void syscall_enter_switch_linux_arm(CPUState *cpu, target_ptr_t pc, int static_callno);
 void syscall_enter_switch_linux_mips(CPUState *cpu, target_ptr_t pc, int static_callno);
-void syscall_enter_switch_linux_mipsn32(CPUState *cpu, target_ptr_t pc, int static_callno);
 void syscall_enter_switch_linux_mips64(CPUState *cpu, target_ptr_t pc, int static_callno);
+void syscall_enter_switch_linux_mips64n32(CPUState *cpu, target_ptr_t pc, int static_callno);
 void syscall_enter_switch_linux_x64(CPUState *cpu, target_ptr_t pc, int static_callno);
 void syscall_enter_switch_linux_x86(CPUState *cpu, target_ptr_t pc, int static_callno);
 void syscall_enter_switch_windows_2000_x86(CPUState *cpu, target_ptr_t pc, int static_callno);
@@ -27,7 +27,7 @@ void syscall_return_switch_freebsd_x64(CPUState *cpu, target_ptr_t pc, const sys
 void syscall_return_switch_linux_arm64(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx);
 void syscall_return_switch_linux_arm(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx);
 void syscall_return_switch_linux_mips(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx);
-void syscall_return_switch_linux_mipsn32(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx);
+void syscall_return_switch_linux_mips64n32(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx);
 void syscall_return_switch_linux_mips64(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx);
 void syscall_return_switch_linux_x64(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx);
 void syscall_return_switch_linux_x86(CPUState *cpu, target_ptr_t pc, const syscall_ctx_t *ctx);


### PR DESCRIPTION
This fixes a regression in the mips64 target due to a mismatched function name not being resolved by the target.