### PR TITLE
Allow larger kernel cmdline for MIPS Malta

### DIFF
--- a/hw/mips/mips_malta.c
+++ b/hw/mips/mips_malta.c
@@ -62,7 +62,7 @@
 
 #define ENVP_ADDR		0x80002000l
 #define ENVP_NB_ENTRIES	 	16
-#define ENVP_ENTRY_SIZE	 	256
+#define ENVP_ENTRY_SIZE	 	0xfdc0
 
 /* Hardware addresses */
 #define FLASH_ADDRESS 0x1e000000ULL


### PR DESCRIPTION
Previously, a kernel cmdline longer than 256 bytes would be silently truncated. This PR increases that size to the maximum amount such that it doesn't overlap the kernel. (ARM seems to not have this issue, but the kernel has its own `COMMAND_LINE_SIZE` limit.)