### PR TITLE
Updating and adding architecture support in pypanda.

### DIFF
--- a/hw/avatar/configurable_machine.c
+++ b/hw/avatar/configurable_machine.c
@@ -438,8 +438,9 @@ static void set_entry_point(QDict *conf, THISCPU *cpuu)
     cpuu->env.active_tc.PC = entry;
 
 #elif defined(TARGET_PPC)
+    cpuu->env.nip = entry;
     //Not implemented yet
-    fprintf(stderr, "Not yet implemented- can't start execution at 0x%x\n", entry);
+    //fprintf(stderr, "Not yet implemented- can't start execution at 0x%x\n", entry);
 #endif
 
 }

--- a/panda/python/core/pandare/panda.py
+++ b/panda/python/core/pandare/panda.py
@@ -37,7 +37,7 @@ from .panda_expect import Expect
 from .asyncthread import AsyncThread
 from .qcows_internal import Qcows
 from .qemu_logging import QEMU_Log_Manager
-from .arch import ArmArch, Aarch64Arch, MipsArch, Mips64Arch, X86Arch, X86_64Arch
+from .arch import ArmArch, Aarch64Arch, MipsArch, Mips64Arch, X86Arch, X86_64Arch, PowerPCArch
 from .cosi import Cosi
 from dataclasses import dataclass
 
@@ -150,6 +150,8 @@ class Panda():
             self.arch = MipsArch(self)
         elif self.arch_name in ["mips64"]:
             self.arch = Mips64Arch(self)
+        elif self.arch_name in ["ppc"]: 
+            self.arch = PowerPCArch(self)
         else:
             raise ValueError(f"Unsupported architecture {self.arch_name}")
         self.bits, self.endianness, self.register_size = self.arch._determine_bits()

--- a/target/ppc/translate_init.c
+++ b/target/ppc/translate_init.c
@@ -9814,6 +9814,7 @@ static void ppc_cpu_realizefn(DeviceState *dev, Error **errp)
         error_propagate(errp, local_err);
         return;
     }
+    cpu_reset(cs);
 
 #if !defined(CONFIG_USER_ONLY)
     cpu->cpu_dt_id = (cs->cpu_index / smp_threads) * max_smt
@@ -10247,7 +10248,19 @@ const char *ppc_cpu_lookup_alias(const char *alias)
 
 PowerPCCPU *cpu_ppc_init(const char *cpu_model)
 {
-    return POWERPC_CPU(cpu_generic_init(TYPE_POWERPC_CPU, cpu_model));
+    ObjectClass *cpu_oc; 
+    Object *cpuobj;
+
+    cpu_oc = cpu_class_by_name(TYPE_POWERPC_CPU, cpu_model);
+    if (cpu_oc == NULL) {
+        error_report("Unable to find CPU definition: %s", cpu_model);
+        exit(1); 
+    }
+    cpuobj = object_new(object_class_get_name(cpu_oc));
+    object_property_set_bool(cpuobj, true, "realized", &error_fatal);  
+    return POWERPC_CPU(cpuobj); 
+
+//return POWERPC_CPU(cpu_generic_init(TYPE_POWERPC_CPU, cpu_model));
 }
 
 /* Sort by PVR, ordering special case "host" last. */


### PR DESCRIPTION
This pull request exposes more of the CPU state for `x86` 32 and 64 bit (e.g. segment registers and mmr fields), fixes bug with `aarch64`, and adds `powerpc` support in both pypanda and panda. 

For `powerpc` support in panda, the `cpu_ppc_init` needs to properly create a cpu object (modeled after other implemented `cpu_{arch}_init` functions) and `ppc_cpu_realizefn` needs to properly initialize that cpu state. If `cpu_reset()` is not added here, then we will fault because our `cpu->exception_index` is not properly initialized to `-1` (it stays as `0` and is viewed as an exception). 

This version has been used to run a test suite of binary code examples covering `amd64`, `i386`, `mips`, `mipsel`, `arm`, `aarch64`, `ppc`. 