### PR TITLE
Update all panda-rs plugins to latest version

### DIFF
--- a/panda/plugins/Cargo.lock
+++ b/panda/plugins/Cargo.lock
@@ -112,7 +112,7 @@ version = "0.1.0"
 dependencies = [
  "curl",
  "once_cell",
- "panda-re 0.46.1",
+ "panda-re",
  "regex",
  "volatility_profile",
 ]
@@ -124,7 +124,7 @@ dependencies = [
  "chumsky",
  "log",
  "once_cell",
- "panda-re 0.45.1",
+ "panda-re",
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ dependencies = [
  "gdbstub",
  "gdbstub_arch",
  "lazy_static",
- "panda-re 0.14.0",
+ "panda-re",
  "peg",
  "tabwriter",
 ]
@@ -514,28 +514,9 @@ dependencies = [
 
 [[package]]
 name = "panda-re"
-version = "0.14.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03153860245f365c1f01452404eddd0a0741beafd88acf6e6afe167d1ac6c874"
-dependencies = [
- "dirs",
- "glib-sys",
- "inventory",
- "lazy_static",
- "libloading",
- "panda-re-macros 0.10.0",
- "panda-re-sys 0.5.0",
- "paste",
- "strum 0.20.0",
- "strum_macros 0.20.1",
- "thiserror",
-]
-
-[[package]]
-name = "panda-re"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca671a99ad5cbfb16f9019548dd4bf85145c6e386b3b3989b1e1ed088dc9d032"
+checksum = "fa3072d536c4445015aaae6e37c0c668f61db6e75225cd2d068578c682e03fda"
 dependencies = [
  "array-init",
  "dirs",
@@ -544,45 +525,12 @@ dependencies = [
  "lazy_static",
  "libloading",
  "once_cell",
- "panda-re-macros 0.25.1",
- "panda-re-sys 0.7.0",
+ "panda-re-macros",
+ "panda-re-sys",
  "paste",
  "strum 0.20.0",
  "strum_macros 0.20.1",
  "thiserror",
-]
-
-[[package]]
-name = "panda-re"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758a684eb7563df43de73e64e2e96cc1b8233a4c2c55c47ecfaa59e5064239cb"
-dependencies = [
- "array-init",
- "dirs",
- "glib-sys",
- "inventory",
- "lazy_static",
- "libloading",
- "once_cell",
- "panda-re-macros 0.25.1",
- "panda-re-sys 0.7.0",
- "paste",
- "strum 0.20.0",
- "strum_macros 0.20.1",
- "thiserror",
-]
-
-[[package]]
-name = "panda-re-macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ebc6c9d873a7285c7a09bfe4c80dc80efa8d3ea28bcb18a1d6a933dd3242be"
-dependencies = [
- "darling",
- "doc-comment",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -597,12 +545,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "panda-re-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9fe3ab684d3cf027c816a724de1ea40373b6438dc2240d64bdca0ca99f2e01"
 
 [[package]]
 name = "panda-re-sys"
@@ -803,7 +745,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 name = "rust_skeleton"
 version = "0.1.0"
 dependencies = [
- "panda-re 0.46.1",
+ "panda-re",
 ]
 
 [[package]]
@@ -872,7 +814,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "once_cell",
- "panda-re 0.14.0",
+ "panda-re",
  "pyo3",
 ]
 

--- a/panda/plugins/Cargo.toml
+++ b/panda/plugins/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
 	"gdb",
 	"rust_skeleton",

--- a/panda/plugins/cosi/Cargo.toml
+++ b/panda/plugins/cosi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 once_cell = "1.8.0"
-panda-re = { version = "0.46.0", default-features = false }
+panda-re = { version = "0.47.0", default-features = false }
 regex = "1.5.4"
 curl = "0.4.44"
 volatility_profile = { path = "./volatility_profile" }

--- a/panda/plugins/cosi_strace/Cargo.toml
+++ b/panda/plugins/cosi_strace/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-panda-re = { version = "0.45.0", default-features = false }
+panda-re = { version = "0.47.0", default-features = false }
 chumsky = "0.8"
 log = "0.4"
 once_cell = "1"

--- a/panda/plugins/gdb/Cargo.toml
+++ b/panda/plugins/gdb/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-panda-re = { version = "0.14.0", default-features = false }
+panda-re = { version = "0.47.0", default-features = false }
 gdbstub = "0.5"
 lazy_static = "1.4.0"
 gdbstub_arch = "0.1.0"

--- a/panda/plugins/gdb/src/memory_map.rs
+++ b/panda/plugins/gdb/src/memory_map.rs
@@ -1,11 +1,11 @@
-use panda::prelude::*;
 use panda::plugins::osi::OSI;
+use panda::prelude::*;
 
-use std::ffi::CStr;
 use gdbstub::outputln;
+use std::ffi::CStr;
 
 pub(crate) fn print(cpu: &mut CPUState) {
-    let mut proc = OSI.get_current_process(cpu);
+    let mut proc = OSI.get_current_process(cpu).unwrap();
     let mappings = OSI.get_mappings(cpu, &mut *proc);
 
     println!("Memory map:");
@@ -33,7 +33,7 @@ pub(crate) fn print(cpu: &mut CPUState) {
 }
 
 pub(crate) fn print_to_gdb(cpu: &mut CPUState, mut out: impl std::fmt::Write) {
-    let mut proc = OSI.get_current_process(cpu);
+    let mut proc = OSI.get_current_process(cpu).unwrap();
     let mappings = OSI.get_mappings(cpu, &mut *proc);
 
     outputln!(out);

--- a/panda/plugins/gdb/src/monitor_commands/proc_info.rs
+++ b/panda/plugins/gdb/src/monitor_commands/proc_info.rs
@@ -1,10 +1,10 @@
-use panda::prelude::*;
 use panda::plugins::osi::OSI;
+use panda::prelude::*;
 
 use gdbstub::outputln;
 
 pub(crate) fn print(cpu: &mut CPUState, mut out: impl std::fmt::Write) {
-    let proc = OSI.get_current_process(cpu);
+    let proc = OSI.get_current_process(cpu).unwrap();
 
     outputln!(out);
     outputln!(out, "{}", proc.get_name());
@@ -13,6 +13,10 @@ pub(crate) fn print(cpu: &mut CPUState, mut out: impl std::fmt::Write) {
     outputln!(out, "ASID: {:#x?}", proc.asid);
     outputln!(out, "Parent PID: {}", proc.ppid);
     outputln!(out, "Creation time: {}", proc.create_time);
-    outputln!(out, "PC in shared library: {}", OSI.in_shared_object(cpu, &*proc));
+    outputln!(
+        out,
+        "PC in shared library: {}",
+        OSI.in_shared_object(cpu, &*proc)
+    );
     outputln!(out);
 }

--- a/panda/plugins/gdb/src/monitor_commands/proc_list.rs
+++ b/panda/plugins/gdb/src/monitor_commands/proc_list.rs
@@ -1,19 +1,21 @@
-use panda::prelude::*;
 use panda::plugins::osi::OSI;
+use panda::prelude::*;
 
 use gdbstub::outputln;
-use tabwriter::{TabWriter, Alignment};
+use tabwriter::{Alignment, TabWriter};
 
 use std::io::Write;
 
 pub(crate) fn print(cpu: &mut CPUState, mut out: impl std::fmt::Write) {
     let procs = OSI.get_processes(cpu);
-    let current_pid = OSI.get_current_process(cpu).pid;
+    let current_pid = OSI.get_current_process(cpu).unwrap().pid;
 
     outputln!(out);
 
     let output = Vec::new();
-    let mut output = TabWriter::new(output).padding(1).alignment(Alignment::Right);
+    let mut output = TabWriter::new(output)
+        .padding(1)
+        .alignment(Alignment::Right);
 
     let _ = writeln!(output, " \tPID\tASID\tParent\tCreate Time\tProcess Name");
     let _ = writeln!(output, " \t===\t====\t======\t===========\t============");

--- a/panda/plugins/rust_skeleton/Cargo.toml
+++ b/panda/plugins/rust_skeleton/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-panda-re = { version = "0.46.0", default-features = false }
+panda-re = { version = "0.47.0", default-features = false }
 
 [features]
 default = ["x86_64"]

--- a/panda/plugins/rust_skeleton/README.md
+++ b/panda/plugins/rust_skeleton/README.md
@@ -40,7 +40,7 @@ The dependencies section:
 
 ```toml
 [dependencies]
-panda-re = { version = "0.5", default-features = false }
+panda-re = { version = "0.47", default-features = false }
 ```
 
 To add a new dependency, add a new line in the form `name = "version"`.

--- a/panda/plugins/snake_hook/Cargo.toml
+++ b/panda/plugins/snake_hook/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-panda-re = { version = "0.14.0", default-features = false }
+panda-re = { version = "0.47.0", default-features = false }
 inline-python = { version = "0.12.0" }
 libc = "0.2.98"
 once_cell = "1"


### PR DESCRIPTION
Update all Rust plugins to `panda-re = "0.47"`, update changes needed from API breakage. 

This should:
- Fix some issues long fixed in panda-rs (such as issues with plugin init)
- Improve build times (by not building multiple versions of panda-rs)