### PR TITLE
Use Capstone Debian package

### DIFF
--- a/panda/debian/.gitignore
+++ b/panda/debian/.gitignore
@@ -1,1 +1,2 @@
-panda.deb
+*.deb
+*.whl


### PR DESCRIPTION
Hello,
Based on work here, it seems like I got a fully functional version of libcapstone 5.0.5 working, I locally tested this.

https://github.com/capstone-engine/capstone/pull/2569
https://github.com/capstone-engine/capstone/pull/2596

PANDA Integration tests [taint2](https://github.com/panda-re/panda/blob/dev/panda/plugins/taint2/taint2.cpp#L585-L587), which uses [callstack_instr](https://github.com/panda-re/panda/blob/dev/panda/plugins/callstack_instr/callstack_instr.cpp#L33-L44), which uses capstone. So if this passes, the Debian Package works as expected.

It will pull the Debian image from here
https://github.com/capstone-engine/capstone/releases/tag/5.0.5

P. S.
The Debian package will already run `ldconfig` for you. See the screenshot below