### PR TITLE
Improve nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "libosi-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1693574302,
-        "narHash": "sha256-rHbfp1llyVEvHw+sz+rCmx9DrR/e1nnJYRidhPM3jZY=",
+        "lastModified": 1747316194,
+        "narHash": "sha256-W0UivJRKsOAvUz7sNnb4ieF+SCviCCgNEcS6e9fIHhA=",
         "owner": "panda-re",
         "repo": "libosi",
-        "rev": "c68bafdb7e2a4d83128ae6ba0f5f70e28318eda0",
+        "rev": "70855ec07c8185ef89f7bebfc25d616ad81ca3ab",
         "type": "github"
       },
       "original": {
@@ -16,13 +16,28 @@
         "type": "github"
       }
     },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699725108,
-        "narHash": "sha256-NTiPW4jRC+9puakU4Vi8WpFEirhp92kTOSThuZke+FA=",
+        "lastModified": 1760965567,
+        "narHash": "sha256-0JDOal5P7xzzAibvD0yTE3ptyvoVOAL0rcELmDdtSKg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "911ad1e67f458b6bcf0278fa85e33bb9924fed7e",
+        "rev": "cb82756ecc37fa623f8cf3e88854f9bf7f64af93",
         "type": "github"
       },
       "original": {
@@ -30,10 +45,28 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-wireshark": {
+      "locked": {
+        "lastModified": 1654613154,
+        "narHash": "sha256-Kqpik8NNIzErNoeiQc6FS9F7RMVuG9ykZzVkL+Z7nXg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e93823409f9e6b8e878edf060b430a14353a28f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e93823409f9e6b8e878edf060b430a14353a28f9",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "libosi-src": "libosi-src",
-        "nixpkgs": "nixpkgs"
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-wireshark": "nixpkgs-wireshark"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,47 +2,49 @@
   description = "PANDA: Platform for Architecture-Neutral Dynamic Analysis";
 
   inputs = {
+    # nixpkgs with a Wireshark version that works with the network plugin.
+    nixpkgs-wireshark = {
+      url = "github:NixOS/nixpkgs?rev=e93823409f9e6b8e878edf060b430a14353a28f9";
+    };
     libosi-src = {
       url = "github:panda-re/libosi";
       flake = false;
     };
+    nix-filter.url = "github:numtide/nix-filter";
   };
 
-  outputs = { self, nixpkgs, libosi-src }: {
-
-    packages.x86_64-linux.default = let
-
-      pkgs = import nixpkgs {
-        system = "x86_64-linux";
-        config.permittedInsecurePackages = [ "libdwarf-20210528" ];
-      };
-
+  outputs = { self, nixpkgs, nixpkgs-wireshark, libosi-src, nix-filter }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      lib = pkgs.lib;
       pyPkgs = pkgs.python3Packages;
+      filter = nix-filter.lib;
 
-      # We need to use an older version of wireshark, since 2.5.1 breaks the network plugin
-      wireshark = (import (pkgs.fetchFromGitHub {
-        owner = "NixOS";
-        repo = "nixpkgs";
-        rev = "a7e0fb6ffcae252bdd0c85928f179c74c3492a89";
-        hash = "sha256-RdXz/U0JJvsABkGWhF4Cukl4KuZvOJvkci7EuizKid0=";
-      }) { localSystem.system = "x86_64-linux"; }).wireshark-cli.overrideAttrs
+      wireshark = (import nixpkgs-wireshark { inherit system; }).wireshark-cli.overrideAttrs
         (prev: {
           outputs = [ "out" "dev" ];
           postInstall = ''
             ${prev.postInstall}
 
-            # Install headers
-            mkdir $dev/include/wireshark/{epan/{wmem,ftypes,dfilter},wsutil,wiretap} -pv
             cp config.h $dev/include/wireshark
-            cp ../ws_*.h $dev/include/wireshark
-            cp ../epan/*.h $dev/include/wireshark/epan/
-            cp ../epan/wmem/*.h $dev/include/wireshark/epan/wmem/
-            cp ../epan/ftypes/*.h $dev/include/wireshark/epan/ftypes/
-            cp ../epan/dfilter/*.h $dev/include/wireshark/epan/dfilter/
-            cp ../wsutil/*.h $dev/include/wireshark/wsutil/
-            cp ../wiretap/*.h $dev/include/wireshark/wiretap
           '';
         });
+
+      libdwarf = pkgs.stdenv.mkDerivation rec {
+        pname = "libdwarf";
+        version = "20210528";
+
+        src = pkgs.fetchurl {
+          url = "https://www.prevanders.net/libdwarf-${version}.tar.gz";
+          hash = "sha512-4PnIhVQFPubBsTM5YIkRieeCDEpN3DArfmN1Skzc/CrLG0tgg6ci0SBKdemU//NAHswlG4w7JAkPjLQEbZD4cA==";
+        };
+
+        configureFlags = [ "--enable-shared" "--disable-nonshared" ];
+        buildInputs = with pkgs; [ zlib libelf ];
+        outputs = [ "bin" "lib" "dev" "out" ];
+        enableParallelBuilding = true;
+      };
 
       libosi = pkgs.stdenv.mkDerivation {
         name = "libosi";
@@ -50,107 +52,164 @@
         buildInputs = with pkgs; [ cmake pkg-config glib ];
       };
 
-      default = pkgs.stdenv.mkDerivation {
-        name = "panda";
-        src = ./.;
-        cargoRoot = "panda/plugins";
-        cargoDeps = pkgs.rustPlatform.importCargoLock {
-          lockFile = ./panda/plugins/Cargo.lock;
+      pkgsWithConfig = {
+        configFile ? ./panda/plugins/config.panda,
+        targetList ? [
+          "x86_64-softmmu"
+          "i386-softmmu"
+          "arm-softmmu"
+          "aarch64-softmmu"
+          "ppc-softmmu"
+          "mips-softmmu"
+          "mipsel-softmmu"
+          "mips64-softmmu"
+        ],
+      }: let
+        config = builtins.readFile configFile;
+
+        # Is any plugin in `plugins` enabled in config.panda?
+        plugin-enabled = plugins:
+          (builtins.match "(^|.*\n)(${builtins.concatStringsSep "|" plugins})(\n.*|$)" config) != null;
+
+        panda = pkgs.stdenv.mkDerivation {
+          name = "panda";
+          src = filter {
+            root = ./.;
+            # exclude flake files to prevent unnecessary rebuilds
+            exclude = [
+              ./flake.nix
+              ./flake.lock
+            ];
+          };
+          cargoRoot = "panda/plugins";
+          cargoDeps = pkgs.rustPlatform.importCargoLock {
+            lockFile = ./panda/plugins/Cargo.lock;
+          };
+          buildInputs = (with pkgs; [
+            python3
+            zlib
+            glib
+            libarchive
+            openssl
+            pixman
+            capstone
+            protobufc
+            protobuf
+            cargo
+            zip
+          ])
+            ++ (lib.optionals (plugin-enabled [ "network" ]) [ wireshark ])
+            ++ (lib.optionals (plugin-enabled [ "wintrospection" ]) [ libosi ])
+            ++ (lib.optionals (plugin-enabled [ "pri_dwarf" ]) [ libdwarf ])
+            ++ (lib.optionals (plugin-enabled [ "pri_dwarf" "dwarf2" ]) [ pkgs.libelf ])
+            ++ (lib.optionals (plugin-enabled [ "dwarf2" "syscalls_logger" ]) [ pkgs.jsoncpp ])
+            ++ (lib.optionals (plugin-enabled [ "osi_linux" ]) [ pkgs.curl ])
+            ++ (with pyPkgs; [ pycparser libfdt setuptools ]);
+          nativeBuildInputs = [ pkgs.pkg-config pkgs.rustPlatform.cargoSetupHook ];
+          propagatedBuildInputs = with pyPkgs; [ cffi colorama ];
+          enableParallelBuilding = true;
+          patches = [
+            (pkgs.writeText "fix-rpath-error.patch" ''
+              diff --git a/Makefile b/Makefile
+              index cc2064de42..8b357e9a9a 100644
+              --- a/Makefile
+              +++ b/Makefile
+              @@ -653,7 +653,6 @@ newtoobig=$(shell oldrp="$(rppart)" ; oldrplen=`expr $''${$(number_sign)oldrp} - 6
+               endif
+
+               install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir
+              -ifeq ($(newtoobig), false)
+               ifneq ($(TOOLS),)
+               	$(call install-prog,$(subst qemu-ga,qemu-ga$(EXESUF),$(TOOLS)),$(DESTDIR)$(bindir))
+               endif
+              @@ -684,9 +683,6 @@ endif
+               	for d in $(TARGET_DIRS); do \
+               	$(MAKE) $(SUBDIR_MAKEFLAGS) TARGET_DIR=$$d/ -C $$d $@ || exit 1 ; \
+                       done
+              -else
+              -	$(error new RPATH too long - cannot adjust .so files for installation)
+              -endif
+
+               # various test targets
+               test speed: all
+            '')
+          ];
+          postPatch = ''
+            patchShebangs .
+            substituteInPlace rules.mak \
+              --replace 'std=c++11' 'std=c++17'
+            substituteInPlace panda/plugins/pri_dwarf/*.{h,cpp} \
+              --replace '<libdwarf/' '<'
+            cp "${configFile}" panda/plugins/config.panda
+          '' + lib.optionalString (plugin-enabled [ "network" ]) ''
+            substituteInPlace panda/plugins/network/Makefile \
+              --replace '/usr/include/wireshark' '${wireshark.dev}/include/wireshark'
+          '';
+          preConfigure = "mkdir build && cd build";
+          configureScript = "../configure";
+          configureFlags = [
+            "--target-list=${builtins.concatStringsSep "," targetList}"
+            "--disable-numa"
+            # TODO: "--enable-llvm"
+          ];
+          postInstall = ''
+            rm -rf $out/lib/panda/*/{cosi,cosi_strace,gdb,snake_hook,rust_skeleton}
+            # Generated files for PyPANDA (built separately)
+            (cd ../panda/python/core && python ./create_panda_datatypes.py)
+            mkdir "$out/lib/panda/python"
+            cp -r ../panda/python/core/pandare/{autogen,include,plog_pb2.py} "$out/lib/panda/python"
+            rm -r "$out/lib/python3"
+          '';
         };
-        buildInputs = (with pkgs; [
-          pkg-config
-          python3
-          zlib
-          glib
-          libarchive
-          openssl
-          pixman
-          capstone
-          protobufc
-          protobuf
-          cargo
-          curl
-          libdwarf_20210528
-          zip
-          libelf
-          jsoncpp
-        ]) ++ [ wireshark libosi ]
-          ++ (with pyPkgs; [ pycparser libfdt setuptools ]);
-        nativeBuildInputs = [ pkgs.rustPlatform.cargoSetupHook ];
-        propagatedBuildInputs = with pyPkgs; [ cffi colorama ];
-        enableParallelBuilding = true;
-        patches = [
-          (pkgs.writeText "fix-rpath-error.patch" ''
-            diff --git a/Makefile b/Makefile
-            index cc2064de42..8b357e9a9a 100644
-            --- a/Makefile
-            +++ b/Makefile
-            @@ -653,7 +653,6 @@ newtoobig=$(shell oldrp="$(rppart)" ; oldrplen=`expr $''${$(number_sign)oldrp} - 6
-             endif
 
-             install: all $(if $(BUILD_DOCS),install-doc) install-datadir install-localstatedir
-            -ifeq ($(newtoobig), false)
-             ifneq ($(TOOLS),)
-             	$(call install-prog,$(subst qemu-ga,qemu-ga$(EXESUF),$(TOOLS)),$(DESTDIR)$(bindir))
-             endif
-            @@ -684,9 +683,6 @@ endif
-             	for d in $(TARGET_DIRS); do \
-             	$(MAKE) $(SUBDIR_MAKEFLAGS) TARGET_DIR=$$d/ -C $$d $@ || exit 1 ; \
-                     done
-            -else
-            -	$(error new RPATH too long - cannot adjust .so files for installation)
-            -endif
+        pypanda = pyPkgs.buildPythonPackage {
+          pname = "pandare";
+          version = "1.8";
+          format = "setuptools";
+          src = ./panda/python/core;
 
-             # various test targets
-             test speed: all
-          '')
-        ];
-        postPatch = ''
-          patchShebangs .
-          substituteInPlace rules.mak \
-            --replace 'std=c++11' 'std=c++17'
-          substituteInPlace panda/plugins/network/Makefile \
-            --replace '/usr/include/wireshark' '${wireshark.dev}/include/wireshark'
-          substituteInPlace panda/plugins/pri_dwarf/*.{h,cpp} \
-            --replace '<libdwarf/' '<'
-          substituteInPlace panda/python/core/pandare/utils.py \
-            --replace \
-            'pjoin(python_package, arch_dir), pjoin(local_build, arch_dir)' \
-            'realpath(pjoin(dirname(__file__), "../../../../bin"))'
-          substituteInPlace panda/python/core/pandare/panda.py \
-            --replace 'self.plugin_path = plugin_path' "self.plugin_path = plugin_path or pjoin('$out', 'lib/panda', arch)" \
-            --replace 'if libpanda_path:' 'if True:' \
-            --replace '= libpanda_path' "= libpanda_path or pjoin('$out', 'bin', f'libpanda-{arch}.so')" \
-            --replace 'realpath(pjoin(self.get_build_dir(), "pc-bios"))' "pjoin('$out', 'share/panda')"
-        '';
-        preConfigure = "mkdir build && cd build";
-        configureScript = "../configure";
-        configureFlags = [
-          "--target-list=${
-            builtins.concatStringsSep "," [
-              "x86_64-softmmu"
-              "i386-softmmu"
-              "arm-softmmu"
-              "aarch64-softmmu"
-              "ppc-softmmu"
-              "mips-softmmu"
-              "mipsel-softmmu"
-              "mips64-softmmu"
-            ]
-          }"
-          "--disable-numa"
-          # TODO: "--enable-llvm"
-        ];
-        postInstall = ''
-          rm -r $out/lib/panda/*/{cosi,cosi_strace,gdb,snake_hook,rust_skeleton}
-          (
-            cd ../panda/python/core
-            python3 setup.py install --prefix "$out"
-          )
-        '';
+          propagatedBuildInputs = with pyPkgs; [
+            cffi
+            protobuf
+            colorama
+          ];
+
+          nativeBuildInputs = [
+            pyPkgs.setuptools_scm
+          ];
+
+          buildInputs = [ panda ];
+
+          postPatch = ''
+            substituteInPlace setup.py \
+              --replace 'install_requires=parse_requirements("requirements.txt"),' ""
+            substituteInPlace pandare/utils.py \
+              --replace '/usr/local/bin/' '${panda}'
+            substituteInPlace pandare/panda.py \
+              --replace 'self.plugin_path = plugin_path' "self.plugin_path = plugin_path or pjoin('${panda}', 'lib/panda', arch)" \
+              --replace 'if libpanda_path:' 'if True:' \
+              --replace '= libpanda_path' "= libpanda_path or pjoin('${panda}', 'bin', f'libpanda-{arch}.so')" \
+              --replace 'realpath(pjoin(self.get_build_dir(), "pc-bios"))' "pjoin('${panda}', 'share/panda')"
+
+            # Use auto-generated files from separate derivation above.
+            rm create_panda_datatypes.py
+            rm -r pandare/{include,autogen}
+            cp -rt pandare "${panda}"/lib/panda/python/{include,autogen,plog_pb2.py}
+          '';
+        };
+      in {
+        inherit panda pypanda;
       };
 
-    in default;
+      pkgsDefaultConfig = pkgsWithConfig {};
 
-  };
+    in {
+      packages.x86_64-linux = {
+        default = pkgsDefaultConfig.panda;
+        pypanda = pkgsDefaultConfig.pypanda;
+        pkgsWithConfig = pkgsWithConfig;
+        wireshark = wireshark;
+        libdwarf = libdwarf;
+      };
+    };
 }


### PR DESCRIPTION
This fixes the nix flake (it didn't work with current nixpkgs since the old libdwarf was removed and some Python trouble) and implements some improvements:

- The plugin configuration can be overwritten by flake consumers and the flake can reduce the dependencies accordingly.
- PyPANDA is built separately (mostly to avoid rebuilding all of PANDA with every change while figuring out Python packaging)
- I also updated Wireshark to the newest version supported by the network plugin

cc @be32826 who built the flake originally