### PR TITLE
Reduce memory usage when LLVM is enabled.

### DIFF
--- a/panda/include/panda/tcg-llvm.h
+++ b/panda/include/panda/tcg-llvm.h
@@ -163,7 +163,8 @@ class TCGLLVMTranslator {
     llvm::Value* getEnvOffsetPtr(int64_t offset, TCGTemp &temp);
 
     /* Function pass manager (used for optimizing the code) */
-    llvm::legacy::FunctionPassManager *m_functionPassManager;
+    std::unique_ptr<llvm::legacy::FunctionPassManager> m_functionPassManager =
+        nullptr;
 
     /* Count of generated translation blocks */
     int m_tbCount;
@@ -300,7 +301,7 @@ class TCGLLVMTranslator {
     }
 
     llvm::legacy::FunctionPassManager* getFunctionPassManager() const {
-        return m_functionPassManager;
+        return m_functionPassManager.get();
     }
 
     /* Code generation */

--- a/panda/llvm/helper_runtime.cpp
+++ b/panda/llvm/helper_runtime.cpp
@@ -55,7 +55,6 @@ namespace llvm {
  ***/
 
 char PandaCallMorphFunctionPass::ID = 0;
-static FunctionPass *cmfp;
 static RegisterPass<PandaCallMorphFunctionPass>
 Y("PandaCallMorph", "Change helper function calls to the the LLVM version");
 
@@ -138,6 +137,7 @@ void PandaHelperCallVisitor::visitCallInst(CallInst &I) {
 
 static void llvmCallMorphNewModuleCallback(Module *module,
         legacy::FunctionPassManager *functionPassManager) {
+    auto cmfp = new llvm::PandaCallMorphFunctionPass();
     functionPassManager->add(cmfp);
 }
 
@@ -196,8 +196,8 @@ void init_llvm_helpers() {
     tcg_llvm_translator->writeModule(mod_file.str().c_str());*/
 
     // Create call morph pass and add to function pass manager
-    llvm::cmfp = new llvm::PandaCallMorphFunctionPass();
-    fpm->add(llvm::cmfp);
+    auto cmfp = new llvm::PandaCallMorphFunctionPass();
+    fpm->add(cmfp);
     tcg_llvm_translator->addNewModuleCallback(
         &llvm::llvmCallMorphNewModuleCallback);
     helpers_initialized = true;

--- a/panda/llvm/tcg-llvm.cpp
+++ b/panda/llvm/tcg-llvm.cpp
@@ -159,7 +159,8 @@ TCGLLVMTranslator::TCGLLVMTranslator()
     m_eip = NULL;
     m_ccop = NULL;
 
-    m_functionPassManager = new legacy::FunctionPassManager(m_module.get());
+    m_functionPassManager = std::make_unique<legacy::FunctionPassManager>(
+        m_module.get());
 
     /*
     Note: if we want to use any of these, they also need to get added to the
@@ -1310,9 +1311,10 @@ void TCGLLVMTranslator::jitPendingModule()
 
     m_module = std::make_unique<Module>(("tcg-llvm" +
         std::to_string(m_tbCount)).c_str(), *m_context);
-    m_functionPassManager = new legacy::FunctionPassManager(m_module.get());
+    m_functionPassManager = std::make_unique<legacy::FunctionPassManager>(
+        m_module.get());
     for(auto cb : newModuleCallbacks) {
-        cb(m_module.get(), m_functionPassManager);
+        cb(m_module.get(), m_functionPassManager.get());
     }
 }
 
@@ -1511,10 +1513,7 @@ void TCGLLVMTranslator::generateCode(TCGContext *s, TranslationBlock *tb)
  */
 TCGLLVMTranslator::~TCGLLVMTranslator()
 {
-    if (m_functionPassManager) {
-        delete m_functionPassManager;
-        m_functionPassManager = nullptr;
-    }
+    m_functionPassManager = nullptr;
 
     /*if (llvm::llvm_is_multithreaded()) {
         LLVMStopMultithreaded();


### PR DESCRIPTION
Function pass manager objects were being created, but never destroyed.

When a function pass manager object is destroyed, it destroys all pass objects that have been registered.  Previously pass objects were being reused, which is why the pass managers were never being freed, but this results in a large memory leak.  This commit shuffles things around so the pass managers can be freed.

a891