### PR TITLE
Fix variety of problems in coverage plugin

### DIFF
--- a/panda/plugins/coverage/README.md
+++ b/panda/plugins/coverage/README.md
@@ -16,7 +16,7 @@ execution is also stored, regardless of mode.  (A value of 1 means the block
 was executed in kernel mode.) For the `osi-block` and `asid-block` modes, the
 mode used to create the CSV file is also written at the top of the file, to cue
 parsers in as to how to interpret the file. `edge` mode writes two blocks per
-records where the first block represents the "from" node in a control flow
+record where the first block represents the "from" node in a control flow
 graph (CFG) and the second represents the "to" node. Note that the `edge` mode
 requires OSI and only works with X86 guests.
 
@@ -69,10 +69,10 @@ adjusted manually for DOS operating systems.
 
 Arguments
 ---------
-* `filename` - The name of the file to output (default:  `coverage.csv`).
+* `filename` - The name of the file to output (default: `coverage.csv`).
 * `mode` - Output mode, one of `asid-block`, `osi-block`, or `edge` (default:
 `asid-block`). Note that `edge` requires OSI.
-* `full` - When `true`, logs each record every time it is generated (default:
+* `full` - When `true`, logs each record every time it is generated (default: `false`)
 * `summary` - When `true`, only report total distinct blocks executed per process. Requires OSI and a mode of `osi-block` (default:
 `false`)
 * `start_disabled` - When `true`, does not start data collection when the
@@ -111,12 +111,14 @@ None
 Example
 -------
 Use the coverage plugin with a recording:
+
 ```
 panda-system-i386 -m 2G -replay test \
     -os windows-32-xpsp3 \
     -panda coverage:filename=test_coverage.csv,mode=osi-block
 ```
 Use the coverage plugin on a live system:
+
 ```
 panda-system-i386 -monitor stdio -m 2G -net nic -net user -os linux-32-.+ -panda osi -panda osi_linux:kconf_file=myconf.conf,kconf_group=mygroup -hda myimage.img
 (qemu) load_plugin coverage,filename=test01.csv,mode=osi-block

--- a/panda/plugins/coverage/coverage.cpp
+++ b/panda/plugins/coverage/coverage.cpp
@@ -42,8 +42,7 @@ using namespace coverage;
 const char *DEFAULT_FILE = "coverage.csv";
 
 // commands that can be accessed through the QEMU monitor
-const char *MONITOR_HELP = "help";
-constexpr size_t MONITOR_HELP_LEN = 4;
+const std::string MONITOR_HELP = "help";
 const std::string MONITOR_ENABLE = "coverage_enable";
 const std::string MONITOR_DISABLE = "coverage_disable";
 
@@ -124,6 +123,11 @@ int monitor_callback(Monitor *mon, const char *cmd_cstr)
                 std::cerr << "Error enabling instrumentation: " << err.code().message() << "\n";
             }
         }
+    } else if (0 == cmd.find(MONITOR_HELP)) {
+        log_message("coverage_enable=filename:  start logging coverage "
+                "information to the named file");
+        log_message("coverage_disable:  stop logging coverage information "
+                "and close the current file");
     }
     return 0;
 }


### PR DESCRIPTION
Added fetches for the FS and DS registers, or the plugin would crash when trying to instrument an instruction using one of those segment registers.
Added back in the response to plugin_cmd help (which mysteriously disappeared a few years ago).
Fixed pointer arithmetic problems when fetching register values, which resulted in garbage values being used when trying to read any register except the first one in the regs list.
Fixed calculations of jump destination addresses when the 'base' register is RIP.
Made some minor fixes in the README file.