### PR TITLE
CallstackInstr: switch to SBE/EBE callbacks

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -55,10 +55,8 @@ extern "C" {
 #include "panda/plog.h"
 #include "callstack_instr_int_fns.h"
 
-bool translate_callback(CPUState* cpu, target_ulong pc);
-int exec_callback(CPUState* cpu, target_ulong pc);
-void before_block_exec(CPUState* cpu, TranslationBlock *tb);
-void after_block_exec(CPUState* cpu, TranslationBlock *tb, uint8_t exitCode);
+void start_block_exec(CPUState* cpu, TranslationBlock *tb);
+void end_block_exec(CPUState* cpu, TranslationBlock *tb);
 void after_block_translate(CPUState* cpu, TranslationBlock *tb);
 
 bool init_plugin(void *);
@@ -322,7 +320,7 @@ void after_block_translate(CPUState *cpu, TranslationBlock *tb) {
     return;
 }
 
-void before_block_exec(CPUState *cpu, TranslationBlock *tb) {
+void start_block_exec(CPUState *cpu, TranslationBlock *tb) {
   // if the block a call returns to was interrupted before it completed, this
   // function will be called twice - only want to remove the return value from
   // the stack once
@@ -366,7 +364,7 @@ void before_block_exec(CPUState *cpu, TranslationBlock *tb) {
   }
 }
 
-void after_block_exec(CPUState* cpu, TranslationBlock *tb, uint8_t exitCode) {
+void end_block_exec(CPUState* cpu, TranslationBlock *tb) {
     target_ulong pc = 0x0;
     target_ulong cs_base = 0x0;
     uint32_t flags = 0x0;
@@ -377,35 +375,19 @@ void after_block_exec(CPUState* cpu, TranslationBlock *tb, uint8_t exitCode) {
 
     // sometimes an attempt to run a block is interrupted, but this callback is
     // still made - only update the callstack if the block has run to completion
-    if (exitCode <= TB_EXIT_IDX1) {
-        if (tb_type == INSTR_CALL) {
-            stack_entry se = {tb->pc + tb->size, tb_type};
-            callstacks[curStackid].push_back(se);
+    if (tb_type == INSTR_CALL) {
+        stack_entry se = {tb->pc + tb->size, tb_type};
+        callstacks[curStackid].push_back(se);
 
-            // Also track the function that gets called
-            // This retrieves the pc in an architecture-neutral way
-            cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
-            function_stacks[curStackid].push_back(pc);
-
-            PPP_RUN_CB(on_call, cpu, pc);
-        } else if (tb_type == INSTR_RET) {
-            //printf("Just executed a RET in TB " TARGET_FMT_lx "\n", tb->pc);
-            //if (next) printf("Next TB: " TARGET_FMT_lx "\n", next->pc);
-        }
-    }
-    // in case this block is one that a call returns to, need to node that its
-    // execution was interrupted, so don't try to remove it from the callstack
-    // when try (as already removed before this attempt)
-    else {
-        // verbose output is helpful in regression testing
-        if (tb_type == INSTR_CALL) {
-            verbose_log("callstack_instr not adding Stopped caller to stack",
-                    tb, curStackid, true);
-        }
+        // Also track the function that gets called
+        // This retrieves the pc in an architecture-neutral way
         cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
-        // erase nicely does nothing if key DNE
-        stoppedInfo.erase(curStackid);
-        stoppedInfo[curStackid] = pc;
+        function_stacks[curStackid].push_back(pc);
+
+        PPP_RUN_CB(on_call, cpu, pc);
+    } else if (tb_type == INSTR_RET) {
+        //printf("Just executed a RET in TB " TARGET_FMT_lx "\n", tb->pc);
+        //if (next) printf("Next TB: " TARGET_FMT_lx "\n", next->pc);
     }
 }
 
@@ -611,9 +593,9 @@ bool init_plugin(void *self) {
 
     pcb.after_block_translate = after_block_translate;
     panda_register_callback(self, PANDA_CB_AFTER_BLOCK_TRANSLATE, pcb);
-    pcb.after_block_exec = after_block_exec;
+    pcb.end_block_exec = end_block_exec;
     panda_register_callback(self, PANDA_CB_AFTER_BLOCK_EXEC, pcb);
-    pcb.before_block_exec = before_block_exec;
+    pcb.start_block_exec = start_block_exec;
     panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
 
     bool setup_ok = true;


### PR DESCRIPTION
The old callstack instr logic would miss many calls if tb_chaining was enabled (which is is by default). Since this plugin did not disable tb_chaining, many calls would be missed if a user didn't disable chaining or load another plugin that disabled chaining.

This commit updates the plugin to use start_block_exec and end_block_exec which work even with tb_chaining enabled.

Thanks to @lacraig2 for suggesting this fix.

Hopefully fixes #1443.

One slight concern about this change is how the EBE callback works with interrupts - I know ABE is triggered when a block is interrupted and callbacks are infored of this through the `exitCode` arg which callstack_instr was checking. If EBE is just not called when this happens, this updated code will be correct. Otherwise, if it's still called on these weird "end" blocks, I'm not sure these changes will be correct.