### PR TITLE
Automatic versioning on dev

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -22,19 +22,24 @@ jobs:
       uses: actions/checkout@v4
       with:
           fetch-depth: 0
+    - name: Get next version
+      uses: reecetech/version-increment@2023.10.1
+      id: version
+      with:
+        release_branch: dev
     - name: Build panda:latest
       uses: docker/build-push-action@v5
       with:
         push: true
         context: ${{ github.workspace }}
-        tags: pandare/panda:${{ github.sha }}, pandare/panda:latest
+        tags: pandare/panda:${{ github.sha }}, pandare/panda:${{ steps.version.outputs.v-version }}, pandare/panda:latest
         target: panda
     - name: Build pandadev:latest
       uses: docker/build-push-action@v5
       with:
         push: true
         context: ${{ github.workspace }}
-        tags: pandare/pandadev:${{ github.sha }}, pandare/pandadev:latest
+        tags: pandare/pandadev:${{ github.sha }}, pandare/pandadev:${{ steps.version.outputs.v-version }}, pandare/pandadev:latest
         target: developer
 
     - name: Checkout docs and reset
@@ -61,6 +66,11 @@ jobs:
            git add . &&
            git commit -m "Documentation update for PANDA commit ${{ github.sha  }} branch dev" &&
            git push || true
+    - name: Push tag
+      uses: actions-ecosystem/action-push-tag@v1
+      with:
+        tag: ${{ steps.version.outputs.v-version }}
+        message: '${{ steps.version.outputs.v-version }}'
 
   build_stable:
     if: github.repository  == 'panda-re/panda' && github.ref == 'refs/heads/stable'


### PR DESCRIPTION
This PR allows PANDA to automatically pick new incrementing versions and triggers a deb package release by pushing a new tag.

It also begins to tag our docker releases with those incrementing versions.