### PR TITLE
Fix split_taps.py to work in python3

### DIFF
--- a/panda/scripts/split_taps.py
+++ b/panda/scripts/split_taps.py
@@ -5,9 +5,9 @@ import time
 
 def main(logfile, prefix, num_callers=1):
     if logfile.endswith('.gz'):
-        f = gzip.GzipFile(logfile)
+        f = gzip.open(logfile, mode='rt')
     else:
-        f = open(logfile)
+        f = open(logfile,'r')
 
     filemap = {}
 
@@ -21,9 +21,9 @@ def main(logfile, prefix, num_callers=1):
         callers = callers.split()
         fname = prefix + "." + ".".join( callers[-num_callers:] + [pc, stack_kind, sid_first, sid_second] ) + ".dat"
         if fname not in filemap:
-            filemap[fname] = open(fname,'a')
+            filemap[fname] = open(fname,'ab')
 
-        val = val.decode('hex')
+        val = bytes.fromhex(val)
         filemap[fname].write(val)
 
 if __name__ == "__main__":


### PR DESCRIPTION
split_taps.py does not work in python3, it mixes up byte arrays and strings and uses functionality not existing in python3.

This results in exceptions when trying to use it both for plain txt and for .gz files.

```
# ./split_taps.py write_tap_buffers.txt.gz out
Traceback (most recent call last):
  File "/usr/local/share/panda/scripts/split_taps.py", line 37, in <module>
    main(args.logfile, args.prefix, num_callers=args.callers)
  File "/usr/local/share/panda/scripts/split_taps.py", line 20, in main
    callers, pc, stack_kind, sid_first, sid_second, addr, n, val = line.strip().rsplit(" ", 7)
TypeError: a bytes-like object is required, not 'str'
```
And for non-gz:
```
./split_taps.py read_tap_buffers.txt out
Traceback (most recent call last):
  File "/usr/local/share/panda/scripts/split_taps.py", line 37, in <module>
    main(args.logfile, args.prefix, num_callers=args.callers)
  File "/usr/local/share/panda/scripts/split_taps.py", line 26, in main
    val = val.decode('hex')
AttributeError: 'str' object has no attribute 'decode'
```