### PR TITLE
DO NOT MERGE: Ubuntu 24 - LLVM 14 preview

### DIFF
--- a/configure
+++ b/configure
@@ -269,8 +269,8 @@ stack_protector=""
 git_submodules=""
 protobuf="yes"
 llvm="no"
-llvmdir="/usr/lib/llvm-11" # Default to try if unspecified
-llvmver="11"
+llvmdir="/usr/lib/llvm-14" # Default to try if unspecified
+llvmver="14"
 
 # Don't accept a target_list environment variable.
 unset target_list

--- a/panda/include/panda/tcg-llvm.h
+++ b/panda/include/panda/tcg-llvm.h
@@ -280,6 +280,9 @@ class TCGLLVMTranslator {
 
     void jitPendingModule();
 
+    llvm::LoadInst *createLoad(llvm::Value *Ptr, const llvm::Twine &Name = "",
+        bool isVolatile = false);
+
     public:
     TCGLLVMTranslator();
     ~TCGLLVMTranslator();

--- a/panda/plugins/config.panda
+++ b/panda/plugins/config.panda
@@ -31,7 +31,6 @@ memorymap
 memsavep
 mmio_trace
 net
-network
 osi
 osi_linux
 osi_test

--- a/panda/plugins/taint2/llvm_taint_lib.cpp
+++ b/panda/plugins/taint2/llvm_taint_lib.cpp
@@ -1788,7 +1788,7 @@ void PandaTaintVisitor::visitCallInst(CallInst &I) {
     insertCallBefore(I, deleteF, args);
 
     // And now copy taint for the arguments into the new frame
-    int numArgs = I.getNumArgOperands();
+    int numArgs = I.getNumOperands() - 1;
     for (int i = 0; i < numArgs; i++) {
         Value *arg = I.getArgOperand(i);
         int argBytes = getValueSize(arg);

--- a/panda/tools/helper_call_modifier.cpp
+++ b/panda/tools/helper_call_modifier.cpp
@@ -104,8 +104,9 @@ int main(int argc, char **argv) {
              * here: http://llvm.org/bugs/show_bug.cgi?id=11089
              */
             const AttributeList AS = newFunc->getAttributes();
-            newFunc->setAttributes(AS.removeAttribute(newFunc->getContext(),
-                AttributeList::FunctionIndex, Attribute::StackProtectReq));
+            newFunc->setAttributes(AS.removeAttributeAtIndex(
+                newFunc->getContext(), AttributeList::FunctionIndex,
+                Attribute::StackProtectReq));
             f->replaceAllUsesWith(newFunc);
             f->eraseFromParent();
         }


### PR DESCRIPTION

I managed to get PANDA built under Ubuntu 24, including an update to LLVM 14.
This isn't production ready quite yet, but it's a start.
I don't have the bandwidth to get this all the way to Ubuntu 24, but hoping with this initial work others can chip away at the problems that are left.
There are a lot of little issues that are nicely segregated, that would take me a while to research and fix all of them.  I suspect many of these have an easy solution, so I'm looking for help to move this along.

I'm not convinced yet the update to LLVM 14 is 100% correct - but I have a lots of test cases and most agree with the output from LLVM 11.  I have a few tests that are tightly coupled to the IR that gets generated, these will require some time to investigate whether or not the output I'm seeing in LLVM 14 is correct.  Luckily I know where the author of these tests works (@LauraLMann) so I know where to look for help.

I didn't even try to fire up PyPANDA - so I'm not sure what state it is in.

Known issues:
- When LLVM is enabled many warnings about unsupported intrinsics appear on the console.
- The libosi build takes a long time.
- LLVM 14 uses significantly more memory mapped regions than LLVM 11.
-- "wc -l /proc/\<panda pid\>/maps" to see what I mean.
-- Long running recordings with LLVM enabled may fail with out of memory errors.
-- You can increase the number of permitted memory mapped regions for a process by writing to /proc/sys/vm/max_map_count.  Doing this resolves the issue.
- configure must be run with --disable-werror.
- When installing required Ubuntu packages:
-- The Ubuntu 20 qemu package was renamed to qemu-system in Ubuntu 24.
-- I also installed llvm-14, llvm-14-doc, clang-14 & clang-tools-14.  (Not sure the clang packages are necessary - things might be building with clang-18 which was already installed in my Ubuntu 24 environment.)
- cmake is complaining loudly - but no fatal issues.
- There are warnings when compiling PANDA.
-- Many of these are about invalid escape sequences - at first glance it looks like these might be coming from python.
- Network plugin won't build.
-- Wireshark api changed, again.
