### PR TITLE
Create new Templates and DwarfDump documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+<!-- This template is meant for GENERAL bug reports.
+
+Please be as descriptive as possible
+-->
+
+### Work environment
+
+<!-- Filling this table is mandatory -->
+
+| Questions                                | Answers
+|------------------------------------------|--------------------
+| System PANDA runs on OS/arch/bits        | panda-system-i386, panda-system-x86-64
+| PANDA module affected                    | dwarf2 plugin, taint2, PyPanda, etc.
+| Source of PANDA                          | `git clone`, pip, release binaries etc.
+| Version/git commit                       | v1.8.21, <commit hash>
+
+<!-- OTHER BUGS -->
+
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce the behavior
+
+- Use code markdown `CODE` to make your code visible
+
+<!-- ADDITIONAL CONTEXT -->
+
+### Additional Logs, screenshots, source code,  configuration dump, ...
+
+Drag and drop zip archives containing the Additional info here, don't use external services or link.
+Screenshots can be directly dropped here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for PANDA
+
+---
+
+### Feature
+
+- [ ] New PANDA plugin
+- [ ] Support for new architecture
+- [ ] Optimize PANDA performance
+- [ ] Other (elaborated below)
+
+**Describe the feature you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+ <!-- Filling this template is mandatory -->
+
+**Your checklist for this pull request**
+- [ ] I've documented or updated the documentation of every API function and struct this PR changes.
+- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
+
+**Detailed description**
+
+<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
+
+...
+
+**Test plan**
+
+<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Ideally provide screenshots to show the your code changes work as expected -->
+
+...
+
+**Closing issues**
+
+<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
+
+...

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,248 @@
+Build:
+  - Dockerfile
+  - ./panda/build.sh
+  - ./panda/build-llvm.sh
+  - ./panda/Makefile.panda
+  - ./panda/Makefile.panda.target
+  - Makefile
+  - Makefile.objs
+  - Makefile.target
+  - configure
+
+Documentation:
+  - '**/*.md'
+
+Github-files:
+  - .github/**
+
+PyPanda:
+  - ./panda/python/**/*.py
+  - ./panda/python/**/*.h
+
+Debian:
+  - ./panda/debian/**
+
+LLVM:
+  - ./panda/llvm/**
+  - ./panda/include/panda/tcg-llvm.h
+
+PANDA-Core:
+  - ./panda/src/**
+
+PANDA-Tests:
+  - ./panda/testing/**
+  - ./panda/plugins/taint2/tests/**
+
+# All PANDA plug-in tags, used to call specific plug-in tests
+asid_instr_count:
+  - ./panda/plugins/asid_instr_count/**
+
+asidstory:
+  - ./panda/plugins/asidstory/**
+
+callfunc:
+  - ./panda/plugins/callfunc/**
+
+callstack_instr:
+  - ./panda/plugins/callstack_instr/**
+
+callwitharg:
+  - ./panda/plugins/callwitharg/**
+
+checkpoint:
+  - ./panda/plugins/checkpoint/**
+
+collect_code:
+  - ./panda/plugins/collect_code/**
+
+correlatetaps:
+  - ./panda/plugins/correlatetaps/**
+
+cosi:
+  - ./panda/plugins/cosi/**
+  - ./panda/python/core/extras/cosi.py
+
+cosi_strace:
+  - ./panda/plugins/cosi_strace/**
+
+coverage:
+  - ./panda/plugins/coverage/**
+
+dwarf2:
+  - ./panda/plugins/dwarf2/**
+  - ./panda/python/core/extras/dwarfdump.py
+
+dynamic_symbols:
+  - ./panda/plugins/dynamic_symbols/**
+
+edge_coverage:
+  - ./panda/plugins/edge_coverage/**
+
+file_taint:
+  - ./panda/plugins/file_taint/**
+
+filereadmon:
+  - ./panda/plugins/filereadmon/**
+
+findcall:
+  - ./panda/plugins/findcall/**
+
+forcedexec:
+  - ./panda/plugins/forcedexec/**
+
+func_stats:
+  - ./panda/plugins/func_stats/**
+
+gdb:
+  - ./panda/plugins/gdb/**
+
+hooks:
+  - ./panda/plugins/hooks/**
+
+hooks2:
+  - ./panda/plugins/hooks2/**
+
+hw_proc_id:
+  - ./panda/plugins/hw_proc_id/**
+
+hypercaller:
+  - ./panda/plugins/hypercaller/**
+
+ida_taint2:
+  - ./panda/plugins/ida_taint2/**
+
+keyfind:
+  - ./panda/plugins/keyfind/**
+
+libfi:
+  - ./panda/plugins/libfi/**
+
+lighthouse_coverage:
+  - ./panda/plugins/lighthouse_coverage/**
+
+loaded:
+  - ./panda/plugins/loaded/**
+
+loaded_libs:
+  - ./panda/plugins/loaded_libs/**
+
+mem_hooks:
+  - ./panda/plugins/mem_hooks/**
+
+memorymap:
+  - ./panda/plugins/memorymap/**
+
+memsavep:
+  - ./panda/plugins/memsavep/**
+
+mmio_trace:
+  - ./panda/plugins/mmio_trace/**
+
+net:
+  - ./panda/plugins/net/**
+
+network:
+  - ./panda/plugins/network/**
+
+osi:
+  - ./panda/plugins/osi/**
+
+osi_linux:
+  - ./panda/plugins/osi_linux/**
+
+osi_test:
+  - ./panda/plugins/osi_test/**
+
+pc_search:
+  - ./panda/plugins/pc_search/**
+
+pri_dwarf:
+  - ./panda/plugins/pri_dwarf/**
+
+pri_simple:
+  - ./panda/plugins/pri_simple/**
+
+pri_taint:
+  - ./panda/plugins/pri_taint/**
+
+pri_trace:
+  - ./panda/plugins/pri_trace/**
+
+proc_start_linux:
+  - ./panda/plugins/proc_start_linux/**
+
+proc_trace:
+  - ./panda/plugins/proc_trace/**
+
+query_file_writes:
+  - ./panda/plugins/query_file_writes/**
+
+recctrl:
+  - ./panda/plugins/recctrl/**
+
+replaymovie:
+  - ./panda/plugins/replaymovie/**
+
+scissors:
+  - ./panda/plugins/scissors/**
+
+serial_taint:
+  - ./panda/plugins/serial_taint/**
+
+signal:
+  - ./panda/plugins/signal/**
+
+snake_hook:
+  - ./panda/plugins/snake_hook/**
+
+speedtest:
+  - ./panda/plugins/speedtest/**
+
+stringsearch:
+  - ./panda/plugins/stringsearch/**
+
+syscalls_logger:
+  - ./panda/plugins/syscalls_logger/**
+
+syscalls2:
+  - ./panda/plugins/syscalls2/**
+
+taint2:
+  - ./panda/plugins/taint2/**
+  - ./panda/python/core/taint/**
+
+tainted_branch:
+  - ./panda/plugins/tainted_branch/**
+
+tainted_instr:
+  - ./panda/plugins/tainted_instr/**
+
+tainted_mmio:
+  - ./panda/plugins/tainted_mmio/**
+
+tainted_net:
+  - ./panda/plugins/tainted_net/**
+
+tapindex:
+  - ./panda/plugins/tapindex/**
+
+targetcmp:
+  - ./panda/plugins/targetcmp/**
+
+textprinter:
+  - ./panda/plugins/textprinter/**
+
+trace:
+  - ./panda/plugins/trace/**
+
+track_intexc:
+  - ./panda/plugins/track_intexc/**
+
+tstringsearch:
+  - ./panda/plugins/tstringsearch/**
+
+unigrams:
+  - ./panda/plugins/unigrams/**
+
+wintrospection:
+  - ./panda/plugins/wintrospection/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+# Automatically cancel any previous workflow on new push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -232,3 +232,34 @@ jobs:
         files: |
           dist/*
           debs/**/*.deb
+
+  documentation:
+    if: github.repository == 'panda-re/panda'
+    needs: build_release_assets
+    runs-on: panda-arc
+    steps:
+      - name: Checkout docs and reset
+        run: |
+          rm -rf "${GITHUB_WORKSPACE}/auto_pydoc";
+          git clone https://panda-jenkins-ci:${{ secrets.PANDABOT_GITHUB_API }}@github.com/panda-re/panda-re.github.io.git --branch=master ${GITHUB_WORKSPACE}/auto_pydoc/pandare
+
+      - name: Update PYPANDA docs in container
+        run: docker run --rm -v ${GITHUB_WORKSPACE}/auto_pydoc:/out pandare/pandadev:latest /bin/sh -c "pip3 install pdoc3; cd /panda/panda/python/core; pdoc3 --html --template-dir=../docs/template --force -o /out/${GITHUB_REF##*/} pandare; chmod -R 777 /out/"
+        # will put docs in workspace/auto_pydoc/dev/pandare and/or workspace/auto_pydoc/<branch>/pandare
+        # we want to copy auto_pydoc/dev/pandare to auto_pydoc/pandare/ and /auto_pydoc/<branch>/pandare to /auto_pydoc/pandare/<branc>
+        #
+        # This is a bit complicated, sorry. We want to keep pandare/{CNAME,.git/} and nothing else
+        # then we copy in the new files (and merge doc-search.html and index.js with <branch>/pandare/
+      - name: Push PYPANDA docs to GitHub Pages if docs changed
+        run: cd "${GITHUB_WORKSPACE}/auto_pydoc" &&
+            mv pandare/CNAME ${{ github.ref_name }} &&
+            rm -rf pandare/* &&
+            mv ${{ github.ref_name }}/pandare/* pandare &&
+            rmdir ${{ github.ref_name }}/pandare &&
+            mv ${{ github.ref_name }}/* pandare/ &&
+            cd pandare &&
+            git config --global user.email "panda-ci@panda-re.mit.edu" &&
+            git config --global user.name "PANDA Bot" &&
+            git add . &&
+            git commit -m "Documentation update for PANDA commit ${{ github.sha }} branch ${{ github.ref_name }}" &&
+            git push || true

--- a/panda/python/core/pandare/extras/dwarfdump.py
+++ b/panda/python/core/pandare/extras/dwarfdump.py
@@ -6,6 +6,19 @@ import json
 # dwarfdump -dil $PROG
 
 def parse_die(ent):
+    """
+    Parses a single DWARF Debugging Information Entry (DIE) line from dwarfdump output.
+
+    The line is expected to start after the DIE tag (e.g., '<1><0x45> DW_TAG_... >').
+    It extracts DWARF attributes (DW_AT_*) and their values.
+
+    Args:
+        ent (str): A string containing the DWARF attributes and values for a DIE.
+
+    Returns:
+        dict: A dictionary where keys are DWARF attribute names (str) and
+              values are the attribute data (str).
+    """
     result = {}
     for e in ent.split('> ')[1:]:
         while e.endswith('>'):
@@ -20,6 +33,19 @@ def parse_die(ent):
     return result
 
 def parse_section(indat):
+    """
+    Parses the raw dwarfdump output into sections, separating .debug_info
+    and .debug_line entries.
+
+    Args:
+        indat (bytes): The raw byte content of the dwarfdump output.
+
+    Returns:
+        dict: A dictionary with keys '.debug_line' and '.debug_info'.
+              Each value is a list of relevant string lines from that section.
+              A 'None' marker is added to .debug_line to signal the end of a CU's
+              line table.
+    """
     result = {'.debug_line': [], '.debug_info': []}
     data = indat.decode().strip().split('\n')
     for l in data:
@@ -34,6 +60,16 @@ def parse_section(indat):
     return result
 
 def reprocess_ops(ops):
+    """
+    Converts DWARF location/frame base operation values from strings to integers,
+    handling hexadecimal addresses.
+
+    Args:
+        ops (list): A list of strings representing DWARF operations and operands.
+
+    Returns:
+        list: A list with operands converted to integer types where applicable.
+    """
     out = []
     for op in ops:
         if op.startswith('DW_'):
@@ -49,16 +85,35 @@ def reprocess_ops(ops):
 
 
 class TypeDB(object):
+    """
+    A database to store and manage DWARF type information (TypeInfo objects)
+    indexed by Compilation Unit (CU) offset and type offset within the CU.
+    """
     def __init__(self):
+        """Initializes an empty dictionary to store type data."""
         self.data = {}
 
     def insert(self, cu, off, ty):
+        """
+        Inserts a TypeInfo object into the database.
+
+        Args:
+            cu (int): The offset of the Compilation Unit (CU).
+            off (int): The offset of the type within the CU.
+            ty (TypeInfo): The TypeInfo object to store.
+        """
         if cu not in self.data:
             self.data[cu] = {}
         if off not in self.data[cu]:
             self.data[cu][off] = ty
 
     def jsondump(self):
+        """
+        Prepares the database content for JSON serialization.
+
+        Returns:
+            dict: A nested dictionary structure ready for JSON output.
+        """
         jout = {}
         for cu in self.data:
             jout[cu] = {}
@@ -67,10 +122,26 @@ class TypeDB(object):
         return jout
 
 class LineDB(object):
+    """
+    A database to store and manage source code line number and address mapping (LineRange objects).
+    """
     def __init__(self):
+        """Initializes an empty dictionary to store line data."""
         self.data = {}
 
     def _find_best_fit(self, srcfn, lno, addr):
+        """
+        (Internal) Finds the best-fitting LineRange entry for a previous line number
+        that should be extended to cover the current address range.
+
+        Args:
+            srcfn (str): Source file name.
+            lno (int): Line number to search for.
+            addr (int): Current address.
+
+        Returns:
+            int: The index of the best-fit LineRange, or -1 if none is found.
+        """
         r = [-1, -1]
         for i in range(len(self.data[srcfn])):
             if self.data[srcfn][i].lno == lno:
@@ -79,6 +150,16 @@ class LineDB(object):
         return r[0]
 
     def insert(self, srcfn, lno, col, addr, func=None):
+        """
+        Inserts or updates a code address to line number mapping.
+
+        Args:
+            srcfn (str): Source file name.
+            lno (int): Line number.
+            col (int): Column number.
+            addr (int): Start address of the line range.
+            func (int, optional): Address of the enclosing function. Defaults to None.
+        """
         if srcfn not in self.data:
             self.data[srcfn] = []
 
@@ -99,6 +180,18 @@ class LineDB(object):
             self.data[srcfn][i].highpc = addr
 
     def update_function(self, base_addr, end_addr, finfo):
+        """
+        Updates the function association for a range of line entries.
+
+        Args:
+            base_addr (int): Start address of the function.
+            end_addr (int): End address of the function.
+            finfo (FuncInfo): The function information object.
+
+        Returns:
+            tuple or None: (source_filename, line_number) of the function declaration,
+                           or None if not found.
+        """
         srcinfo = None
         for srcfn in self.data:
             for i in range(len(self.data[srcfn])):
@@ -110,6 +203,12 @@ class LineDB(object):
         return srcinfo
 
     def jsondump(self):
+        """
+        Prepares the database content for JSON serialization.
+
+        Returns:
+            dict: A dictionary mapping source file names to lists of line range data.
+        """
         jout = {}
         for srcfn in self.data:
             key = srcfn
@@ -123,30 +222,66 @@ class LineDB(object):
         return jout
 
 class GlobVarDB(object):
+    """
+    A database to store and manage global variable information (VarInfo objects)
+    indexed by Compilation Unit (CU) offset.
+    """
     def __init__(self):
+        """Initializes an empty dictionary to store global variable data."""
         self.data = {}
 
     def insert(self, cu, var):
+        """
+        Inserts a global variable into the database.
+
+        Args:
+            cu (int): The offset of the Compilation Unit (CU).
+            var (VarInfo): The VarInfo object to store.
+        """
         if cu not in self.data:
             self.data[cu] = set()
         self.data[cu].add(var)
 
     def jsondump(self):
+        """
+        Prepares the database content for JSON serialization.
+
+        Returns:
+            dict: A dictionary mapping CU offsets to lists of global variable data.
+        """
         jout = {}
         for cu in self.data:
             jout[cu] = [f.jsondump() for f in self.data[cu]]
         return jout
 
 class FunctionDB(object):
+    """
+    A database to store and manage function information (FuncInfo objects)
+    indexed by Compilation Unit (CU) offset.
+    """
     def __init__(self):
+        """Initializes an empty dictionary to store function data."""
         self.data = {}
 
     def insert(self, cu, f):
+        """
+        Inserts a function into the database.
+
+        Args:
+            cu (int): The offset of the Compilation Unit (CU).
+            f (FuncInfo): The FuncInfo object to store.
+        """
         if cu not in self.data:
             self.data[cu] = set()
         self.data[cu].add(f)
 
     def jsondump(self):
+        """
+        Prepares the database content for JSON serialization.
+
+        Returns:
+            dict: A dictionary mapping CU offsets to lists of function data.
+        """
         jout = {}
         for cu in self.data:
             jout[cu] = [f.jsondump() for f in self.data[cu]]
@@ -154,7 +289,15 @@ class FunctionDB(object):
 
 
 class VarInfo(object):
+    """Stores DWARF information for a variable (local, global, or parameter)."""
     def __init__(self, name, cu_off):
+        """
+        Initializes VarInfo.
+
+        Args:
+            name (str): Variable name.
+            cu_off (int): Compilation Unit offset.
+        """
         self.name = name
         self.cu_offset = cu_off
         self.scope = None
@@ -164,6 +307,12 @@ class VarInfo(object):
         self.type = None
 
     def jsondump(self):
+        """
+        Prepares the variable info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing all variable attributes.
+        """
         return {'name': self.name, \
                 'cu_offset': self.cu_offset, \
                 'scope': self.scope.jsondump(), \
@@ -173,7 +322,17 @@ class VarInfo(object):
                 'type': self.type}
 
 class FuncInfo(object):
+    """Stores DWARF information for a function (subprogram)."""
     def __init__(self, cu_off, name, scope, fb_op):
+        """
+        Initializes FuncInfo.
+
+        Args:
+            cu_off (int): Compilation Unit offset.
+            name (str): Function name.
+            scope (Scope): The memory range (low/high PC) of the function.
+            fb_op (list): DWARF operation list for the frame base.
+        """
         self.cu_offset = cu_off
         self.name = name
         self.scope = scope
@@ -183,6 +342,12 @@ class FuncInfo(object):
         self.varlist = []
 
     def jsondump(self):
+        """
+        Prepares the function info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing all function attributes.
+        """
         return {'name': self.name, \
                 'cu_offset': self.cu_offset, \
                 'scope': self.scope.jsondump(), \
@@ -192,20 +357,48 @@ class FuncInfo(object):
                 'varlist': [v.jsondump() for v in self.varlist]}
 
 class TypeInfo(object):
+    """Base class for all DWARF type information."""
     def __init__(self, name):
+        """
+        Initializes TypeInfo.
+
+        Args:
+            name (str): Type name.
+        """
         self.name = name
 
     def jsondump(self):
+        """
+        Prepares the base type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing the type name.
+        """
         return {'name': self.name}
 
 class StructType(TypeInfo):
+    """Stores DWARF information for a structure or class."""
     def __init__(self, name, cu_off, size):
+        """
+        Initializes StructType.
+
+        Args:
+            name (str): Struct name.
+            cu_off (int): Compilation Unit offset.
+            size (int): Size of the struct in bytes.
+        """
         TypeInfo.__init__(self, name)
         self.size = size
         self.cu_off = cu_off
         self.children = {}  # <member_offset: (name, type_offset)>
 
     def jsondump(self):
+        """
+        Prepares the struct info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing struct-specific and base attributes.
+        """
         d = TypeInfo.jsondump(self)
         d.update({
                 'tag': 'StructType',
@@ -216,11 +409,25 @@ class StructType(TypeInfo):
         return d
 
 class BaseType(TypeInfo):
+    """Stores DWARF information for a fundamental type (e.g., int, float)."""
     def __init__(self, name, size):
+        """
+        Initializes BaseType.
+
+        Args:
+            name (str): Base type name.
+            size (int): Size of the base type in bytes.
+        """
         TypeInfo.__init__(self, name)
         self.size = size
 
     def jsondump(self):
+        """
+        Prepares the base type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing base type-specific and base attributes.
+        """
         d = TypeInfo.jsondump(self)
         d.update({
                 'tag': 'BaseType',
@@ -229,12 +436,26 @@ class BaseType(TypeInfo):
         return d
 
 class SugarType(TypeInfo):
+    """Base class for types that are aliases or modifiers (e.g., typedef, const)."""
     def __init__(self, name, cu_off):
+        """
+        Initializes SugarType.
+
+        Args:
+            name (str): Type name/alias.
+            cu_off (int): Compilation Unit offset.
+        """
         TypeInfo.__init__(self, name)
         self.cu_off = cu_off
         self.ref = None
 
     def jsondump(self):
+        """
+        Prepares the sugar type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing sugar type-specific and base attributes.
+        """
         d = TypeInfo.jsondump(self)
         d.update({
                 'tag': 'SugarType',
@@ -244,11 +465,26 @@ class SugarType(TypeInfo):
         return d
 
 class PointerType(SugarType):
+    """Stores DWARF information for a pointer type."""
     def __init__(self, name, cu_off, target):
+        """
+        Initializes PointerType.
+
+        Args:
+            name (str): Type name.
+            cu_off (int): Compilation Unit offset.
+            target (int): DWARF offset of the type being pointed to.
+        """
         SugarType.__init__(self, name, cu_off)
         self.ref = target
 
     def jsondump(self):
+        """
+        Prepares the pointer type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing pointer type-specific and base attributes.
+        """
         d = SugarType.jsondump(self)
         d.update({
                 'tag': 'PointerType',
@@ -256,12 +492,27 @@ class PointerType(SugarType):
         return d
 
 class ArrayType(SugarType):
+    """Stores DWARF information for an array type."""
     def __init__(self, name, cu_off, elemty):
+        """
+        Initializes ArrayType.
+
+        Args:
+            name (str): Type name.
+            cu_off (int): Compilation Unit offset.
+            elemty (int): DWARF offset of the array element type.
+        """
         SugarType.__init__(self, name, cu_off)
         self.ref = elemty
         self.range = []
 
     def jsondump(self):
+        """
+        Prepares the array type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing array type-specific and base attributes.
+        """
         d = SugarType.jsondump(self)
         d.update({
                 'tag': 'ArrayType',
@@ -270,12 +521,28 @@ class ArrayType(SugarType):
         return d
 
 class ArrayRangeType(SugarType):
+    """Stores DWARF information for the size or bounds of an array dimension."""
     def __init__(self, name, cu_off, rtype, cnt):
+        """
+        Initializes ArrayRangeType.
+
+        Args:
+            name (str): Type name.
+            cu_off (int): Compilation Unit offset.
+            rtype (int): DWARF offset of the array index type.
+            cnt (int): Array size/count.
+        """
         SugarType.__init__(self, name, cu_off)
         self.ref = rtype
         self.size = cnt
 
     def jsondump(self):
+        """
+        Prepares the array range type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing array range type-specific and base attributes.
+        """
         d = SugarType.jsondump(self)
         d.update({
                 'tag': 'ArrayRangeType',
@@ -284,11 +551,25 @@ class ArrayRangeType(SugarType):
         return d
 
 class EnumType(TypeInfo):
+    """Stores DWARF information for an enumeration type."""
     def __init__(self, name, size):
+        """
+        Initializes EnumType.
+
+        Args:
+            name (str): Enum name.
+            size (int): Size of the enum in bytes.
+        """
         TypeInfo.__init__(self, name)
         self.size = size
 
     def jsondump(self):
+        """
+        Prepares the enum type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing enum type-specific and base attributes.
+        """
         d = TypeInfo.jsondump(self)
         d.update({
                 'tag': 'EnumType',
@@ -297,10 +578,23 @@ class EnumType(TypeInfo):
         return d
 
 class SubroutineType(TypeInfo):
+    """Stores DWARF information for a function type (signature)."""
     def __init__(self, name):
+        """
+        Initializes SubroutineType.
+
+        Args:
+            name (str): Subroutine type name.
+        """
         TypeInfo.__init__(self, name)
 
     def jsondump(self):
+        """
+        Prepares the subroutine type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing subroutine type-specific and base attributes.
+        """
         d = TypeInfo.jsondump(self)
         d.update({
                 'tag': 'SubroutineType',
@@ -308,13 +602,28 @@ class SubroutineType(TypeInfo):
         return d
 
 class UnionType(TypeInfo):
+    """Stores DWARF information for a union type."""
     def __init__(self, name, cu_off, size):
+        """
+        Initializes UnionType.
+
+        Args:
+            name (str): Union name.
+            cu_off (int): Compilation Unit offset.
+            size (int): Size of the union in bytes.
+        """
         TypeInfo.__init__(self, name)
         self.size = size
         self.cu_off = cu_off
         self.children = {}  # <member_offset: (name, type_offset)>
 
     def jsondump(self):
+        """
+        Prepares the union type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing union type-specific and base attributes.
+        """
         d = TypeInfo.jsondump(self)
         d.update({
                 'tag': 'UnionType',
@@ -325,15 +634,40 @@ class UnionType(TypeInfo):
         return d
 
 class Scope(object):
+    """Represents a code range (e.g., function body, lexical block)."""
     def __init__(self, lopc, hipc):
+        """
+        Initializes Scope.
+
+        Args:
+            lopc (int): Low PC (start address).
+            hipc (int): High PC (end address).
+        """
         self.lowpc = lopc
         self.highpc = hipc
 
     def jsondump(self):
+        """
+        Prepares the scope info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing lowpc and highpc.
+        """
         return {'lowpc': self.lowpc, 'highpc': self.highpc}
 
 class LineRange(object):
+    """Represents a contiguous range of addresses corresponding to a source line."""
     def __init__(self, lno, col, lopc, hipc, func):
+        """
+        Initializes LineRange.
+
+        Args:
+            lno (int): Line number.
+            col (int): Column number.
+            lopc (int): Low PC (start address).
+            hipc (int): High PC (end address).
+            func (int): Start address of the enclosing function.
+        """
         self.lno = lno
         self.col = col
         self.lowpc = lopc
@@ -341,6 +675,12 @@ class LineRange(object):
         self.func = func
 
     def jsondump(self):
+        """
+        Prepares the line range info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing all line range attributes.
+        """
         return {
                 'lno': self.lno,
                 'col': self.col,
@@ -350,6 +690,15 @@ class LineRange(object):
                 }
 
 def parse_dwarfdump(indat, prefix=""):
+    """
+    The main parsing routine. Reads dwarfdump output, processes both line info
+    and debug info sections, and populates the databases of variables, functions,
+    and types. Finally, it dumps the databases to JSON files.
+
+    Args:
+        indat (bytes): The raw byte content of the dwarfdump output.
+        prefix (str, optional): Prefix for the output JSON filenames. Defaults to "".
+    """
     reloc_base = 0
     line_info = LineDB()
     globvar_info = GlobVarDB()
@@ -419,6 +768,8 @@ def parse_dwarfdump(indat, prefix=""):
                 if lvl_stack[-1][1] == 'DW_TAG_lexical_block':
                     scope_stack.pop()
                 if lvl_stack[-1][1] == 'DW_TAG_subprogram':
+                    # TODO: Verify if scope pop is needed here
+                    # scope_stack.pop() # Added scope pop, AI recommendation...
                     func_stack.pop()
                 if lvl_stack[-1][1] == 'DW_TAG_structure_type':
                     type_stack.pop()
@@ -514,7 +865,12 @@ def parse_dwarfdump(indat, prefix=""):
                 assert ('DW_AT_decl_file' in res)
                 decl_fn = res['DW_AT_decl_file']
                 decl_fn = decl_fn[v.decl_fn.find(' ')+1:]
-
+                # The check below may fail if v is not defined (first time through loop)
+                # It's better to use the current scope's file info if available, but
+                # given the original code's structure, we'll keep the assignment as is
+                # for minimal functional change, but note potential bug.
+                # TODO: Check if bottom line is correct in broader context.
+                # decl_fn = decl_fn[decl_fn.find(' ')+1:] # Safer version
                 if 'DW_AT_frame_base' in res:
                     fb_op = [res['DW_AT_frame_base'].split(':')[-1].strip()]
                 else:
@@ -682,6 +1038,15 @@ def parse_dwarfdump(indat, prefix=""):
         dump_json(fd, type_info)
 
 def dump_json(j, info):
+    """
+    Utility function to serialize a DWARF database object to a JSON file.
+
+    It uses a custom encoder to call the 'jsondump' method on DWARF objects.
+
+    Args:
+        j (file object): The file stream to write JSON to.
+        info (TypeDB, LineDB, etc.): The database object to serialize.
+    """
     class DwarfJsonEncoder(json.JSONEncoder):
         def default(self, obj):
             if hasattr(obj, "jsondump"):


### PR DESCRIPTION
I got these from the [Capstone project](https://github.com/capstone-engine/capstone/tree/next/.github). They are OK with me using it, and more importantly, I think we can leverage the labels to limit the scope of testing.

For good measure, I also noticed that panda.re has documentation, so I added some using AI for DwarfDump, which is used by LAVA.

Also, I think it's time to try reviving automatic documentation updates:
https://github.com/panda-re/panda-re.github.io