### PR TITLE
[WIP] Use Capstone Debian package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE="ubuntu:20.04"
 ARG TARGET_LIST="x86_64-softmmu,i386-softmmu,arm-softmmu,aarch64-softmmu,ppc-softmmu,mips-softmmu,mipsel-softmmu,mips64-softmmu,mips64el-softmmu"
 ARG LIBOSI_VERSION="v0.1.7"
+ARG CAPSTONE_VERSION="6.0.0-Alpha5"
 
 ### BASE IMAGE
 FROM $BASE_IMAGE as base
@@ -24,6 +25,7 @@ FROM base AS builder
 ARG BASE_IMAGE
 ARG TARGET_LIST
 ARG LIBOSI_VERSION
+ARG CAPSTONE_VERSION
 
 RUN [ -e /tmp/build_dep.txt ] && \
     apt-get -qq update && \
@@ -34,16 +36,19 @@ RUN [ -e /tmp/build_dep.txt ] && \
     python3 -m pip install --upgrade --no-cache-dir "capstone" && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
 
-# Then install capstone from source
+# Then install capstone debian package
 RUN cd /tmp && \
-    git clone https://github.com/capstone-engine/capstone/ -b v5 && \
-    cd capstone/ && ./make.sh && make install && cd /tmp && \
-    rm -rf /tmp/capstone && ldconfig
+    curl -LJO https://github.com/AndrewQuijano/capstone/releases/download/${CAPSTONE_VERSION}/libcapstone-dev_${CAPSTONE_VERSION}_amd64.deb && \
+    apt-get install /tmp/libcapstone-dev_${CAPSTONE_VERSION}_amd64.deb && \
+    rm -rf /tmp/libcapstone-dev_${CAPSTONE_VERSION}_amd64.deb
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # install libosi
-RUN cd /tmp && curl -LJO https://github.com/panda-re/libosi/releases/download/${LIBOSI_VERSION}/libosi_$(echo "$BASE_IMAGE" | awk -F':' '{print $2}').deb && dpkg -i /tmp/libosi_$(echo "$BASE_IMAGE" | awk -F':' '{print $2}').deb
+RUN cd /tmp && \ 
+    curl -LJO https://github.com/panda-re/libosi/releases/download/${LIBOSI_VERSION}/libosi_$(echo "$BASE_IMAGE" | awk -F':' '{print $2}').deb && \
+    dpkg -i /tmp/libosi_$(echo "$BASE_IMAGE" | awk -F':' '{print $2}').deb && \
+    rm -rf /tmp/libosi_$(echo "$BASE_IMAGE" | awk -F':' '{print $2}').deb
 
 # Build and install panda
 # Copy repo root directory to /panda, note we explicitly copy in .git directory
@@ -125,7 +130,7 @@ COPY --from=base /tmp/build_dep.txt /tmp
 
 # Copy panda + libcapstone.so* + libosi libraries
 COPY --from=cleanup /usr/local /usr/local
-COPY --from=cleanup /usr/lib/libcapstone* /usr/lib/
+COPY --from=cleanup /usr/lib/x86_64-linux-gnu/libcapstone.so* /usr/lib/
 COPY --from=cleanup /lib/libosi.so /lib/libiohal.so /lib/liboffset.so /lib/
 
 # Workaround issue #901 - ensure LD_LIBRARY_PATH contains the panda plugins directories

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -27,6 +27,7 @@ git --help &>/dev/null || $SUDO apt-get -qq update && $SUDO apt-get -qq install 
 # some globals
 LIBOSI_VERSION="0.1.7"
 UBUNTU_VERSION=$(lsb_release -r | awk '{print $2}')
+CAPSTONE_VERSION="6.0.0-Alpha5"
 PANDA_GIT="https://github.com/panda-re/panda.git"
 
 # system information
@@ -109,11 +110,10 @@ fi
 # Install libcapstone v5 release if it's not present
 if [[ !$(ldconfig -p | grep -q libcapstone.so.5) ]]; then
   echo "Installing libcapstone v5"
-  pushd /tmp && \
-  git clone https://github.com/capstone-engine/capstone/ -b v5 && \
-  cd capstone/ && MAKE_JOBS=$(nproc) ./make.sh && $SUDO make install && cd /tmp && \
-  rm -rf /tmp/capstone
-  $SUDO ldconfig
+  pushd /tmp
+  curl -LJO https://github.com/AndrewQuijano/capstone/releases/download/${CAPSTONE_VERSION}/libcapstone-dev_${CAPSTONE_VERSION}_amd64.deb
+  $SUDO apt-get install /tmp/libcapstone-dev_${CAPSTONE_VERSION}_amd64.deb
+  rm -rf /tmp/libcapstone-dev_${CAPSTONE_VERSION}_amd64.deb
   popd
 fi
 


### PR DESCRIPTION
Hello,
Based on work here, it seems like I got a fully functional version of libcapstone 5.0.4 working, I locally tested this, I can see libcapstone, I want to test this somehow.
https://github.com/capstone-engine/capstone/pull/2569

So two questions
1. I assume the integration test will make extensive use of callstack_instr which uses capstone right? I want to show the capstone team that if this passes the PANDA integration test, the Debian package works as expected

2. Once the confirmation is complete, I'll ask capstone to create a 5.0.4 release, with the Debian package, and I'd need to tweak this PR to match the capstone GitHub address.

Although, I think based on the work, it seems we should be very close to be able to put this on Debian apt repos directly too

P. S.
The Debian package already will run `ldconfig` for you.
