### PR TITLE
Simple but significant speed improvement in textprinter.cpp

### DIFF
--- a/panda/plugins/textprinter/textprinter.cpp
+++ b/panda/plugins/textprinter/textprinter.cpp
@@ -35,6 +35,7 @@ PANDAENDCOMMENT */
 #include <set>
 #include <iostream>
 #include <fstream>
+#include <unordered_set>
 
 #include "panda/plugin.h"
 
@@ -53,11 +54,16 @@ void write_mem_callback(CPUState *env, target_ulong pc, target_ulong addr, size_
 uint64_t mem_counter;
 
 std::set<prog_point> tap_points;
+std::unordered_set<target_ulong> tap_pc;
 gzFile read_tap_buffers;
 gzFile write_tap_buffers;
 
 void mem_callback(CPUState *env, target_ulong pc, target_ulong addr,
                   size_t size, uint8_t *buf, gzFile f) {
+    if (tap_pc.find(pc) == tap_pc.end()) {
+        mem_counter++;
+        return;
+    }
     prog_point p = {};
     get_prog_point(env, &p);
 
@@ -142,6 +148,7 @@ bool init_plugin(void *self) {
         printf("Adding tap point (" TARGET_FMT_lx "," TARGET_FMT_lx ", %s)\n",
                p.caller, p.pc, sid_string);
         tap_points.insert(p);
+        tap_pc.insert(p.pc);
         g_free(sid_string);
     }
     taps.close();

--- a/panda/plugins/textprinter/textprinter.cpp
+++ b/panda/plugins/textprinter/textprinter.cpp
@@ -60,32 +60,32 @@ gzFile write_tap_buffers;
 
 void mem_callback(CPUState *env, target_ulong pc, target_ulong addr,
                   size_t size, uint8_t *buf, gzFile f) {
+    mem_counter++;
     if (tap_pc.find(pc) == tap_pc.end()) {
-        mem_counter++;
         return;
     }
     prog_point p = {};
     get_prog_point(env, &p);
-
-    if (tap_points.find(p) != tap_points.end()) {
-        target_ulong callers[16] = {0};
-        int nret = get_callers(callers, 16, env);
-        unsigned char *buf_uc = static_cast<unsigned char *>(buf);
-        for (unsigned int i = 0; i < size; i++) {
-            for (int j = nret-1; j > 0; j--) {
-                gzprintf(f, TARGET_FMT_lx " ", callers[j]);
-            }
-            gzprintf(f,
-                     TARGET_FMT_lx " " TARGET_FMT_lx " %d " TARGET_FMT_lx
-                                   " " TARGET_FMT_lx " %s " TARGET_FMT_lx
-                                   " %ld %02x\n",
-                     p.caller, p.pc, p.stackKind, p.sidFirst, p.sidSecond,
-                     p.isKernelMode ? "kernel" : "user", addr + i, mem_counter,
-                     buf_uc[i]);
-        }
+    if (tap_points.find(p) == tap_points.end()) {
+        return;
     }
-    mem_counter++;
-
+    
+    target_ulong callers[16] = {0};
+    int nret = get_callers(callers, 16, env);
+    unsigned char *buf_uc = static_cast<unsigned char *>(buf);
+    for (unsigned int i = 0; i < size; i++) {
+        for (int j = nret-1; j > 0; j--) {
+            gzprintf(f, TARGET_FMT_lx " ", callers[j]);
+        }
+        gzprintf(f,
+                 TARGET_FMT_lx " " TARGET_FMT_lx " %d " TARGET_FMT_lx
+                               " " TARGET_FMT_lx " %s " TARGET_FMT_lx
+                               " %ld %02x\n",
+                 p.caller, p.pc, p.stackKind, p.sidFirst, p.sidSecond,
+                 p.isKernelMode ? "kernel" : "user", addr + i, mem_counter,
+                 buf_uc[i]);
+    }
+    
     return;
 }
 


### PR DESCRIPTION
Currently the textprinter plugin does a full `get_prog_point` for all callbacks.
However a simple speedup is to verify that any tap point has the current PC before continuing.

For my test case this gave a very big improvement as you can see below.

Without optimization:
```
        test.rec:  2535950507 (  1.00%) instrs. 1422.76 sec.  2.06 GB ram.
        test.rec:  5071900973 (  2.00%) instrs. 2593.45 sec.  2.59 GB ram.
        test.rec:  7607851447 (  3.00%) instrs. 4124.41 sec.  2.80 GB ram.
```
With opt:
```
        test.rec:  2535950507 (  1.00%) instrs.  528.39 sec.  1.96 GB ram.
        test.rec:  5071900973 (  2.00%) instrs.  922.36 sec.  2.14 GB ram.
        test.rec:  7607851447 (  3.00%) instrs. 1660.56 sec.  2.39 GB ram.
```