### PR TITLE
Syscalls2 Bugfix

### DIFF
--- a/panda/plugins/syscalls2/syscalls2.cpp
+++ b/panda/plugins/syscalls2/syscalls2.cpp
@@ -894,7 +894,7 @@ if (profile == PROFILE_LINUX_AARCH64) {
 if (profile == PROFILE_LINUX_MIPS64) {
     arch = "mips64";
 }else if (profile == PROFILE_LINUX_MIPS32){
-    arch = "mips32";
+    arch = "mips";
 }else if (profile == PROFILE_LINUX_MIPS64N32){
     arch = "mips64n32";
 }else{


### PR DESCRIPTION
The name of the DSO is mips not mips32 - which doesn't really match the overall pattern, but needs to be accurate regardless.