### PR TITLE
Prevent usage of uninitialized mem_buffer

### DIFF
--- a/panda/plugins/trace/trace.cpp
+++ b/panda/plugins/trace/trace.cpp
@@ -283,7 +283,7 @@ bool init_plugin(void *self) {
         assert(init_osi_api());
     }
 
-    mem_buffer = (char*) malloc(MEM_BUF_SIZE);
+    mem_buffer = (char*) calloc(1, MEM_BUF_SIZE);
     if (mem_buffer == NULL) {
         perror("malloc");
         return false;


### PR DESCRIPTION
Check at line 186 (if (strlen(mem_buffer) > 0)) is not correct if the result of malloc is not zero, resulting in broken traces.