### PR TITLE
New Plugin: hypercaller

### DIFF
--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -20,6 +20,7 @@ gdb
 hooks
 hooks2
 hw_proc_id
+hypercaller
 keyfind
 libfi
 lighthouse_coverage

--- a/panda/plugins/hypercaller/Makefile
+++ b/panda/plugins/hypercaller/Makefile
@@ -1,0 +1,17 @@
+# Don't forget to add your plugin to config.panda!
+
+# If you need custom CFLAGS or LIBS, set them up here
+# CFLAGS+=
+# LIBS+=
+
+# Example: this plugin has runtime symbol dependencies on plugin_x:
+# LIBS+=-L$(PLUGIN_TARGET_DIR) -l:panda_plugin_x.so
+# Also create a plugin_plugin.d file in this directory to ensure plugin_x
+# gets compiled before this plugin, example contents:
+# plugin-this_plugins_name : plugin-plugin_x
+# or if you're using the extra plugins dir:
+# extra-plugin-this_plugins_name : extra-plugin-plugin_x
+
+# The main rule for your plugin. List all object-file dependencies.
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: \
+	$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o

--- a/panda/plugins/hypercaller/README.md
+++ b/panda/plugins/hypercaller/README.md
@@ -1,0 +1,17 @@
+Plugin: NAME
+===========
+
+Summary
+-------
+
+Arguments
+---------
+
+Dependencies
+------------
+
+APIs and Callbacks
+------------------
+
+Example
+-------

--- a/panda/plugins/hypercaller/README.md
+++ b/panda/plugins/hypercaller/README.md
@@ -1,17 +1,83 @@
-Plugin: NAME
+Plugin: `hypercaller`
 ===========
 
 Summary
 -------
 
+This plugin provides an interface for hypercalls from the guest. It establishes a basic interface for those hypercalls and simplifies the interactions.
+
+In particular, it presumes the following:
+
+- There is a single source for a message from a guest hypercall
+- The guest hypercall indicates the recipient for that message via a unique magic number
+- All magic numbers for interactions are unique
+
 Arguments
 ---------
+
+This plugin takes no arguments.
 
 Dependencies
 ------------
 
+This plugin has no external dependencies.
+
 APIs and Callbacks
 ------------------
 
+The plugin provides a simple interface for external plugins to register and unregister hypercalls. The interface is as follows:
+
+A function within a plugin can register a hypercall with the following signature:
+```
+typedef void (*hypercall_t)(CPUState *cpu);
+```
+
+It then passes a reference to this function to the `register_hypercall` function, along with a unique magic number that will be used to identify the hypercall.
+```
+void register_hypercall(uint32_t magic, hypercall_t);
+```
+
+To unregister a hypercall, the plugin can call the following function with the magic number that was used to register the hypercall:
+```
+void unregister_hypercall(uint32_t magic);
+```
+
 Example
 -------
+
+This was designed primarily for Python use cases:
+
+```Python
+MAGIC = 0x12345678
+@panda.hypercall(MAGIC)
+def hypercall(cpu):
+    print("Hello from my hypercall!"
+
+```
+
+
+It's much easier to handle this from Python, but here's an example of how you might use this plugin from a C plugin:
+
+
+
+```C
+#include <panda/plugin.h>
+#include <hypercaller/hypercaller.h>
+
+hypercall_t* register_hypercall;
+
+void my_hypercall(CPUState *cpu) {
+    printf("Hello from my hypercall!\n");
+}
+
+bool init_plugin(void *self) {
+    void *hypercaller = panda_get_plugin_by_name("hypercaller");
+    if (hypercaller == NULL){
+      panda_require("hypercaller");
+      hypercaller = panda_get_plugin_by_name("hypercaller");
+    }
+    register_hypercall = (hypercall_t*)dlsym(hypercaller, "register_hypercall");
+    register_hypercall(0x12345678, my_hypercall);
+    return true;
+}
+```

--- a/panda/plugins/hypercaller/hypercaller.cpp
+++ b/panda/plugins/hypercaller/hypercaller.cpp
@@ -1,0 +1,76 @@
+/* PANDABEGINCOMMENT
+ * 
+ * Authors:
+ * Luke Craig luke.craig@ll.mit.edu
+ * 
+ * This work is licensed under the terms of the GNU GPL, version 2. 
+ * See the COPYING file in the top-level directory. 
+ * 
+PANDAENDCOMMENT */
+// This needs to be defined before anything is included in order to get
+// the PRIx64 macro
+#define __STDC_FORMAT_MACROS
+
+#include "panda/plugin.h"
+#include <unordered_map>
+
+// These need to be extern "C" so that the ABI is compatible with
+// QEMU/PANDA, which is written in C
+extern "C" {
+bool init_plugin(void *);
+void uninit_plugin(void *);
+bool hypercall(CPUState *cpu);
+#include "hypercaller.h"
+}
+
+std::unordered_map<target_ulong, hypercall_t> hypercalls;
+
+void register_hypercall(target_ulong magic, hypercall_t hyp){
+    if (hypercalls.find(magic) == hypercalls.end()){
+        hypercalls[magic] = hyp;
+    }else{
+        assert(false && "Hypercall already registered");
+    }
+}
+
+void unregister_hypercall(target_ulong magic){
+    hypercalls.erase(magic);
+}
+
+target_ulong get_magic(CPUState *cpu){
+    target_ulong magic;
+    CPUArchState * env = (CPUArchState *)cpu->env_ptr;
+#if defined(TARGET_ARM)
+    // r0
+    magic =env->regs[0];
+#elif defined(TARGET_MIPS)
+    // a0
+    magic =env->active_tc.gpr[4];
+#elif defined(TARGET_I386)
+    // eax
+    magic = env->regs[R_EAX];
+#elif defined(TARGET_PPC)
+    // r0
+    magic = env->gpr[0];
+#else
+    #error "Unsupported target architecture"
+#endif
+    return magic;
+}
+
+bool guest_hypercall(CPUState *cpu) {
+    target_ulong magic = get_magic(cpu);
+    if (hypercalls.find(magic) != hypercalls.end()){
+        hypercalls[magic](cpu);
+        return true;
+    }
+    return false;
+}
+
+bool init_plugin(void *self) {
+    panda_cb pcb = { .guest_hypercall = guest_hypercall};
+    panda_register_callback(self, PANDA_CB_GUEST_HYPERCALL, pcb);
+    return true;
+}
+
+void uninit_plugin(void *self) {}

--- a/panda/plugins/hypercaller/hypercaller.h
+++ b/panda/plugins/hypercaller/hypercaller.h
@@ -1,0 +1,14 @@
+#ifndef __HYPERCALLER_H
+#define __HYPERCALLER_H
+// BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
+// api autogen needs it.  And don't put any compiler directives
+// between this and END_PYPANDA_NEEDS_THIS except includes of other
+// files in this directory that contain subsections like this one.
+
+typedef void (*hypercall_t)(CPUState *cpu);
+void register_hypercall(target_ulong magic, hypercall_t);
+void unregister_hypercall(target_ulong magic);
+
+// END_PYPANDA_NEEDS_THIS -- do not delete this comment!
+
+#endif

--- a/panda/plugins/hypercaller/hypercaller.h
+++ b/panda/plugins/hypercaller/hypercaller.h
@@ -6,8 +6,8 @@
 // files in this directory that contain subsections like this one.
 
 typedef void (*hypercall_t)(CPUState *cpu);
-void register_hypercall(target_ulong magic, hypercall_t);
-void unregister_hypercall(target_ulong magic);
+void register_hypercall(uint32_t magic, hypercall_t);
+void unregister_hypercall(uint32_t magic);
 
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 

--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -381,6 +381,7 @@ def main(install=False,recompile=True):
     copy_ppp_header("%s/%s" % (PLUGINS_DIR+"/forcedexec",   "forcedexec_ppp.h"))
     copy_ppp_header("%s/%s" % (PLUGINS_DIR+"/stringsearch", "stringsearch_ppp.h"))
     create_pypanda_header("%s/%s" % (PLUGINS_DIR+"/hooks2", "hooks2.h"))
+    create_pypanda_header("%s/%s" % (PLUGINS_DIR+"/hypercaller", "hypercaller.h"))
     
     copy_ppp_header("%s/%s" % (PLUGINS_DIR+"/proc_start_linux", "proc_start_linux_ppp.h"))
     create_pypanda_header("%s/%s" % (PLUGINS_DIR+"/proc_start_linux", "proc_start_linux.h"))

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -3505,8 +3505,16 @@ class Panda():
                         return None
 
             hook_cb_passed = hypercall_cb_type(_run_and_catch)
-
-            self.plugins['hypercaller'].register_hypercall(magic, hook_cb_passed)
+            if type(magic) is int:
+                self.plugins['hypercaller'].register_hypercall(magic, hook_cb_passed)
+            elif type(magic) is list:
+                for m in magic:
+                    if type(m) is int:
+                        self.plugins['hypercaller'].register_hypercall(m, hook_cb_passed)
+                    else:
+                        raise TypeError("Magic list must consist of integers")
+            else:
+                raise TypeError("Magics must be either an int or list of ints")
 
             def wrapper(*args, **kw):
                 _run_and_catch(args,kw)
@@ -3516,7 +3524,12 @@ class Panda():
     
     def disable_hypercall(self, fn):
         if fn in self.hypercalls:
-            self.plugins['hypercaller'].unregister_hypercall(self.hypercalls[fn][1])
+            magic = self.hypercalls[fn][1]
+            if type(magic) is int:
+                self.plugins['hypercaller'].unregister_hypercall(magic)
+            elif type(magic) is list:
+                for m in magic:
+                    self.plugins['hypercaller'].unregister_hypercall(m)
         else:
             breakpoint()
             print("ERROR: Your hypercall was not in the hook list")


### PR DESCRIPTION
Much like hooks the hypercaller plugin is intended to marshal and discern the proper set of requests that should make their way to Python.

The reason is simple: performance. Without a layer of C code to act as a simple filter our Python code would be overused and our runtimes much slower.