### PR TITLE
Replace gnutls-dev in ubuntu_20.04_build.txt to use exact package

### DIFF
--- a/panda/dependencies/ubuntu_18.04_build.txt
+++ b/panda/dependencies/ubuntu_18.04_build.txt
@@ -36,7 +36,7 @@ nasm
 
 # Qemu build deps
 device-tree-compiler
-gnutls-dev
+libgnutls28-dev
 libaio-dev
 libasound2-dev
 libattr1-dev

--- a/panda/dependencies/ubuntu_20.04_build.txt
+++ b/panda/dependencies/ubuntu_20.04_build.txt
@@ -33,7 +33,7 @@ nasm
 # Qemu build deps
 debhelper
 device-tree-compiler
-gnutls-dev
+libgnutls28-dev
 libaio-dev
 libasound2-dev
 libattr1-dev

--- a/panda/dependencies/ubuntu_22.04_build.txt
+++ b/panda/dependencies/ubuntu_22.04_build.txt
@@ -33,7 +33,7 @@ nasm
 # Qemu build deps
 debhelper
 device-tree-compiler
-gnutls-dev
+libgnutls28-dev
 libaio-dev
 libasound2-dev
 libattr1-dev


### PR DESCRIPTION
`gnutls-dev` is actually a virtual package, and could resolve to multiple package such as `libgnutls-dev` and `libgnutls28-dev`, which could lead to installation abortion and user would need to select the exact `gnutls` package in order to proceed.

This PR seeks to replace this virtual package to use the exact package `libgnutls28-dev`
![image](https://github.com/panda-re/panda/assets/36411557/6f205f43-5bc0-4a52-a2cc-1770f1a0c983)
