### PR TITLE
Guard calls to WindowsProcessManager::initialize

### DIFF
--- a/panda/plugins/wintrospection/wintrospection.cpp
+++ b/panda/plugins/wintrospection/wintrospection.cpp
@@ -631,11 +631,14 @@ void on_has_mapping_prefix(CPUState *cpu, OsiProc *p, const char *prefix,
 ****************************************************************** */
 
 void task_change(CPUState *cpu) {
-  g_process_manager.reset(new WindowsProcessManager());
-
+  if(last_seen_paddr != 0) {
+    g_process_manager.reset(new WindowsProcessManager());
+  }
   auto kernel = g_kernel_manager->get_kernel_object();
   last_seen_paddr = kosi_get_current_process_address(kernel);
-  g_process_manager->initialize(kernel, last_seen_paddr);
+  if(last_seen_paddr != 0) {
+    g_process_manager->initialize(kernel, last_seen_paddr);
+  }
 
   notify_task_change(cpu);
 }


### PR DESCRIPTION
In task_change(), wintrospection calls WindowsProcessManager::initialize and passes it the return value from kosi_get_current_process_address(). When this value is 0, the WindowsProcessManager object is left in an uninitialized state, and this warning message is printed:

    Must provdied either the address or the pid of the process

Since we know before calling initialize whether or not the result will be successful, an if was added around the call.  This results in the warning message not being printed.  In some usages this warning would be printed repeatedly.

Another if was added around the code that creates a new WindowsProcessManager.  If we know the current WindowsProcessManager has not been initialized it can be reused instead of creating a new instance.

The end result should be the same behavior as before, but without the the warning message repeatedly printed to stderr.