### PR TITLE
Fix off-by-1 error in stringsearch.

### DIFF
--- a/panda/plugins/stringsearch/stringsearch.cpp
+++ b/panda/plugins/stringsearch/stringsearch.cpp
@@ -300,7 +300,7 @@ bool init_plugin(void *self) {
             }
             printf("]\n");
 
-            if (num_strings == 1) {
+            if (num_strings == 0) {
                 // First string - enable callback
                 panda_enable_callback(self, PANDA_CB_VIRT_MEM_AFTER_READ,  pcb_memread);
                 panda_enable_callback(self, PANDA_CB_VIRT_MEM_AFTER_WRITE, pcb_memwrite);


### PR DESCRIPTION
Memory callbacks were not being enabled when using a stringsearch file that contained exactly one string. Enable callbacks when the first string is read from the file, not the second string.