### PR TITLE
Callstack_instr: disable TB chaining to improve accuracy

### DIFF
--- a/panda/plugins/callstack_instr/callstack_instr.cpp
+++ b/panda/plugins/callstack_instr/callstack_instr.cpp
@@ -615,6 +615,7 @@ bool init_plugin(void *self) {
     panda_register_callback(self, PANDA_CB_AFTER_BLOCK_EXEC, pcb);
     pcb.before_block_exec = before_block_exec;
     panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+    panda_disable_tb_chaining(); // TODO: if we switch to SBE style callbacks we can leave chaining enabled
 
     bool setup_ok = true;
 


### PR DESCRIPTION
#1447 switches callstack_instr to use start block exec callbacks instead of before block exec to fix an issue where tb chaining causes calls to be missed. That PR is based off a now-reverted change in #1445. Unfortunately the changes in #1447 have revealed some unexpected non-determinism around the SBE callback that we're trying to track down before merging it.

This PR acts as an interim fix for callstack_instr to improve its accuracy by ensuring tb chaining is disabled.