### PR TITLE
Remove rust artifacts from panda docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,13 @@ WORKDIR /panda/
 
 #### Install PANDA + pypanda from builder - Stage 4
 FROM builder as installer
-RUN  make -C /panda/build install
+RUN  make -C /panda/build install && \
+    rm -r /usr/local/lib/panda/*/cosi \
+        /usr/local/lib/panda/*/cosi_strace \
+        /usr/local/lib/panda/*/gdb \
+        /usr/local/lib/panda/*/snake_hook \
+        /usr/local/lib/panda/*/rust_skeleton
+
 # Install pypanda
 RUN cd /panda/panda/python/core && \
     python3 setup.py install


### PR DESCRIPTION
This commit removes the artifacts of the rust plugin build process from the docker container.

This one change decreases the size of our container from (uncompressed) 15.155GB to 2.837GB (18% original size).