### PR TITLE
Update callstack_instr to track binary names

### DIFF
--- a/panda/plugins/callstack_instr/README.md
+++ b/panda/plugins/callstack_instr/README.md
@@ -59,6 +59,12 @@ uint32_t get_callers(target_ulong *callers, uint32_t n, CPUState *env);
 // Return value is the number of callers actually retrieved
 uint32_t get_functions(target_ulong *functions, uint32_t n, CPUState *env);
 
+// Get up to n binaries from the given stack in use at this moment
+// Binaries are returned in libs[], most recent first
+// Return value is the number of binaries actually retrieved
+// Must have OSI enabled for this api to work.
+uint32_t get_binaries(char **libs, uint32_t n, CPUState *cpu);
+
 // Get the current program point: (Caller, PC, stack ID)
 // This isn't quite the right place for it, but since it's awkward
 // right now to have a "utilities" library, this will have to do

--- a/panda/plugins/callstack_instr/README.md
+++ b/panda/plugins/callstack_instr/README.md
@@ -65,6 +65,9 @@ uint32_t get_functions(target_ulong *functions, uint32_t n, CPUState *env);
 // Must have OSI enabled for this api to work.
 uint32_t get_binaries(char **libs, uint32_t n, CPUState *cpu);
 
+// Must be called by plugins which intend to call get_binaries.
+void callstack_enable_binary_tracking(void);
+
 // Get the current program point: (Caller, PC, stack ID)
 // This isn't quite the right place for it, but since it's awkward
 // right now to have a "utilities" library, this will have to do
@@ -102,10 +105,13 @@ Example
 
 int some_plugin_fn(CPUState *env) {
     target_ulong callers[16];
+    char *binaries[16];
     int n;
     n = get_callers(callers, 16, env);
+    get_binaries(binaries, 16, env);
     for (int i = 0; i < n; i++)
-        printf("Callstack entry: " TARGET_FMT_lx "\n", callers[i]);
+        printf("Callstack entry: " TARGET_FMT_lx " %s\n", callers[i],
+            binaries[i]);
     return 0;
 }
 
@@ -114,5 +120,6 @@ int some_plugin_fn(CPUState *env) {
 bool init_plugin(void *self) {
     panda_require("callstack_instr");
     if (!init_callstack_instr_api()) return false;
+    callstack_enable_binary_tracking();
 }
 ```

--- a/panda/plugins/callstack_instr/callstack_instr_int_fns.h
+++ b/panda/plugins/callstack_instr/callstack_instr_int_fns.h
@@ -18,6 +18,10 @@ uint32_t get_callers(target_ulong *callers, uint32_t n, CPUState *cpu);
 // Functions are returned in functions[], most recent first
 uint32_t get_functions(target_ulong *functions, uint32_t n, CPUState *cpu);
 
+// Get up to n binaries from the given stack in use at this moment
+// Binaries are returned in libs[], most recent first
+uint32_t get_binaries(char **libs, uint32_t n, CPUState *cpu);
+
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 // NB: prog_point is c++, so beware

--- a/panda/plugins/callstack_instr/callstack_instr_int_fns.h
+++ b/panda/plugins/callstack_instr/callstack_instr_int_fns.h
@@ -22,6 +22,9 @@ uint32_t get_functions(target_ulong *functions, uint32_t n, CPUState *cpu);
 // Binaries are returned in libs[], most recent first
 uint32_t get_binaries(char **libs, uint32_t n, CPUState *cpu);
 
+// Called by plugins that intend to call get_binaries.
+void callstack_enable_binary_tracking(void);
+
 // END_PYPANDA_NEEDS_THIS -- do not delete this comment!
 
 // NB: prog_point is c++, so beware


### PR DESCRIPTION
Supercedes #1549 

Updates callstack_instr to track binary names along with program counters to make callstack dumps more useful.  Plugins that use callstack_instr to display callstacks need to opt-in to leverage the new functionality.  Enabling the new functionality does come with a performance hit.

Optimized the new API a bit and added some documentation to the README to illustrate how to use it.