### PR TITLE
osi_linux/kernelinfo_gdb: Ignore print_offset() errors

### DIFF
--- a/panda/plugins/osi_linux/utils/kernelinfo_gdb/extract_kernelinfo.py
+++ b/panda/plugins/osi_linux/utils/kernelinfo_gdb/extract_kernelinfo.py
@@ -10,8 +10,11 @@ def print_size(structv, cfgmemb, cfgname):
     print(f"{cfgname}.{cfgmemb} = {size}",file=file_out)
 
 def print_offset(structp, memb, cfgname):
-    offset = gdb.execute(f'printf "%d",(int)&(({structp}*)0)->{memb}',to_string=True)
-    print(f"{cfgname}.{memb}_offset = {offset}",file=file_out)
+    try:
+        offset = gdb.execute(f'printf "%d",(int)&(({structp}*)0)->{memb}',to_string=True)
+        print(f"{cfgname}.{memb}_offset = {offset}",file=file_out)
+    except gdb.error:
+        pass
 
 def print_offset_from_member(structp, memb_base, memb_dest, cfgname):
     offset = gdb.execute(f'printf "%lld", (int64_t)&(({structp})*0)->{memb_dest} - (int64_t)&(({structp})*0)->{memb_base}',to_string=True)


### PR DESCRIPTION
Fixes part of #1422. If a struct field is deleted, kernelinfo_gdb will do the best it can instead of erroring and outputting nothing. Higher-level plugins that need to get a list of threads and need to be compatible with newer kernels can implement their own handling on top of this.