### PR TITLE
Bug fixes for -O3.

### DIFF
--- a/qapi/string-input-visitor.c
+++ b/qapi/string-input-visitor.c
@@ -252,7 +252,7 @@ static void parse_type_uint64(Visitor *v, const char *name, uint64_t *obj,
                               Error **errp)
 {
     /* FIXME: parse_type_int64 mishandles values over INT64_MAX */
-    int64_t i;
+    int64_t i=0;
     Error *err = NULL;
     parse_type_int64(v, name, &i, &err);
     if (err) {

--- a/qemu-io-cmds.c
+++ b/qemu-io-cmds.c
@@ -2197,7 +2197,7 @@ static void help_oneline(const char *cmd, const cmdinfo_t *ct)
     if (cmd) {
         printf("%s ", cmd);
     } else {
-        printf("%s ", ct->name);
+        printf("%s ", ct->name ? ct->name : "(ct->name==NULL!)");
         if (ct->altname) {
             printf("(or %s) ", ct->altname);
         }


### PR DESCRIPTION
Compiling at -O3 fails with warnings that don't occur at -O2. Might be related to inlining of function calls.