### PR TITLE
Ubuntu 22 and Improved Debian Packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Explicitly enforce LF for specific files, if these are in CRLF it breaks the Debian package...
+panda/debian/control eol=lf
+pnada/debian/triggers eol=lf

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install git
         run: sudo apt-get -qq update -y && sudo apt-get -qq install git curl jq -y
       - name: Get next version
-        uses: reecetech/version-increment@2023.10.2
+        uses: reecetech/version-increment@2024.10.1
         id: version
         with:
           release_branch: dev
@@ -28,7 +28,7 @@ jobs:
   build_docker:
     needs: get_version
     runs-on: panda-arc
-    if: github.repository  == 'panda-re/panda' && github.ref == 'refs/heads/dev'
+    if: github.repository == 'panda-re/panda' && github.ref == 'refs/heads/dev'
     steps:
       - name: 'Login to Docker Registry'
         uses: docker/login-action@v3
@@ -104,7 +104,7 @@ jobs:
 
 
   build_release_assets:
-    if: github.repository  == 'panda-re/panda' && github.ref == 'refs/heads/dev'
+    if: github.repository == 'panda-re/panda' && github.ref == 'refs/heads/dev'
     needs: get_version
     runs-on: panda-arc
     strategy:
@@ -187,7 +187,7 @@ jobs:
       
   publish-to-pypi-and-release:
     name: Publish Python 🐍 distribution 📦 to PyPI and Make Release
-    if: github.repository  == 'panda-re/panda' && github.ref == 'refs/heads/dev'
+    if: github.repository == 'panda-re/panda' && github.ref == 'refs/heads/dev'
     needs:
     - get_version
     - build_release_assets

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We have two primary branches of PANDA: `dev` for development and `stable` for st
 
 ## Building
 ### Quickstart: Docker
-The latest version of PANDA's `master` branch is automatically built as a two docker images based on Ubuntu 20.04 and published to Docker Hub.
+The latest version of PANDA's `dev` branch is automatically built as a docker image based on Ubuntu 22.04 and published to Docker Hub.
 Most users will want to use the `panda` container which has PANDA and PyPANDA installed along with their runtime dependencies, but no build artifacts or source code to reduce the size of the container.
 Developers interested in using Docker should use the `pandadev` container which has PANDA and PyPANDA installed, build and runtime dependencies for both, all build artifacts and source code and the contents of this repository in the `/panda` directory.
 
@@ -56,11 +56,11 @@ $ docker run --rm pandadev panda-system-i386 --help
 ```
 
 ### Quickstart: Python pip
-The Python interface to PANDA (also known as *pypanda*) can be installed from [PIP](https://pypi.org/project/pandare/) by running `pip3 install pandare`. This will install everything you need for python-based PANDA analyses, but not stand-alone PANDA binaries. The distributed binaries are only tested on 64-bit Ubuntu 18.04 and other architectures/versions are unlikely to work. You can also install pypanda by building PANDA and then running `python3 setup.py install` from the directory `panda/panda/python/core`.
+The Python interface to PANDA (also known as *pypanda*) can be installed from [PIP](https://pypi.org/project/pandare/) by running `pip3 install pandare`. This will install everything you need for python-based PANDA analyses, but not stand-alone PANDA binaries. The distributed binaries are only tested on 64-bit Ubuntu 22.04 and other architectures/versions are likely to work. You can also install pypanda by building PANDA and then running `pip install .` from the directory `panda/panda/python/core`.
 
 ###  Debian, Ubuntu
-The fastest way to install PANDA would be through installing [the debian packages](https://github.com/pandare/panda/releases).
-There is a debian package for both Ubuntu 20.04 and Ubuntu 22.04, and its corresponding PyPanda package.
+The fastest way to install PANDA would be through installing [the debian packages](https://github.com/panda-re/panda/releases).
+There is a debian package for Ubuntu 22.04, and its corresponding PyPanda package.
 Because PANDA has a few dependencies, we've encoded the build instructions into
 the [install\_ubuntu.sh](panda/scripts/install\_ubuntu.sh). The script should
 work on the latest Debian stable/Ubuntu LTS versions.

--- a/panda/debian/control
+++ b/panda/debian/control
@@ -1,9 +1,14 @@
 Package: pandare
-Version: 3.1.0
-Architecture: all
+Source: pandare
+Version: <version-placeholder>
+Architecture: amd64
 BUILD_DEPENDS_LIST
 DEPENDS_LIST
-Maintainer: Andrew Fasano <fasano@mit.edu>
+Maintainer: Luke Craig <luke.craig@mit.edu>
+Installed-Size: <size-in-kb>
+Section: devel
+Priority: optional
+Homepage: https://github.com/panda-re/panda
 Description: dynamic analysis platform
  Platform for Architecture Neutral Dynamic Analysis (PANDA) is a processor
  emulator designed to support analyses of guest code. PANDA supports record-

--- a/panda/debian/triggers
+++ b/panda/debian/triggers
@@ -1,0 +1,2 @@
+# Trigger ldconfig after install
+activate-noawait ldconfig

--- a/panda/plugins/syscalls2/scripts/requirements2.txt
+++ b/panda/plugins/syscalls2/scripts/requirements2.txt
@@ -1,2 +1,2 @@
-Jinja2==3.1.2
+Jinja2>=3.1.6,<4.0
 MarkupSafe==2.1.3

--- a/panda/python/core/.gitignore
+++ b/panda/python/core/.gitignore
@@ -8,3 +8,4 @@ data
 a
 __pycache__
 *.egg-info
+.eggs/

--- a/panda/python/core/create_panda_datatypes.py
+++ b/panda/python/core/create_panda_datatypes.py
@@ -690,14 +690,14 @@ if __name__ == '__main__':
                                           'and prep for PyPanda wheel installation')
     parser.add_argument('--install', '-i', dest='install', action='store_true',
                         help='If set, this means update pandare folder for installation')
-    parser.add_argument('--recompile', '-r', dest='recompile', action='store_true',
-                        help='If set, recompile the headers with cffi')
+    parser.add_argument('--no-compile', dest='compile', action='store_false',
+                        help='Do not compile the headers with cffi')
     args = parser.parse_args()
     """
     Install as a local module (not to system) by
         1) Creating datatype files for local-use
         2) Running regular setup tools logic
     """
-    main()
+    main(args.compile)
     if args.install:
         copy_objs()

--- a/panda/python/core/pandare/qcows_internal.py
+++ b/panda/python/core/pandare/qcows_internal.py
@@ -174,10 +174,10 @@ class Qcows():
 
         if _is_tty:
             print(f"Downloading required file: {url}")
-            cmd = ["wget", '--show-progress', '--quiet', url, "-O", output_path+".tmp"]
+            cmd = ["wget", '--show-progress', '--quiet', "--tries=5", "--wait=10", url, "-O", output_path + ".tmp"]
         else:
             print(f"Please wait for download of required file: {url}", file=stderr)
-            cmd = ["wget", "--quiet", url, "-O", output_path+".tmp"]
+            cmd = ["wget", "--quiet", "--tries=5", "--wait=10", url, "-O", output_path + ".tmp"]
 
         try:
             with Popen(cmd, stdout=PIPE, bufsize=1, universal_newlines=True) as p:


### PR DESCRIPTION
Three big changes:

1. Container is now by default Ubuntu 22, since Ubuntu 20 is EOL

2. Dynamically select the latest LibOSI package

3. Further populate the control file, in particular, manually create MD5 Hashes for file integrity. There is now a way to change the version number dynamically. I don't know which arg to change in CI/CD, but this can be future work. This would be helpful whenever we create an apt repository.

close #1308 Technically, the real fix is panda-ng, but for now this works

TODO in later PR: 
- Consolidate Python installations
- Create an install directory variable in Docker?