### PR TITLE
Add error message when volatility profile is empty

### DIFF
--- a/panda/plugins/cosi/volatility_profile/src/lib.rs
+++ b/panda/plugins/cosi/volatility_profile/src/lib.rs
@@ -171,8 +171,12 @@ pub struct VolatilityJson {
 impl VolatilityJson {
     pub fn from_compressed_file(filename: impl AsRef<Path>) -> VolatilityJson {
         //pub fn from_compressed_file(filename: std::fs::File) -> VolatilityJson {
-        let mut f = BufReader::new(File::open(filename).unwrap());
-        //let mut f = BufReader::new(filename);
+        let file = File::open(filename).unwrap();
+        if file.metadata().unwrap().len() == 0 {
+            panic!("cosi volatility profile empty");
+        }
+
+        let mut f = BufReader::new(file);
         let mut decomp = Vec::new();
         lzma_rs::xz_decompress(&mut f, &mut decomp).unwrap();
         let s = String::from_utf8_lossy(&decomp);


### PR DESCRIPTION
Previously this gave an unhelpful error message, leading to users of MIPS64.