### PR TITLE
Ensure variables are initialized in pri_taint and loaded to silence warnings

### DIFF
--- a/panda/plugins/loaded/loaded.cpp
+++ b/panda/plugins/loaded/loaded.cpp
@@ -69,7 +69,7 @@ uint32_t guest_strncpy(CPUState *cpu, char *buf, size_t maxlen, target_ulong gue
     buf[0] = 0;
     unsigned i;
     for (i=0; i<maxlen; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         panda_virtual_memory_rw(cpu, guest_addr+i, &c, 1, 0);
         buf[i] = c;
         if (c==0) {

--- a/panda/plugins/pri_taint/pri_taint.cpp
+++ b/panda/plugins/pri_taint/pri_taint.cpp
@@ -86,7 +86,7 @@ Addr make_greg(uint64_t r, uint16_t off) {
     return ra;
 }
 void print_membytes(CPUState *env, target_ulong a, target_ulong len) {
-    unsigned char c;
+    unsigned char c = (unsigned char)0;
     printf("{ ");
     for (int i = 0; i < len; i++) {
         if (-1 == panda_virtual_memory_read(env, a+i, (uint8_t *) &c, sizeof(char))) {


### PR DESCRIPTION
Started getting some warnings from gcc about these