### PR TITLE
PyPANDA: Fix syscall args list size

### DIFF
--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -37,7 +37,7 @@ INCLUDE_DIR_PYP = os.path.abspath(os.path.join(*[os.path.dirname(__file__), "pan
 INCLUDE_DIR_PAN = os.path.abspath(os.path.join(*[os.path.dirname(__file__), "..", "..", "include", "panda"])) # panda-git/panda/include/panda
 INCLUDE_DIR_CORE = os.path.abspath(os.path.join(*[os.path.dirname(__file__), "..", "..", "..", "include"]))   # panda-git/include
 
-GLOBAL_MAX_SYSCALL_ARG_SIZE = 64
+GLOBAL_MAX_SYSCALL_ARG_SIZE = 8
 GLOBAL_MAX_SYSCALL_ARGS = 17
 
 

--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -288,7 +288,7 @@ def compile(arch, bits, pypanda_headers, install, static_inc):
             int no;               /**< number */
             target_ptr_t asid;    /**< calling process asid */
             target_ptr_t retaddr; /**< return address */
-            uint8_t args[{GLOBAL_MAX_SYSCALL_ARG_SIZE}]
+            uint8_t args[{GLOBAL_MAX_SYSCALL_ARGS}]
                  [{GLOBAL_MAX_SYSCALL_ARG_SIZE}]; /**< arguments */
                  '''
         +'''


### PR DESCRIPTION
Before this change, accessing non-first syscall args in PyPANDA (such as in the below hook) gives incorrect bytes.

```python3
@panda.ppp("syscalls2", "on_all_sys_return2")
def all_sysret(cpu, pc, call, rp):
    print(list(rp.args[1]))
```