### PR TITLE
Fixed bug in use of string search file

### DIFF
--- a/panda/plugins/stringsearch/stringsearch.cpp
+++ b/panda/plugins/stringsearch/stringsearch.cpp
@@ -290,18 +290,28 @@ bool init_plugin(void *self) {
                 strlens[num_strings] = i;
             }
 
-            printf("stringsearch: added string of length %d to search set\n", strlens[num_strings]);
+             printf("stringsearch: added string %d of length %d to search set\n", num_strings,  strlens[num_strings]);
+            printf("[");
+            for (int i=0; i<strlens[num_strings]; i++) {
+                if (isprint(tofind[num_strings][i]))
+                    printf("%c", tofind[num_strings][i]);
+                else 
+                    printf(".");
+            }
+            printf("]\n");
+
+            if (num_strings == 1) {
+                // First string - enable callback
+                panda_enable_callback(self, PANDA_CB_VIRT_MEM_AFTER_READ,  pcb_memread);
+                panda_enable_callback(self, PANDA_CB_VIRT_MEM_AFTER_WRITE, pcb_memwrite);
+            }
 
             if(++num_strings >= MAX_STRINGS) {
                 printf("WARN: maximum number of strings (%d) reached, will not load any more.\n", MAX_STRINGS);
                 break;
             }
         }
-        if (num_strings == 1) {
-            // First string - enable callback
-            panda_enable_callback(self, PANDA_CB_VIRT_MEM_AFTER_READ,  pcb_memread);
-            panda_enable_callback(self, PANDA_CB_VIRT_MEM_AFTER_WRITE, pcb_memwrite);
-        }
+        
     }
 
     std::string matchfile = prefix;


### PR DESCRIPTION
There was a bug that meant if you used a search strings file with other than exactly one search string (two, three, etc) then the relevant mem callbacks would never get registered meaning nothing would get searched for. Basically, the `num_strings==1` test was outside a loop (the one that increments num_strings) when it should have been inside it.