### PR TITLE
Add PANDA_PLUGIN_PATH

### DIFF
--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -106,7 +106,10 @@ class Panda():
         self.qlog = QEMU_Log_Manager(self)
         self.build_dir = None
         prev_path = environ.get("PANDA_PLUGIN_PATH")
-        environ["PANDA_PLUGIN_PATH"] = plugin_path + (":" + prev_path if prev_path else "")
+        if plugin_path and prev_path:
+            environ["PANDA_PLUGIN_PATH"] = f"{plugin_path}:{prev_path}"
+        elif plugin_path:
+            environ["PANDA_PLUGIN_PATH"] = plugin_path
 
         self.serial_unconsumed_data = b''
 

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -105,7 +105,7 @@ class Panda():
         self.catch_exceptions=catch_exceptions
         self.qlog = QEMU_Log_Manager(self)
         self.build_dir = None
-        prev_path = environ["PANDA_PLUGIN_PATH"]
+        prev_path = environ.get("PANDA_PLUGIN_PATH")
         environ["PANDA_PLUGIN_PATH"] = plugin_path + (":" + prev_path if prev_path else "")
 
         self.serial_unconsumed_data = b''

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -105,7 +105,8 @@ class Panda():
         self.catch_exceptions=catch_exceptions
         self.qlog = QEMU_Log_Manager(self)
         self.build_dir = None
-        environ["PANDA_PLUGIN_PATH"] = f"{plugin_path}:{environ['PANDA_PLUGIN_PATH']}"
+        prev_path = environ["PANDA_PLUGIN_PATH"]
+        environ["PANDA_PLUGIN_PATH"] = plugin_path + (":" + prev_path if prev_path else "")
 
         self.serial_unconsumed_data = b''
 

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -263,7 +263,7 @@ class Panda():
         plugin_name_ffi = self.ffi.new("char[]", bytes(plugin_name, "utf-8"))
         plugin_path_ffi = self.libpanda.panda_plugin_path(plugin_name_ffi)
         plugin_path = self.ffi.string(plugin_path_ffi).decode("utf-8")
-        self.libpanda.g_free(plugin_path_ffi)
+        # TODO: self.libpanda.g_free(plugin_path_ffi)
         return self.plugin_path
 
     def get_build_dir(self):

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -105,7 +105,7 @@ class Panda():
         self.catch_exceptions=catch_exceptions
         self.qlog = QEMU_Log_Manager(self)
         self.build_dir = None
-        os.environ["PANDA_PLUGIN_PATH"] = f"{plugin_path}:{os.environ['PANDA_PLUGIN_PATH']}"
+        environ["PANDA_PLUGIN_PATH"] = f"{plugin_path}:{environ['PANDA_PLUGIN_PATH']}"
 
         self.serial_unconsumed_data = b''
 

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -264,7 +264,7 @@ class Panda():
         plugin_path_ffi = self.libpanda.panda_plugin_path(plugin_name_ffi)
         plugin_path = self.ffi.string(plugin_path_ffi).decode("utf-8")
         # TODO: self.libpanda.g_free(plugin_path_ffi)
-        return self.plugin_path
+        return plugin_path
 
     def get_build_dir(self):
         if self.build_dir is None:

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -105,7 +105,7 @@ class Panda():
         self.catch_exceptions=catch_exceptions
         self.qlog = QEMU_Log_Manager(self)
         self.build_dir = None
-        os.environ["PANDA_PLUGIN_PATH"] = f"{plugin_path}:{os.environ["PANDA_PLUGIN_PATH"]}"
+        os.environ["PANDA_PLUGIN_PATH"] = f"{plugin_path}:{os.environ['PANDA_PLUGIN_PATH']}"
 
         self.serial_unconsumed_data = b''
 

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -105,7 +105,7 @@ class Panda():
         self.catch_exceptions=catch_exceptions
         self.qlog = QEMU_Log_Manager(self)
         self.build_dir = None
-        self.plugin_path = plugin_path
+        os.environ["PANDA_PLUGIN_PATH"] = f"{plugin_path}:{os.environ["PANDA_PLUGIN_PATH"]}"
 
         self.serial_unconsumed_data = b''
 
@@ -259,18 +259,11 @@ class Panda():
         progress ("Panda args: [" + (" ".join(self.panda_args)) + "]")
     # /__init__
 
-    def get_plugin_path(self):
-        if self.plugin_path is None:
-            build_dir = self.get_build_dir()
-            rel_dir = pjoin(*[build_dir, self.arch_name+"-softmmu", "panda", "plugins"])
-
-            if build_dir == "/usr/local/bin/":
-                # Installed - use /usr/local/lib/panda/plugins
-                self.plugin_path = f"/usr/local/lib/panda/{self.arch_name}"
-            elif isdir(rel_dir):
-                self.plugin_path = rel_dir
-            else:
-                raise ValueError(f"Could not find plugin path. Build dir={build_dir}")
+    def get_plugin_path(self, plugin_name):
+        plugin_name_ffi = self.ffi.new("char[]", bytes(plugin_name, "utf-8"))
+        plugin_path_ffi = self.libpanda.panda_plugin_path(plugin_name_ffi)
+        plugin_path = self.ffi.string(plugin_path_ffi).decode("utf-8")
+        self.libpanda.g_free(plugin_path_ffi)
         return self.plugin_path
 
     def get_build_dir(self):
@@ -946,7 +939,7 @@ class Panda():
             libpanda_path_chr = self.ffi.new("char[]",bytes(self.libpanda_path, "UTF-8"))
             self.__did_load_libpanda = self.libpanda.panda_load_libpanda(libpanda_path_chr)
         if not name in self.plugins.keys():
-            plugin = pjoin(*[self.get_plugin_path(), f"panda_{name}.so"])
+            plugin = self.get_plugin_path(name)
             assert(isfile(plugin))
             self.plugins[name] = self.ffi.dlopen(plugin)
 

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -371,8 +371,8 @@ char* resolve_file_from_plugin_directory(const char* file_name_fmt, const char* 
     gchar **panda_plugin_path = g_strsplit(g_getenv("PANDA_PLUGIN_PATH"), ":", -1);
     for (gchar **dir = panda_plugin_path; *dir; dir++) {
         gchar *plugin_path = attempt_normalize_path(g_strdup_printf(
-                                    "%s/%s", *dir,
-                                    name_formatted));
+                                    "%s/%s/%s", *dir,
+                                    TARGET_NAME, name_formatted));
         if (TRUE == g_file_test(plugin_path, G_FILE_TEST_EXISTS)) {
             g_strfreev(panda_plugin_path);
             return plugin_path;

--- a/panda/src/callbacks.c
+++ b/panda/src/callbacks.c
@@ -371,7 +371,7 @@ char* resolve_file_from_plugin_directory(const char* file_name_fmt, const char* 
     gchar **panda_plugin_path = g_strsplit(g_getenv("PANDA_PLUGIN_PATH"), ":", -1);
     for (gchar **dir = panda_plugin_path; *dir; dir++) {
         gchar *plugin_path = attempt_normalize_path(g_strdup_printf(
-                                    "%s/panda/plugins/%s", *dir,
+                                    "%s/%s", *dir,
                                     name_formatted));
         if (TRUE == g_file_test(plugin_path, G_FILE_TEST_EXISTS)) {
             g_strfreev(panda_plugin_path);


### PR DESCRIPTION
Add a colon-separated `PANDA_PLUGIN_PATH` environment variable for specifying plugin directories similar to `PATH`, `PYTHONPATH`, and `LD_LIBRARY_PATH`.