### PR TITLE
Tainted instruction plugin optimizations.

### DIFF
--- a/panda/plugins/tainted_instr/README.md
+++ b/panda/plugins/tainted_instr/README.md
@@ -1,4 +1,4 @@
-Plugin: tainted_instr
+Plugin: tainted\_instr
 ===========
 
 Summary
@@ -11,6 +11,7 @@ Arguments
 
 * `summary`: boolean. Determines whether full or summary information will be produced. In summary mode, `tainted_instr` just produces information about what instructions were tainted in each address space seen. In full mode, a log entry is written every time an instruction handling tainted data is executed, along with the callstack at that point. The logs for full mode can get rather large.
 * `num`: uint64.  Number of tainted instructions to log or summarize.  The default (0) means there is no limit.  Note that if `tainted_instr` sees the same tainted instruction reported mutiple times in a row, that this is counted as only one instruction.  For example, if taint change reports come in five times for tainted data on instruction 1, then three times for tainted data on instruction 2, then seven times for tainted data on instruction 1 again, and then four times for tainted data in instruction 3, then the number of tainted instructions seen will be 4, as there were four distinct runs.
+* `suppress_redundant_taint_reports`: boolean. When the pandalog is enabled, this option has no effect. Otherwise, when true, if there are multiple consecutive invocations of the taint\_change callback with the same program counter, only the first instance will be output. This reduces the amount of output this plugin generates. When false, the default value if this option is not provided, each unique taint change report will be output, which may result in the same program counter being reported multiple times in a row.
 
 Dependencies
 ------------


### PR DESCRIPTION
- Made globals static.
- Added "suppress_redundant_taint_reports" option. -- When enabled, won't output the same PC multiple times consecutively. -- Only used when pandalog is not enabled.
- In the for loop that computes num_tainted in taint_change: -- Exit early if not pandalogging.
-- Further looping in this case isn't necessary as output doesn't change.
- Removed redundant ifs.
- Fix memory leak (ti->taint_query allocated via malloc was not freed.)
- Save "pc = 0x..." generated string in case it can be reused.
- Moved assignments to last_asid and last_pc to avoid unnecessary assignments.