### PR TITLE
gcov fix

### DIFF
--- a/panda/Makefile.panda.target
+++ b/panda/Makefile.panda.target
@@ -220,7 +220,7 @@ llvm-$(TARGET_MIPS64) += $(addprefix target/mips/,$(MIPS64_HELPERS))
 # only support mips64, not mipsel64
 llvmmorph-$(TARGET_MIPS64) += llvm-helpers-mips64.bc
 
-CLANG_FILTER = -Wold-style-declaration -fstack-protector-strong -Wno-error=cpp -g -O0 -O1 -O2 -O3 -mcx16 -Wno-shift-negative-value
+CLANG_FILTER = -Wold-style-declaration -fstack-protector-strong -Wno-error=cpp -g -O0 -O1 -O2 -O3 -mcx16 -Wno-shift-negative-value -fprofile-arcs -ftest-coverage
 QEMU_BC2FLAGS:=$(filter-out $(CLANG_FILTER),$(QEMU_CFLAGS) $(CFLAGS)) -O1 -I../target/$(TARGET_BASE_ARCH)
 %.bc2: %.c $(GENERATED_FILES)
 	$(call quiet-command,\


### PR DESCRIPTION
If --enable-gcov is passed to the configure script, PANDA displays this message and aborts when llvm is first enabled:

JIT session error: Symbols not found: [ llvm_gcov_init ]

This patch fixes that issue.