### PR TITLE
Fix versioning in wheel uploads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN cd /panda/panda/python/core && \
 RUN python3 -m pip install --ignore-install pycparser && python3 -m pip install --force-reinstall --no-binary :all: cffi
 # Build a whl too
 RUN cd /panda/panda/python/core && \
-    python3 setup.py bdist_wheel
+ SETUPTOOLS_SCM_LOCAL_SCHEME=no-local-version python3 setup.py bdist_wheel
 
 # BUG: PANDA sometimes fails to generate all the necessary files for PyPANDA. This is a temporary fix to detect and fail when this occurs
 RUN ls -alt $(pip show pandare | grep Location: | awk '{print $2}')/pandare/autogen/

--- a/panda/python/core/setup.py
+++ b/panda/python/core/setup.py
@@ -121,6 +121,17 @@ class custom_install(install_orig):
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+scm_local_scheme = "node-and-date"
+if "SETUPTOOLS_SCM_LOCAL_SCHEME" in os.environ:
+    local_scheme_values = [
+        "node-and-date",
+        "node-and-timestamp",
+        "dirty-tag",
+        "no-local-version",
+    ]
+    if os.environ["SETUPTOOLS_SCM_LOCAL_SCHEME"] in local_scheme_values:
+        scm_local_scheme = os.environ["SETUPTOOLS_SCM_LOCAL_SCHEME"]
+
 setup(name='pandare',
       description='Python Interface to PANDA',
       long_description=long_description,
@@ -129,6 +140,7 @@ setup(name='pandare',
                     "root": "../../..", 
                     "relative_to": __file__,
                     "fallback_version": "0.0.0.1",
+                    "local_scheme": scm_local_scheme,
                         },
       long_description_content_type="text/markdown",
       author='Andrew Fasano, Luke Craig, and Tim Leek',


### PR DESCRIPTION
PyPi does not allow the use of local versioning https://github.com/panda-re/panda/actions/runs/8561020755/job/23462413277#step:4:35

This seems to be failing with setuptools_scm

I have added code to get rid of the local version. Hopefully this will generate whl files that are acceptable to pypi