### PR TITLE
OSI: fix null ptr dereference when current thread is NULL

### DIFF
--- a/panda/plugins/osi/os_intro.c
+++ b/panda/plugins/osi/os_intro.c
@@ -180,9 +180,16 @@ OsiThread *get_current_thread(CPUState *cpu) {
     if((cachedInstructionCount != 0) &&
             (cachedInstructionCount == cpu->rr_guest_instr_count)) {
         thread=(OsiThread *) g_malloc(sizeof(*thread));
+        if (thread == NULL) {
+            return NULL;
+        }
         memcpy(thread, &cachedThread, sizeof(*thread));
     } else {
         PPP_RUN_CB(on_get_current_thread, cpu, &thread);
+        if (thread == NULL) {
+            // Returns NULL if OSI can't find the current thread
+            return NULL;
+        }
         cachedInstructionCount = cpu->rr_guest_instr_count;
         memcpy(&cachedThread, thread, sizeof(cachedThread));
     }


### PR DESCRIPTION
Previously we'd just get a segfault if OSI linux returned NULL as it can do [here](https://github.com/panda-re/panda/blob/dev/panda/plugins/osi_linux/osi_linux.cpp#L747-L752). This was introduced in #653.

This PR does not update OSI consumers to check if get_current_thread returns NULL, but we're slowly popping the stack on handling this rare condition.

```
Thread 53 "python3" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7f277bc3e700 (LWP 218)]
0x00007f279c23bb29 in get_current_thread () from /usr/local/lib/panda/mipsel/panda_osi.so
(gdb) x/i $pc
=> 0x7f279c23bb29 <get_current_thread+217>:     mov    (%rax),%rdx
(gdb) p $rax
$2 = 0
(gdb) bt
#0  0x00007f279c23bb29 in get_current_thread () from /usr/local/lib/panda/mipsel/panda_osi.so
#1  0x00007f279c138634 in ?? () from /usr/local/lib/panda/mipsel/panda_callstack_instr.so
#2  0x00007f279c1389b8 in before_block_exec () from /usr/local/lib/panda/mipsel/panda_callstack_instr.so
#3  0x00007f2738091733 in panda_callbacks_before_block_exec () from /usr/local/bin/libpanda-mipsel.so
#4  0x00007f27380f9d6b in cpu_exec () from /usr/local/bin/libpanda-mipsel.so
#5  0x00007f273811ca23 in ?? () from /usr/local/bin/libpanda-mipsel.so
#6  0x00007f27b6621609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f27b675b353 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```