### PR TITLE
Fix Upload for v4

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -55,14 +55,15 @@ jobs:
         with:
           tag_name: ${{ needs.create_release.outputs.v-version }}
           files: |
-            panda/debian/pandare-*.whl
-            panda/debian/pandare_*.deb
+            panda/debian/pandare*.whl
+            panda/debian/pandare*.deb
 
       - name: Store the PyPanda distribution packages
-        uses: actions/upload-artifact@v3
+        if: ${{ matrix.ubuntu_version == env.PANDA_CONTAINER_UBUNTU_VERSION }}
+        uses: actions/upload-artifact@v4
         with:
           name: pypanda
-          path: panda/debian/pandare-*.whl
+          path: panda/debian/pandare*.whl
           if-no-files-found: error
         
       - name: 'Login to Docker Registry'
@@ -137,8 +138,7 @@ jobs:
              git push || true
 
   publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
+    name: Publish Python 🐍 distribution 📦 to PyPI
     if: github.repository  == 'panda-re/panda' && github.ref == 'refs/heads/dev'
     needs:
     - build_release_assets


### PR DESCRIPTION
The reason why the upload for v4 failed is due to this.

https://github.com/actions/upload-artifact/issues/478

I am adding an if condition so uploading wheel only occurs once. Not sure if you need same version to upload and download too, that might be the cause of why the original hot fix might have failed.

Plus GitHub is going to deprecate version 3 for upload and download in November 2024, so I might as well get this hot fix in
https://github.com/actions/upload-artifact