### PR TITLE
Bump capstone version + aarch64 support in callstack_instr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,6 @@ RUN cd /tmp && \
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Sanity check to ensure cargo is installed
-RUN cargo --help
-
 # install libosi
 RUN cd /tmp && curl -LJO https://github.com/panda-re/libosi/releases/download/${LIBOSI_VERSION}/libosi_$(echo "$BASE_IMAGE" | awk -F':' '{print $2}').deb && dpkg -i /tmp/libosi_$(echo "$BASE_IMAGE" | awk -F':' '{print $2}').deb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN [ -e /tmp/build_dep.txt ] && \
 
 # Then install capstone from source
 RUN cd /tmp && \
-    git clone https://github.com/capstone-engine/capstone/ -b 4.0.2 && \
+    git clone https://github.com/capstone-engine/capstone/ -b v5 && \
     cd capstone/ && ./make.sh && make install && cd /tmp && \
     rm -rf /tmp/capstone && ldconfig
 

--- a/panda/python/examples/callstack_instr.py
+++ b/panda/python/examples/callstack_instr.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+from sys import argv
+from os import path
+from pandare import Panda
+
+arch = "x86_64" if len(argv) <= 1 else argv[1]
+panda = Panda(generic=arch)
+
+panda.load_plugin("callstack_instr", #{"verbose": "true"}
+        )
+
+@panda.ppp("callstack_instr", "on_call")
+def call_to(cpu, target):
+    print(hex(target))
+
+@panda.queue_blocking
+def driver():
+    panda.revert_sync("root")
+    print(panda.run_serial_cmd("whoami"))
+    panda.end_analysis()
+
+panda.run()


### PR DESCRIPTION
Previously aarch64 was hitting arm32 code and failing to identify any calls and returns. this PR updates that plugin to support aarch64 and also bumps the capstone version as our prior version failed to properly identify call/return groups for aarch64.

Adds a simple pypanda test for callstack instr.
Also has a commit dropping a needless call to `cargo help` while building the docker container.