### PR TITLE
Panda load plugin enhancements

### DIFF
--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -67,7 +67,7 @@ void panda_disable_plugin(void *plugin);
 
 // Structure to store metadata about a plugin
 typedef struct panda_plugin {
-    char name[256];        // Currently basename(filename)
+    char *name;            // Plugin name: basename(filename)
     void *plugin;          // Handle to the plugin (for use with dlsym())
     bool unload;           // When true, unload plugin when safe
     bool exported_symbols; // True if plugin dlopened with RTLD_GLOBAL

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -194,10 +194,6 @@ bool _panda_load_plugin(const char *filename, const char *plugin_name, bool libr
  */
 bool panda_add_arg(const char *plugin_name, const char *plugin_arg);
 
-
-// I think this is not used anywhere?
-bool panda_load_external_plugin(const char *filename, const char *plugin_name, void *plugin_uuid, void *init_fn_ptr);
-
 /**
  * panda_get_plugin_by_name() - Returns pointer to the plugin of this name.
  * @name: The name of the desired plugin.

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -69,6 +69,7 @@ void panda_disable_plugin(void *plugin);
 typedef struct panda_plugin {
     char name[256];     // Currently basename(filename)
     void *plugin;       // Handle to the plugin (for use with dlsym())
+    bool unload;        // When true, unload plugin when safe
 } panda_plugin;
 
 
@@ -228,8 +229,6 @@ void panda_unload_plugins(void);
 extern bool panda_update_pc;
 extern bool panda_use_memcb;
 extern panda_cb_list *panda_cbs[PANDA_CB_LAST];
-extern bool panda_plugins_to_unload[MAX_PANDA_PLUGINS];
-extern bool panda_plugin_to_unload;
 extern bool panda_tb_chaining;
 
 // this stuff is used by the new qemu cmd-line arg '-os os_name'

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -182,10 +182,6 @@ void panda_unregister_callbacks(void *plugin);
  */
 bool panda_load_plugin(const char *filename, const char *plugin_name);
 
-
-bool _panda_load_plugin(const char *filename, const char *plugin_name, bool library_mode);
-
-
 /**
  * panda_add_arg() - Add an argument to those for a plugin.
  * @plugin_name: The name of the plugin.

--- a/panda/include/panda/plugin.h
+++ b/panda/include/panda/plugin.h
@@ -67,9 +67,10 @@ void panda_disable_plugin(void *plugin);
 
 // Structure to store metadata about a plugin
 typedef struct panda_plugin {
-    char name[256];     // Currently basename(filename)
-    void *plugin;       // Handle to the plugin (for use with dlsym())
-    bool unload;        // When true, unload plugin when safe
+    char name[256];        // Currently basename(filename)
+    void *plugin;          // Handle to the plugin (for use with dlsym())
+    bool unload;           // When true, unload plugin when safe
+    bool exported_symbols; // True if plugin dlopened with RTLD_GLOBAL
 } panda_plugin;
 
 

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -57,8 +57,6 @@ int panda_argc;
 int nb_panda_plugins = 0;
 panda_plugin panda_plugins[MAX_PANDA_PLUGINS];
 
-bool panda_plugins_to_unload[MAX_PANDA_PLUGINS];
-
 bool panda_plugin_to_unload = false;
 
 bool panda_please_flush_tb = false;
@@ -207,6 +205,7 @@ bool _panda_load_plugin(const char *filename, const char *plugin_name, bool libr
     // initialization completes. E.g. osi does a panda_require("wintrospection"),
     // and then wintrospection does a PPP_REG_CB("osi", ...) while initializing.
     panda_plugins[nb_panda_plugins].plugin = plugin;
+    panda_plugins[nb_panda_plugins].unload = false;
     if (plugin_name) {
         strncpy(panda_plugins[nb_panda_plugins].name, plugin_name, 256);
     } else {
@@ -397,7 +396,7 @@ void panda_unload_plugin_idx(int plugin_idx)
         return;
     }
     panda_plugin_to_unload = true;
-    panda_plugins_to_unload[plugin_idx] = true;
+    panda_plugins[plugin_idx].unload = true;
 }
 
 void panda_unload_plugins(void)

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -152,6 +152,11 @@ static bool _panda_load_plugin(const char *filename, const char *plugin_name, bo
 
     static bool libpanda_loaded = false;
 
+    if ((plugin_name == NULL) || (*plugin_name == '\0')) {
+        LOG_ERROR(PANDA_MSG_FMT "Fatal error: plugin_name is required\n", PANDA_CORE_NAME);
+        abort();
+    }
+
 #ifndef CONFIG_LLVM
     // Taint2 seems to be our most commonly used LLVM plugin and it causes some confusion
     // when users build PANDA without LLVM and then claim taint2 is "missing"
@@ -160,10 +165,10 @@ static bool _panda_load_plugin(const char *filename, const char *plugin_name, bo
     }
 #endif
 
-    if (filename == NULL) {
+    if ((filename == NULL) || (*filename == '\0')) {
         LOG_ERROR(PANDA_MSG_FMT "Fatal error: could not find path for plugin %s\n", PANDA_CORE_NAME, plugin_name);
+        abort();
     }
-    assert(filename != NULL);
 
     // don't load the same plugin twice
     uint32_t i;
@@ -204,14 +209,7 @@ static bool _panda_load_plugin(const char *filename, const char *plugin_name, bo
     panda_plugins[nb_panda_plugins].unload = false;
     panda_plugins[nb_panda_plugins].exported_symbols = false;
 
-    if (plugin_name) {
-        strncpy(panda_plugins[nb_panda_plugins].name, plugin_name, 256);
-    } else {
-        char *pn = g_path_get_basename((char *) filename);
-        *g_strrstr(pn, HOST_DSOSUF) = '\0';
-        strncpy(panda_plugins[nb_panda_plugins].name, pn, 256);
-        g_free(pn);
-    }
+    strncpy(panda_plugins[nb_panda_plugins].name, plugin_name, 256);
 
     char *export_symbol = g_strdup_printf("PANDA_EXPORT_SYMBOLS_%s", plugin_name);
 
@@ -329,7 +327,7 @@ static void _panda_require(const char *plugin_name, char **plugin_args, uint32_t
     LOG_INFO(PANDA_MSG_FMT "loading required plugin %s\n", PANDA_CORE_NAME, plugin_name);
 
     // translate plugin name into a path to .so
-    char *plugin_path = panda_plugin_path(plugin_name); // May be NULL, would raise assert in in _panda_load_plugin
+    char *plugin_path = panda_plugin_path(plugin_name); // May be NULL, would abort in in _panda_load_plugin
     if (NULL == plugin_path) {
         LOG_ERROR(PANDA_MSG_FMT "FAILED to find required plugin %s\n", PANDA_CORE_NAME, plugin_name);
         abort();

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -173,7 +173,7 @@ static bool _panda_load_plugin(const char *filename, const char *plugin_name, bo
     // don't load the same plugin twice
     uint32_t i;
     for (i=0; i<nb_panda_plugins; i++) {
-        if (strncmp(panda_plugins[i].name, plugin_name, 256) == 0) {
+        if (strcmp(panda_plugins[i].name, plugin_name) == 0) {
             LOG_DEBUG(PANDA_MSG_FMT "%s already loaded\n", PANDA_CORE_NAME, plugin_name);
             return true;
         }
@@ -208,8 +208,7 @@ static bool _panda_load_plugin(const char *filename, const char *plugin_name, bo
     panda_plugins[nb_panda_plugins].plugin = plugin;
     panda_plugins[nb_panda_plugins].unload = false;
     panda_plugins[nb_panda_plugins].exported_symbols = false;
-
-    strncpy(panda_plugins[nb_panda_plugins].name, plugin_name, 256);
+    panda_plugins[nb_panda_plugins].name = g_strdup(plugin_name);
 
     char *export_symbol = g_strdup_printf("PANDA_EXPORT_SYMBOLS_%s", plugin_name);
 
@@ -392,7 +391,7 @@ void panda_unload_plugin(void *plugin)
 
 void panda_unload_plugin_by_name(const char *plugin_name) {
     for (int i = 0; i < nb_panda_plugins; i++) {
-        if (strncmp(panda_plugins[i].name, plugin_name, 256) == 0) {
+        if (strcmp(panda_plugins[i].name, plugin_name) == 0) {
             panda_unload_plugin(panda_plugins[i].plugin);
             break;
         }
@@ -420,7 +419,7 @@ void panda_unload_plugins(void)
 void *panda_get_plugin_by_name(const char *plugin_name)
 {
     for (int i = 0; i < nb_panda_plugins; i++) {
-        if (strncmp(panda_plugins[i].name, plugin_name, 256) == 0)
+        if (strcmp(panda_plugins[i].name, plugin_name) == 0)
             return panda_plugins[i].plugin;
     }
     return NULL;

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -181,6 +181,10 @@ static void do_check_export_symbols(panda_plugin *panda_plugin, const char *file
         LOG_DEBUG(PANDA_MSG_FMT "Exporting symbols for plugin %s\n", PANDA_CORE_NAME, panda_plugin->name);
         assert(panda_plugin->plugin == dlopen(filename, RTLD_NOW | RTLD_GLOBAL));
         panda_plugin->exported_symbols = true;
+    } else {
+        // Error condition is not unexpected, clear dlerror(), 
+        // otherwise someone might call it later and be confused
+        dlerror();
     }
 
     g_free(export_symbol);

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -108,10 +108,6 @@ static char* attempt_normalize_path(char* path){
     return new_path;
 }
 
-bool panda_load_plugin(const char *filename, const char *plugin_name) {
-  return _panda_load_plugin(filename, plugin_name, false);
-}
-
 static void *try_open_libpanda(const char *panda_lib) {
     void *libpanda = NULL;
     if(panda_lib != NULL) {
@@ -152,8 +148,7 @@ static bool load_libpanda(void) {
     return libpanda != NULL;
 }
 
-
-bool _panda_load_plugin(const char *filename, const char *plugin_name, bool library_mode) {
+static bool _panda_load_plugin(const char *filename, const char *plugin_name, bool library_mode) {
 
     static bool libpanda_loaded = false;
 
@@ -230,6 +225,10 @@ bool _panda_load_plugin(const char *filename, const char *plugin_name, bool libr
         return false;
     }
     return true;
+}
+
+bool panda_load_plugin(const char *filename, const char *plugin_name) {
+  return _panda_load_plugin(filename, plugin_name, false);
 }
 
 extern const char *qemu_file;

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -151,6 +151,7 @@ static bool load_libpanda(void) {
 // Internal: remove a plugin from the global array panda_plugins
 static void panda_delete_plugin(int i)
 {
+    g_free(panda_plugins[i].name);
     if (i != nb_panda_plugins - 1) { // not the last element
         memmove(&panda_plugins[i], &panda_plugins[i + 1],
                 (nb_panda_plugins - i - 1) * sizeof(panda_plugin));

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -196,13 +196,18 @@ MAKE_CALLBACK_NO_ARGS(void, PRE_SHUTDOWN, pre_shutdown);
 
 // Non-standard callbacks below here
 
+extern bool panda_plugin_to_unload;
+extern int nb_panda_plugins;
+extern panda_plugin panda_plugins[MAX_PANDA_PLUGINS];
+
 void PCB(before_find_fast)(void) {
     if (panda_plugin_to_unload) {
         panda_plugin_to_unload = false;
-        for (int i = 0; i < MAX_PANDA_PLUGINS; i++) {
-            if (panda_plugins_to_unload[i]) {
+        for (int i = 0; i < nb_panda_plugins;) {
+            if (panda_plugins[i].unload) {
                 panda_do_unload_plugin(i);
-                panda_plugins_to_unload[i] = false;
+            } else {
+                i++;
             }
         }
     }

--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -200,56 +200,6 @@ void panda_setup_signal_handling(void (*f) (int, void*, void *))
     panda_external_signal_handler = (void(*)(int,siginfo_t*,void*)) f;
 }
 
-// we have this temporarily in callbacks.c -> to be moved here
-/*
-bool panda_load_external_plugin(const char *filename, const char *plugin_name, void *plugin_uuid, void *init_fn_ptr) {
-    // don't load the same plugin twice
-    uint32_t i;
-    for (i=1; i<nb_panda_plugins_loaded; i++) {
-        if (0 == (strcmp(filename, panda_plugins_loaded[i]))) {
-            fprintf(stderr, PANDA_MSG_FMT "%s already loaded\n", PANDA_CORE_NAME, filename);
-            return true;
-        }
-    }
-    // NB: this is really a list of plugins for which we have started loading
-    // and not yet called init_plugin fn.  needed to avoid infinite loop with panda_require
-    panda_plugins_loaded[nb_panda_plugins_loaded] = strdup(filename);
-    nb_panda_plugins_loaded ++;
-    void *plugin = plugin_uuid;//going to be a handle of some sort -> dlopen(filename, RTLD_NOW);
-    bool (*init_fn)(void *) = init_fn_ptr; //normally dlsym init_fun
-
-    // Populate basic plugin info *before* calling init_fn.
-    // This allows plugins accessing handles of other plugins before
-    // initialization completes. E.g. osi does a panda_require("win7x86intro"),
-    // and then win7x86intro does a PPP_REG_CB("osi", ...) while initializing.
-    panda_plugins[nb_panda_plugins].plugin = plugin;
-    if (plugin_name) {
-        strncpy(panda_plugins[nb_panda_plugins].name, plugin_name, 256);
-    } else {
-        char *pn = g_path_get_basename((char *) filename);
-        *g_strrstr(pn, HOST_DSOSUF) = '\0';
-        strncpy(panda_plugins[nb_panda_plugins].name, pn, 256);
-        g_free(pn);
-    }
-    nb_panda_plugins++;
-
-    // Call init_fn and check status.
-    fprintf(stderr, PANDA_MSG_FMT "initializing %s\n", PANDA_CORE_NAME, panda_plugins[nb_panda_plugins-1].name);
-    panda_help_wanted = false;
-    panda_args_set_help_wanted(plugin_name);
-    if (panda_help_wanted) {
-        printf("Options for plugin %s:\n", plugin_name);
-        fprintf(stderr, "PLUGIN              ARGUMENT                REQUIRED        DESCRIPTION\n");
-        fprintf(stderr, "======              ========                ========        ===========\n");
-    }
-    if(!init_fn(plugin) || panda_plugin_load_failed) {
-        return false;
-    }
-    return true;
-}*/
-
-
-
 // Taken from Avatar2's Configurable Machine - see hw/avatar/configurable_machine.c
 void map_memory(char* name, uint64_t size, uint64_t address) {
     //const char * name; /// XXX const?


### PR DESCRIPTION
The major new functionality here is in do_check_export_symbols().

I have a rather large C++ panda plugin that I'm trying to split up into separate plugins.  I would like to have a base C++ class in plugin plugin_x.  I would like to have plugins plugin_y and plugin_z extend my C++ class defined in plugin_x to implement custom functionality.

This doesn't work with the current logic for loading plugins, as each plugin loaded doesn't provide symbols to subsequently loaded plugins.

do_check_export_symbols changes that behavior, but only for plugins that opt-in to the new behavior.

In plugin_x, by defining a magic symbol:

```
uint32_t PANDA_EXPORT_SYMBOLS_plugin_x = 1;
```

panda_plugin_x.so will be opened (via dlopen) with the RTLD_GLOBAL flag.  This makes symbols defined in plugin_x available to subsequently loaded plugins.

The majority of the commits in this PR aren't related to this new function.  I tried to clean up the various functions that deal with plugin loading and unloading, mostly in callbacks.c.  It's possible I broke something here that someone was using - I can rework things if we find I did break something.

Major changes (including potential breaking changes in obscure cases):

- Consolidated all plugin information in the panda_plugin struct.  Removed panda_plugins_to_unload array and panda_plugins_loaded array.
- Moved pypanda specific logic into their own functions.
- Removed panda_load_external_plugin.  If anyone is using this please let me know and I'll implement a replacement.
- Replaced most printfs with calls to the appropriate logging api.
- Plugin help output now always goes to stdout (previously it was a mix of stderr and stdout.)
- plugin_name is now required in _panda_load_plugin (previously in some cases it was allowed to be null)
- Previously plugins were prevented from being loaded twice by examining the list of filenames already loaded.  This was changed to examine the list of plugin names instead.
