### PR TITLE
Bump panda-rs version to 0.49

### DIFF
--- a/panda/plugins/Cargo.lock
+++ b/panda/plugins/Cargo.lock
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "panda-re"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3903c9c270a4c9ac728c2491432ea810a92a318d7c435220a5d8b9da87111b1"
+checksum = "69681c72aa22165810436f7dc67935c6aea4ae453d50558844c91d63a3346584"
 dependencies = [
  "array-init",
  "dirs",

--- a/panda/plugins/cosi/Cargo.toml
+++ b/panda/plugins/cosi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 once_cell = "1.8.0"
-panda-re = { version = "0.48.0", default-features = false }
+panda-re = { version = "0.49.0", default-features = false }
 regex = "1.5.4"
 curl = "0.4.44"
 volatility_profile = { path = "./volatility_profile" }

--- a/panda/plugins/cosi_strace/Cargo.toml
+++ b/panda/plugins/cosi_strace/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-panda-re = { version = "0.48.0", default-features = false }
+panda-re = { version = "0.49.0", default-features = false }
 chumsky = "0.8"
 log = "0.4"
 once_cell = "1"

--- a/panda/plugins/gdb/Cargo.toml
+++ b/panda/plugins/gdb/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-panda-re = { version = "0.48.0", default-features = false }
+panda-re = { version = "0.49.0", default-features = false }
 gdbstub = "0.5"
 lazy_static = "1.4.0"
 gdbstub_arch = "0.1.0"

--- a/panda/plugins/rust_skeleton/Cargo.toml
+++ b/panda/plugins/rust_skeleton/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-panda-re = { version = "0.48.0", default-features = false }
+panda-re = { version = "0.49.0", default-features = false }
 
 [features]
 default = ["x86_64"]

--- a/panda/plugins/snake_hook/Cargo.toml
+++ b/panda/plugins/snake_hook/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-panda-re = { version = "0.48.0", default-features = false }
+panda-re = { version = "0.49.0", default-features = false }
 inline-python = { version = "0.12.0" }
 libc = "0.2.98"
 once_cell = "1"


### PR DESCRIPTION
This upgrades the `PANDA_PATH` and `PANDA_PLUGIN_DIR` search for Rust plugins, fixes #1438 