### PR TITLE
Replace setup.py 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ trace-ust-all.h
 trace-ust-all.c
 
 .vscode/
+.idea/
 
 # Pypanda Examples
 pwc_log

--- a/panda/python/core/MANIFEST.in
+++ b/panda/python/core/MANIFEST.in
@@ -1,2 +1,3 @@
 graft pandare
-global-exclude *.py[cod] __pycache__ *.sw*
+prune pandare/include
+global-exclude *.py[cod] __pycache__ *.sw* .git*

--- a/panda/python/core/pyproject.toml
+++ b/panda/python/core/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = [
+    "pandare",
+    "pandare.*"
+]
+
+[tool.setuptools.package-data]
+pandare = [
+    "data/*-softmmu/llvm-helpers*.bc*",  # LLVM Helpers
+    "data/pypanda/include/*.h",  # Includes files
+    "qcows.json"  # Generic Images
+]
+
+# This is how to setup cmd replacement, we can figure this out later
+# [tool.setuptools.cmdclass]
+# install = "setup.custom_install"
+# develop = "setup.custom_develop"
+
+[project]
+name = "pandare"
+dynamic = ["version"]
+description = "Python Interface to PANDA"
+readme = "README.md"
+authors = [
+    { name = "Luke Craig", email = "luke.craig@mit.edu" },
+    { name = "Andrew Fasano" },
+    { name = "Tim Leek" }
+]
+requires-python = ">=3.6"
+dependencies = [
+    "cffi>=1.14.3",
+    "protobuf>=4.25.1",
+    "colorama"
+]
+
+[tool.setuptools_scm]
+root = "../../.."
+fallback_version = "0.0.0.1"
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"

--- a/panda/python/core/setup.py
+++ b/panda/python/core/setup.py
@@ -1,156 +1,24 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from setuptools import setup, find_packages
-from setuptools.command.install import install as install_orig
-from setuptools.command.develop import develop as develop_orig
-from setuptools.dist import Distribution
-from subprocess import check_output
-import shutil
-
+from setuptools import setup
 import os
 
-arches = ['arm', 'aarch64', 'i386', 'x86_64', 'ppc', 'mips', 'mipsel', 'mips64', 'mips64el']
-
-# Check for PANDA binaries in /usr/local/bin/ or in our build directory
-# panda_binaries = ['/usr/local/bin/panda-system-{arch}' for arch in arches]
-# Do we actually care at this point?
-
-root_dir = os.path.join(*[os.path.dirname(__file__), "..", "..", ".."])  # panda-git/ root dir
-
-lib_dir = os.path.join("pandare", "data")
-
-
-def copy_objs():
-    '''
-    Run to copy objects into a (local and temporary) python module before installing to the system.
-    Shouldn't be run if you're just installing in develop mode
-    '''
-
-    if os.path.isdir(lib_dir):
-        shutil.rmtree(lib_dir)
-    os.mkdir(lib_dir)
-
-    # Copy pypanda's include directory (different than core panda's) into a datadir
-    pypanda_inc = os.path.join(*[root_dir, "panda", "python", "core", "pandare", "include"])
-    if not os.path.isdir(pypanda_inc):
-        raise RuntimeError(f"Could not find pypanda include directory at {pypanda_inc}")
-    pypanda_inc_dest = os.path.join(*["pandare", "data", "pypanda", "include"])
-    if os.path.isdir(pypanda_inc_dest):
-        shutil.rmtree(pypanda_inc_dest)
-    shutil.copytree(pypanda_inc, pypanda_inc_dest)
-
-    # For each arch, copy llvm-helpers
-    # XXX Should these be in standard panda deb?
-    # What actually uses these? Taint? Disabling for now
-    '''
-    # Check if we have llvm-support
-    with open(os.path.join(*[build_root, 'config-host.mak']), 'r') as cfg:
-        llvm_enabled = True if 'CONFIG_LLVM=y' in cfg.read() else False
-
-    for arch in arches:
-        libname = "libpanda-"+arch+".so"
-        softmmu = arch+"-softmmu"
-        path      = os.path.join(*[build_root, softmmu, libname])
-        llvm1     = os.path.join(*[build_root, softmmu, "llvm-helpers.bc1"])
-        llvm2     = os.path.join(*[build_root, softmmu, f"llvm-helpers-{arch}.bc"])
-
-        if os.path.isfile(path) is False:
-            print(("Missing file {} - did you run build.sh from panda/build directory?\n"
-                   "Skipping building pypanda for {}").format(path, arch))
-            continue
-
-        os.mkdir(os.path.join(lib_dir, softmmu))
-        if llvm_enabled:
-            shutil.copy(    llvm1,      os.path.join(lib_dir, softmmu))
-            shutil.copy(    llvm2,      os.path.join(lib_dir, softmmu))
-    '''
-
-
-def parse_requirements(filename):
-    with open(filename, 'r') as f:
-        return [line.strip() for line in f if line.strip() and not line.strip().startswith('#')]
-
-
-from setuptools.command.install import install as install_orig
-from setuptools.command.develop import develop as develop_orig
-
-
-class custom_develop(develop_orig):
-    '''
-    Install as a local module (not to system) by
-        1) Creating datatype files for local-use
-        2) Running regular setup tools logic
-    '''
-
-    def run(self):
-        from create_panda_datatypes import main as create_datatypes
-        create_datatypes(install=False)
-        super().run()
-
-
-class custom_install(install_orig):
-    '''
-    We're going to install to the system. Two possible states to handle
-    1) Running from within the panda repo with panda built - need to create_datatypes
-    2) Running from a python sdist where all the files are already prepared
-    '''
-
-    def run(self):
-        try:
-            from create_panda_datatypes import main as create_datatypes
-            # If we can do the import, we're in the panda repo
-            create_datatypes(install=True)
-            copy_objs()
-
-        except ImportError:
-            # Import failed, we're either in a python sdist or something has gone very wrong
-            assert (os.path.isfile("pandare/include/panda_datatypes.h")), \
-                "panda_datatypes.h missing and can't be generated"
-            assert (os.path.isfile("pandare/autogen/panda_datatypes.py")), \
-                "panda_datatypes.py missing and can't be generated"
-        super().run()
-
-
-# To build a package for pip:
-# python setup.py install
-# python setup.py sdist
-
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-      
-
-version_options = {
-      "setup_requires": ['setuptools_scm'],
-      "use_scm_version": {
-                    "root": "../../..", 
-                    "relative_to": __file__,
-                    "fallback_version": "0.0.0.1",
-                        },
-}
 
 if "PRETEND_VERSION" in os.environ:
     version = os.environ["PRETEND_VERSION"]
-    version_options = {
-        "version":version,
-    }
+else:
+    from setuptools_scm import get_version
+    version = get_version(root='../../..',
+                          fallback_version="0.0.0.1",
+                          version_scheme="guess-next-dev",
+                          local_scheme="no-local-version")
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
 
-setup(name='pandare',
-      description='Python Interface to PANDA',
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      author='Andrew Fasano, Luke Craig, and Tim Leek',
-      author_email='fasano@mit.edu',
-      url='https://github.com/panda-re/panda/',
-      packages=find_packages(),
-      package_data={'pandare': [
-          'data/*-softmmu/llvm-helpers*.bc*',  # LLVM Helpers
-          'data/pypanda/include/*.h',  # Includes files
-          'data/pypanda/include/*.h',  # Includes files
-          'qcows.json'  # Generic Images
-      ]},
-      install_requires=parse_requirements("requirements.txt"),
-      python_requires='>=3.6',
-      cmdclass={'install': custom_install, 'develop': custom_develop},
-      **version_options
-      )
+setup(
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url='https://github.com/panda-re/panda/',
+    version=version
+)

--- a/panda/scripts/install_ubuntu.sh
+++ b/panda/scripts/install_ubuntu.sh
@@ -147,8 +147,8 @@ pushd build
 progress "PANDA is built and ready to use in panda/build/[arch]-softmmu/panda-system-[arch]."
 
 cd ../panda/python/core
-$SUDO python3 -m pip install -r requirements.txt
-$SUDO python3 setup.py install
+python3 create_panda_datatypes.py --install
+$SUDO python3 -m pip install .
 python3 -c "import pandare; panda = pandare.Panda(generic='i386')" # Make sure it worked
 progress "Pypanda successfully installed"
 popd


### PR DESCRIPTION
It seems like we can't build new Docker containers until we phase out setup.py entirely.

closes #1499 

Main changes:
* Creating a PyProject.toml and migrated some settings to there from setup.py
* Since using custom develop and install isn't working, for now I manually called `create_panda_datatypes.py` to run the necessary actions needed to maintain the same behavior from `setup.py` with pip. Most of the code changes is from code being migrated from `setup.py` to `create_panda_datatypes.py`
* Update installations to use pip for everything, based on guidance from here https://packaging.python.org/en/latest/guides/modernize-setup-py-project/
* I confirm the `PRETEND_VERSION` can dynamically pass the version as before

Please feel free to investigate the wheel file created with this approach, which is identical to what current PyPanda files look like.
[pypanda.zip](https://github.com/user-attachments/files/19249802/pypanda.zip)

Existing wheel from using setup.py
https://github.com/panda-re/panda/releases/tag/v1.8.57