### PR TITLE
Make errors on return type much harder to achieve in PyPANDA

### DIFF
--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -2733,7 +2733,13 @@ class Panda():
                         #print(pandatype, type(r)) # XXX Can we use pandatype to determine requried return and assert if incorrect
                         #assert(isinstance(r, int)), "Invalid return type?"
                         #print(fun, r) # Stuck with TypeError in _run_and_catch? Enable this to find where the bug is.
-                        return r
+                        if return_type:
+                            try:
+                                return self.ffi.cast(return_type, r)
+                            except TypeError:
+                                print("TypeError in _run_and_catch")
+                                # consider throwing an exception
+                                return self.ffi.cast(return_type, 0)
                     except Exception as e:
                         # exceptions wont work in our thread. Therefore we print it here and then throw it after the
                         # machine exits.
@@ -2746,6 +2752,11 @@ class Panda():
 
             cast_rc = pandatype(_run_and_catch)
             cast_rc_string = str(self.ffi.typeof(cast_rc))
+            return_type = self.ffi.typeof(cast_rc).result
+            
+            if return_type.cname == "void":
+                return_type = None
+            
             return_from_exception = 0
             if "void(*)(" in cast_rc_string:
                 return_from_exception = None

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -2984,11 +2984,12 @@ class Panda():
                         r = fun(*args, **kwargs)
                         #print(pandatype, type(r)) # XXX Can we use pandatype to determine requried return and assert if incorrect
                         #assert(isinstance(r, int)), "Invalid return type?"
-                        try:
-                            return self.ffi.cast(return_type, r)
-                        except TypeError:
-                            # consider throwing an exception
-                            return self.ffi.cast(return_type, 0)
+                        if return_type is not None:
+                            try:
+                                return self.ffi.cast(return_type, r)
+                            except TypeError:
+                                # consider throwing an exception
+                                return self.ffi.cast(return_type, 0)
                     except Exception as e:
                         # exceptions wont work in our thread. Therefore we print it here and then throw it after the
                         # machine exits.


### PR DESCRIPTION
This is a draft for code that would need to be propagated to other parts of PyPANDA to make it much harder for callbacks to error on the incorrect type returned from a callback.

In this case we move the type conversion that cffi would do upon return of our outer callback wrapper to the forefront and check it for errors. If there is an error we make an explicit offering of a type cast from zero.

This should be handled in the other _run_and_catch functions. It should also have a better policy on errors. Printing every time is annoying, but some feedback is useful.