### PR TITLE
add warning about coverage plugin impacting taint results

### DIFF
--- a/panda/plugins/coverage/README.md
+++ b/panda/plugins/coverage/README.md
@@ -46,6 +46,11 @@ Regardless of mode used, the output CSV file contains metadata at the top of
 the header consisting of the PANDA build date and the execution time.  Note
 that the header is written out each time coverage collection is enabled.
 
+N.B.  Loading the coverage plugin, even if it is disabled, impacts taint
+collection and propagation.  It is not advisable to load the coverage plugin
+while taint is being collected as the results may be different than what would
+be produced if the coverage plugin were not loaded.
+
 This plugin can be used with the included `coverage.py` script in IDAPython.
 `coverage.py` colorizes the dissasembly in IDA Pro using the CSV file produced
 by this plugin. It also provides options to add comments to the blocks noting


### PR DESCRIPTION
I know it's just a little thing, but hopefully the warning will save someone else the pain we just went through of trying to figure out what is going on.
The issue is that when the coverage plugin is loaded (it doesn't even have to be enabled), it inserts calls into the TCG instruction stream.  This not only impacts the TCG optimizations, but also these calls get instrumented by the taint system.  So, you get different taint than if you ran the same scenario without the coverage plugin loaded.
Although it is possible to make the taint system recognize the functions inserted by the coverage plugin and not instrument them, this only reduces the number of taint differences - it doesn't entirely eradicate them.  One would also need to build PANDA without TCG optimizations in order to get rid of all the taint differences.  Neither adjustment is sufficient on its own to make all the taint differences go away.
It doesn't seem like a good idea to permanently disable TCG optimizations (things are slow enough with them, and the number of taint reports increases with TCG optimizations off), and with recordings you shouldn't need to run coverage with taint at the same time (you can run them separately if you really want output from both plugins), so it seemed best just to warn the user "don't do that".