### PR TITLE
Update publish to include Pypanda

### DIFF
--- a/.github/workflows/publish_deb.yml
+++ b/.github/workflows/publish_deb.yml
@@ -51,7 +51,7 @@ jobs:
             panda/debian/pandare-*.whl
           asset_name: |
             pandare_${{ matrix.ubuntu_version }}.deb
-            pandare-$(echo "$(ls panda/dist/panda_re-*.whl)" | sed 's/^.*\/\(.*\)/\1/')
+            pandare-$(echo "$(ls panda/debian/pandare-*.whl)" | sed 's/^.*pandare-//')
           asset_content_type: |
             application/vnd.debian.binary-package
             application/octet-stream

--- a/.github/workflows/publish_deb.yml
+++ b/.github/workflows/publish_deb.yml
@@ -40,12 +40,18 @@ jobs:
         working-directory: panda/debian
         run: ./setup.sh Ubuntu ${{ matrix.ubuntu_version }}
 
-      - name: Upload to release
+      - name: Upload packages to release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: panda/debian/pandare.deb
-          asset_name: pandare_${{ matrix.ubuntu_version }}.deb
-          asset_content_type: application/vnd.debian.binary-package
+          asset_path: |
+            panda/debian/pandare_${{ matrix.ubuntu_version }}.deb
+            panda/debian/pandare-*.whl
+          asset_name: |
+            pandare_${{ matrix.ubuntu_version }}.deb
+            pandare-$(echo "$(ls panda/dist/panda_re-*.whl)" | sed 's/^.*\/\(.*\)/\1/')
+          asset_content_type: |
+            application/vnd.debian.binary-package
+            application/octet-stream


### PR DESCRIPTION
Every time a Debian package release is created, the pypanda release should also be released as well. This would be important as when updating LAVA, I need both pypanda and the panda debian package to correctly install LAVA.

NOTE:
I have not been able to fully test this locally if the release correctly publishes the wheel.

Also, it is IMPORTANT that the whl file name not change!

Right now if you change the file name 'pandare-0.1.2.0-py3-none-any.whl' to anything else, pip will not correctly install pypanda.
This is reflected on $(echo "$(ls panda/debian/pandare-*.whl)" | sed 's/^.*pandare-//') to just get the '0.1.2.0-py3-none-any.whl' to append to the 'pandare-' package.

P. S.
Might also not be a bad idea to change 'publish_debian' to just 'publish'