### PR TITLE
Add new callback for QMP events

### DIFF
--- a/panda/include/panda/callbacks/cb-defs.h
+++ b/panda/include/panda/callbacks/cb-defs.h
@@ -57,6 +57,7 @@ typedef enum panda_cb_type {
     PANDA_CB_HD_WRITE,              // Each HDD write
     PANDA_CB_GUEST_HYPERCALL,       // Hypercall from the guest (e.g. CPUID)
     PANDA_CB_MONITOR,               // Monitor callback
+    PANDA_CB_QMP,                   // QMP callback
     PANDA_CB_CPU_RESTORE_STATE,     // In cpu_restore_state() (fault/exception)
     PANDA_CB_BEFORE_LOADVM,         // at start of replay, before loadvm
     PANDA_CB_ASID_CHANGED,          // When CPU asid (address space identifier) changes
@@ -591,6 +592,23 @@ typedef union panda_cb {
         as a prefix ("sample_do_foo" rather than "do_foo").
     */
     int (*monitor)(Monitor *mon, const char *cmd);
+
+    /* Callback ID: PANDA_CB_QMP
+
+       qmp:
+        Called when someone sends an unhandled QMP command
+
+       Arguments:
+         char *command: the command string as json
+         char *args:    the arguments string as json
+         char **result: pointer to a json result or NULL
+
+       Helper call location: TBA
+
+       Return value:
+         bool: true IFF the command was handled by the plugin
+    */
+    bool (*qmp)(char *command, char* args, char **result);
 
 
     /* Callback ID: PANDA_CB_CPU_RESTORE_STATE
@@ -1543,6 +1561,23 @@ typedef union panda_cb_with_context {
         as a prefix ("sample_do_foo" rather than "do_foo").
     */
     int (*monitor)(void* context, Monitor *mon, const char *cmd);
+
+    /* Callback ID: PANDA_CB_QMP
+
+       qmp:
+        Called when someone sends an unhandled QMP command
+
+       Arguments:
+         char *command: the command string as json
+         char *args:    the arguments string as json
+         char **result: pointer to a json result or NULL
+
+       Helper call location: TBA
+
+       Return value:
+         bool: true IFF the command was handled by the plugin
+    */
+    bool (*qmp)(void* context, char *command, char* args, char **result);
 
 
     /* Callback ID: PANDA_CB_CPU_RESTORE_STATE

--- a/panda/include/panda/callbacks/cb-support.h
+++ b/panda/include/panda/callbacks/cb-support.h
@@ -75,6 +75,7 @@ bool panda_callbacks_after_find_fast(CPUState *cpu, TranslationBlock *tb, bool b
 int panda_callbacks_insn_exec(CPUState *env, target_ptr_t pc);
 int panda_callbacks_after_insn_exec(CPUState *env, target_ptr_t pc);
 int panda_callbacks_monitor(Monitor *mon, const char *cmd);
+bool panda_callbacks_qmp(char *command, char *args, char **result);
 int panda_callbacks_before_loadvm(void);
 void panda_callbacks_replay_hd_transfer(CPUState *env, uint32_t type, target_ptr_t src_addr, target_ptr_t dest_addr, size_t num_bytes);
 void panda_callbacks_after_machine_init(CPUState *env);

--- a/panda/include/panda/callbacks/cb-trampolines.h
+++ b/panda/include/panda/callbacks/cb-trampolines.h
@@ -19,6 +19,7 @@ void panda_cb_trampoline_phys_mem_after_write(void* context, CPUState *env, targ
 int panda_cb_trampoline_insn_exec(void* context, CPUState *env, target_ptr_t pc);
 int panda_cb_trampoline_after_insn_exec(void* context, CPUState *env, target_ptr_t pc);
 int panda_cb_trampoline_monitor(void* context, Monitor *mon, const char *cmd);
+bool panda_cb_trampoline_qmp(void* context, char *command, char *args, char **result);
 //int panda_cb_trampoline_before_loadvm(void* context);
 void panda_cb_trampoline_replay_hd_transfer(void* context, CPUState *env, uint32_t type, target_ptr_t src_addr, target_ptr_t dest_addr, size_t num_bytes);
 void panda_cb_trampoline_after_machine_init(void* context, CPUState *env);

--- a/panda/python/examples/cb_qmp.py
+++ b/panda/python/examples/cb_qmp.py
@@ -1,0 +1,45 @@
+from pandare import Panda
+from time import sleep
+import json
+import tempfile
+
+path = tempfile.mktemp(".sock")
+panda = Panda(generic="x86_64", extra_args=["-qmp", f"unix:{path},server,nowait"])
+
+print()
+print("QMP example running! To send a QMP command to this VM, run:")
+print("""echo '{ "execute": "mycmd", "arguments": { "arg_key" : "arg_val" } }' | socat - UNIX-CONNECT:""" + path + """  | cat""")
+print()
+
+@panda.cb_qmp
+def on_qmp_command(cmd, arg_json, result_json):
+    args = {}
+    cmd = panda.ffi.string(cmd).decode() if cmd != panda.ffi.NULL else None
+    if cmd != 'mycmd':
+        return False
+    if arg_json != panda.ffi.NULL:
+        args = json.loads(panda.ffi.string(arg_json).decode())
+
+    print(f"PyPANDA handling QMP command {cmd} with args {args}")
+
+    data = {
+        "hello": "world",
+        "key": "value",
+        "0": 1,
+    }
+
+    # Dump our result to json and copy it into the result_json buffer
+    encoded_data = json.dumps(data).encode()
+    result_buffer = panda.ffi.new("char[]", len(encoded_data) + 1) # Null term
+    panda.ffi.memmove(result_buffer, encoded_data, len(encoded_data))
+    result_json[0] = result_buffer
+    return True
+
+@panda.queue_blocking
+def driver():
+    panda.revert_sync("root")
+    panda.run_serial_cmd("whoami")
+    sleep(300)
+    panda.end_analysis()
+
+panda.run()

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -474,6 +474,7 @@ panda_cb_with_context panda_get_cb_trampoline(panda_cb_type type) {
         CASE_CB_TRAMPOLINE(HD_WRITE,hd_write)
         CASE_CB_TRAMPOLINE(GUEST_HYPERCALL,guest_hypercall)
         CASE_CB_TRAMPOLINE(MONITOR,monitor)
+        CASE_CB_TRAMPOLINE(QMP,qmp)
         CASE_CB_TRAMPOLINE(CPU_RESTORE_STATE,cpu_restore_state)
 
         //CASE_CB_TRAMPOLINE(BEFORE_LOADVM,before_loadvm)

--- a/panda/src/cb-support.c
+++ b/panda/src/cb-support.c
@@ -101,7 +101,9 @@ void panda_cb_trampoline_start_block_exec(void* context, CPUState *cpu, Translat
 // these aren't used
 MAKE_CALLBACK(void, HD_READ, hd_read, CPUState*, env);
 MAKE_CALLBACK(void, HD_WRITE, hd_write, CPUState*, env);
+
 MAKE_CALLBACK(int, MONITOR, monitor, Monitor*, mon, const char*, cmd);
+MAKE_CALLBACK(bool, QMP, qmp, char*, cmd, char*, args, char **, result);
 
 // Helper - get a physical address
 static inline hwaddr get_paddr(CPUState *cpu, target_ptr_t addr, void *ram_ptr) {

--- a/qapi/qmp-dispatch.c
+++ b/qapi/qmp-dispatch.c
@@ -19,8 +19,11 @@
 #include "qapi/qmp/qjson.h"
 #include "qapi-types.h"
 #include "qapi/qmp/qerror.h"
+
 //#include "panda/callbacks/cb-support.h"
 extern bool panda_callbacks_qmp(char *command, char* args, char **result);
+// And we have a stub in stubs/qtest.c  that always returns false if we build
+// without panda for tests
 
 static QDict *qmp_dispatch_check_obj(const QObject *request, Error **errp)
 {

--- a/stubs/qtest.c
+++ b/stubs/qtest.c
@@ -18,3 +18,9 @@ bool qtest_driver(void)
 {
     return false;
 }
+
+/* Needed for qmp-dispatch tests to pass when we don't have panda */
+bool panda_callbacks_qmp(char *command, char* args, char **result);
+bool panda_callbacks_qmp(char *command, char* args, char **result) {
+    return false;
+}


### PR DESCRIPTION
If no QEMU code is consuming a QMP event of type "execute" give panda a chance to jump in with the new `qmp` callback.

I initially explored passing the QObject structures directly to PANDA but this forced our callback consumers to be able to parse a whole bunch of QObjects and related types that were quite painful to deal with (see the abandoned attempt at https://github.com/panda-re/panda/compare/qmp_cb2). Instead I just went with JSON.

It's not pretty but it works and there's an example.