### PR TITLE
Fix the time-trevel feature (panda/docs/time-travel.md)

### DIFF
--- a/panda/docs/time-travel.md
+++ b/panda/docs/time-travel.md
@@ -9,7 +9,7 @@ $PANDA_PATH/build/x86_64-softmmu/panda-system-x86_64 -replay foo -S -s -panda ch
 
 To attach the GDB client and load PANDA commands, run
 ```
-gdb -x ~/panda/panda/scripts/gdbinit -ex 'target remote localhost:1234'
+gdb -x ~/panda/panda/scripts/gdbinit -ex 'target remote localhost:1234' [kernel binary path]
 ```
 
 ## Reverse execution

--- a/panda/scripts/gdbinit
+++ b/panda/scripts/gdbinit
@@ -1,8 +1,3 @@
-dir /home/raywang/lava32_ksyms/linux-3.2.51
-set substitute-path /build/linux-n2St39/ /home/raywang/lava32_ksyms/
-symbol-file /home/raywang/lava32_ksyms/usr/lib/debug/vmlinux-3.2.0-4-686-pae
-display/5i $pc
-
 set python print-stack full
 python
 


### PR DESCRIPTION
By cleaning panda/scripts/gdbinit from redundant commands fix time-traveling feature and ensure that it works according to the docs: panda/docs/time-travel.md.