### PR TITLE
Callwitharg: fix aarch64 support, add pypanda interface and test

### DIFF
--- a/panda/plugins/callwitharg/callwitharg.cpp
+++ b/panda/plugins/callwitharg/callwitharg.cpp
@@ -18,7 +18,7 @@ extern "C" {
 PPP_CB_BOILERPLATE(on_call_match_str);
 PPP_CB_BOILERPLATE(on_call_match_num);
 
-uint N;
+uint32_t N;
 bool verbose;
 void on_call_with_args(CPUState *cpu, target_ulong func_pc);
 
@@ -154,7 +154,7 @@ void on_call_with_args(CPUState *cpu, target_ulong func_pc) {
   }
 
   // Check the up to N arguments for matches
-  for (uint i=0; i < N; i++) {
+  for (uint32_t i=0; i < N; i++) {
     // Is argument a string or a number?
     if (have_nums) {
       if (int_targets.find(args.args[i]) != int_targets.end()) {

--- a/panda/plugins/callwitharg/callwitharg.cpp
+++ b/panda/plugins/callwitharg/callwitharg.cpp
@@ -98,9 +98,14 @@ typedef struct {
 } Arguments;
 
 bool _get_args_for_arch(CPUArchState *env, Arguments *args, int N) {
-#ifdef TARGET_ARM
+#if defined(TARGET_ARM) && !defined(TARGET_AARCH64)
   for (int i = 0; i < N; ++i) {
     args->args[i] = env->regs[i];
+  }
+#elif defined(TARGET_AARCH64)
+  for (int i = 0; i < N; ++i) {
+    // aarch64 uses xregs over regs
+    args->args[i] = env->xregs[i];
   }
 #elif defined(TARGET_MIPS)
   for (int i = 0; i < N; ++i) {

--- a/panda/plugins/callwitharg/callwitharg.h
+++ b/panda/plugins/callwitharg/callwitharg.h
@@ -1,15 +1,2 @@
-#ifndef __CALLWITHARG_H
-#define __CALLWITHARG_H
-
-// BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
-// api autogen needs it.  And don't put any compiler directives
-// between this and END_PYPANDA_NEEDS_THIS except includes of other
-// files in this directory that contain subsections like this one.
-
-PPP_CB_TYPEDEF(void, on_call_match_num, CPUState *env, target_ulong func_addr, target_ulong *args, uint matching_idx, uint args_read);
-PPP_CB_TYPEDEF(void, on_call_match_str, CPUState *env, target_ulong func_addr, target_ulong *args, char* value, uint matching_idx, uint args_read);
-
-// END_PYPANDA_NEEDS_THIS -- do not delete this comment!
-
-#endif
+#include "callwitharg_ppp.h"
 

--- a/panda/plugins/callwitharg/callwitharg_ppp.h
+++ b/panda/plugins/callwitharg/callwitharg_ppp.h
@@ -1,0 +1,15 @@
+#ifndef __CALLWITHARG_H
+#define __CALLWITHARG_H
+
+// BEGIN_PYPANDA_NEEDS_THIS -- do not delete this comment bc pypanda
+// api autogen needs it.  And don't put any compiler directives
+// between this and END_PYPANDA_NEEDS_THIS except includes of other
+// files in this directory that contain subsections like this one.
+
+PPP_CB_TYPEDEF(void, on_call_match_num, CPUState *env, target_ulong func_addr, target_ulong *args, uint32_t matching_idx, uint32_t args_read);
+PPP_CB_TYPEDEF(void, on_call_match_str, CPUState *env, target_ulong func_addr, target_ulong *args, char* value, uint32_t matching_idx, uint32_t args_read);
+
+// END_PYPANDA_NEEDS_THIS -- do not delete this comment!
+
+#endif
+

--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -305,6 +305,7 @@ def compile(arch, bits, pypanda_headers, install, static_inc):
     define_clean_header(ffi, include_dir + "/proc_start_linux_ppp.h")
     define_clean_header(ffi, include_dir + "/forcedexec_ppp.h")
     define_clean_header(ffi, include_dir + "/stringsearch_ppp.h")
+    define_clean_header(ffi, include_dir + "/callwitharg_ppp.h")
     # END PPP headers
 
     define_clean_header(ffi, include_dir + "/breakpoints.h")
@@ -378,6 +379,7 @@ def main(install=False,recompile=True):
 
     copy_ppp_header("%s/%s" % (PLUGINS_DIR+"/hooks2", "hooks2_ppp.h"))
     # TODO: programtically copy anything that ends with _ppp.h
+    copy_ppp_header("%s/%s" % (PLUGINS_DIR+"/callwitharg",   "callwitharg_ppp.h"))
     copy_ppp_header("%s/%s" % (PLUGINS_DIR+"/forcedexec",   "forcedexec_ppp.h"))
     copy_ppp_header("%s/%s" % (PLUGINS_DIR+"/stringsearch", "stringsearch_ppp.h"))
     create_pypanda_header("%s/%s" % (PLUGINS_DIR+"/hooks2", "hooks2.h"))

--- a/panda/python/examples/callwitharg.py
+++ b/panda/python/examples/callwitharg.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Run the date command in the guest, identify all strings compared to 'America',
+# since that's the start of the timezone we set. We should see relevant strings
+# like EDT or EST in a comparison at some point.
+
+from sys import argv
+from os import path
+from pandare import Panda
+
+LOG_ALL = False
+LOG_UNIQUE = True
+
+arch = "x86_64" if len(argv) <= 1 else argv[1]
+panda = Panda(generic=arch)
+
+panda.load_plugin("callstack_instr")
+panda.load_plugin("callwitharg", {"targets": "America", "verbose": False})
+interesting_args = set()
+
+@panda.ppp("callwitharg", "on_call_match_str")
+def on_match(cpu, func_addr, args, str_match, match_idx, n_args_read):
+    # Report on every match
+
+    if LOG_ALL:
+        print(f"String match at {func_addr:x} for {panda.ffi.string(str_match)} in arg {match_idx}")
+        for i in range(n_args_read):
+            try:
+                str_arg = panda.read_str(cpu, args[i])
+            except ValueError:
+                str_arg = f"(error reading {args[i]:#x})"
+
+            print("\t", repr(str_arg))
+
+    if LOG_UNIQUE:
+        for i in range(n_args_read):
+            if i == match_idx:
+                continue
+            try:
+                str_arg = panda.read_str(cpu, args[i])
+            except ValueError:
+                continue
+            if len(str_arg):
+                interesting_args.add(str_arg)
+
+@panda.queue_blocking
+def driver():
+    panda.revert_sync("root")
+    print(panda.run_serial_cmd("TZ=America/New_York date"))
+    panda.end_analysis()
+
+panda.run()
+
+if LOG_UNIQUE:
+    for arg in interesting_args:
+        print(repr(arg))


### PR DESCRIPTION
This PR makes it so the callwitharg plugin can be used by pypanda and adds an example. It also fixes a bug where aarch64 arguments were being read incorrectly by the plugin.