### PR TITLE
Fix unloading of C plugins

### DIFF
--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -543,8 +543,9 @@ class Panda():
         self.running.set()
         self.libpanda.panda_run() # Give control to panda
         self.running.clear() # Back from panda's execution (due to shutdown or monitor quit)
-        self.unload_plugins() # Unload pyplugins and C plugins
+        self.unload_plugins() # Unload pyplugins
         self.delete_callbacks() # Unload any registered callbacks
+        self.libpanda.panda_unload_plugins() # Unload C plugins
         self.plugins = plugin_list(self)
         # Write PANDALOG, if any
         #self.libpanda.panda_cleanup_record()


### PR DESCRIPTION
https://github.com/panda-re/panda/commit/76b5d84a9155f95c69cfc03dade634a990aa83ea removed the direct call to `self.libpanda.panda_unload_plugins()`, introduced by <https://github.com/panda-re/panda/commit/bb83a2f6d270301542243c05d00db850796e3771>. As noted in the comment in `unload_plugins()` in that commit, that function doesn't unload C plugins during shutdown, so the direct call is still required.

(Or at least I assume that is what is happening - adding the call back fixes uninit calls for me anyways.)