### PR TITLE
File Taint: Adding ARM for Linux and Wildcard for Files, with PANDA logging

### DIFF
--- a/panda/debian/setup.sh
+++ b/panda/debian/setup.sh
@@ -64,12 +64,14 @@ HTTP_PROXY="${HTTP_PROXY:-}"
 HTTPS_PROXY="${HTTPS_PROXY:-}"
 
 # Finish building main panda container for the target ubuntu version
+# For local testing, feel free to reduce the TARGET_LIST to a smaller set of targets for faster compiling.
 DOCKER_BUILDKIT=1 docker build \
     --target whlpackager \
     -t packager \
     --build-arg HTTP_PROXY="${HTTP_PROXY}" \
     --build-arg HTTPS_PROXY="${HTTPS_PROXY}" \
     --build-arg BASE_IMAGE="ubuntu:${version}" \
+    --build-arg TARGET_LIST="x86_64-softmmu,i386-softmmu,arm-softmmu,aarch64-softmmu,ppc-softmmu,mips-softmmu,mipsel-softmmu,mips64-softmmu,mips64el-softmmu" \
     --build-arg PACKAGE_VERSION="${tag_version}" \
     ../..
 

--- a/panda/plugins/file_taint/file_taint.proto
+++ b/panda/plugins/file_taint/file_taint.proto
@@ -1,0 +1,9 @@
+message FileTaintMatch {
+    required string filename = 1;
+    required uint32 pid = 2;
+    required uint32 tid = 3;
+    required uint32 file_id = 4;
+}
+
+// Extend the main Panda LogEntry to include this
+optional FileTaintMatch file_taint_match = 1001;

--- a/panda/plugins/taint2/taint2_hypercalls.cpp
+++ b/panda/plugins/taint2/taint2_hypercalls.cpp
@@ -561,8 +561,7 @@ bool guest_hypercall_warning_callback(CPUState *cpu) {
             "hypercall processing\n");
         panda_cb pcb;
         pcb.guest_hypercall = guest_hypercall_warning_callback;
-        panda_disable_callback(taint2_plugin, PANDA_CB_GUEST_HYPERCALL,
-            pcb);
+        panda_disable_callback(taint2_plugin, PANDA_CB_GUEST_HYPERCALL, pcb);
     }
 #endif // defined(TARGET_I386) || defined(TARGET_X86_64) || defined(TARGET_ARM)
     return ret;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every API function and struct this PR changes.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
This PR completes two changes:
1. It adds ARM; OSI Linux already supports multiple architectures like ARM.

For 32-bit ARM, the system calls are identical it i386

https://github.com/panda-re/panda/blob/dev/panda/plugins/syscalls2/generated/syscalls_ext_typedefs_arm64.h#L1377-L1384

https://github.com/panda-re/panda/blob/dev/panda/plugins/syscalls2/generated/syscalls_ext_typedefs_arm.h#L1589-L1596

For 64-bit ARM, the system calls are identical to x86-64

https://github.com/panda-re/panda/blob/dev/panda/plugins/syscalls2/generated/syscalls_ext_typedefs_arm64.h#L1277-L1284

https://github.com/panda-re/panda/blob/dev/panda/plugins/syscalls2/generated/syscalls_ext_typedefs_arm64.h#L1373-L1380

I'm also assuming that I need to check register 0 for both the ARM architecture to get the number of bytes read.

2. For LAVA, I intend to have one recording have one binary run on multiple files in one shot. This would massively improve performance, but file_taint only works with one file at a time. I'm updating the rules on matching to support regular expression matching at the end, allowing for matching multiple files.

fnmatch seems to be the best fit for supporting flexibility on file names, matching how shells do file matching.

https://man7.org/linux/man-pages/man3/fnmatch.3.html
...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Or what test cases you added. Ideally, provide screenshots to show that your code changes work as expected -->

With LAVA, I will test being able to run with files such as ./toy/inputs/*, which should taint files such as ./toy/inputs/small-1.bin, ./toy/inputs/small-2.bin

I can confirm, based on LAVA logs, that two files, testbig.bin and testsmall.bin, were tainted using the wildcard. Additionally, it appears that taint2 works on both files. I added a debug print on label_ram JUST to make sure.

When testing originally, I saw the taint2 hypercall warning, hence that debug message, but I guess I was needlessly spooked.

[bug_mining.log](https://github.com/user-attachments/files/23831194/bug_mining.log)

Also, I added panda logging to any new files tainted, see here:
<img alt="image" src="https://github.com/user-attachments/assets/34650904-3519-4623-a818-9d010e8de62f" />

This would be useful so if your log captures multiple file taints, you can figure out which taints belong to which files!

**PSA: If you use Python to convert panda log to JSON, you MUST use the updated version of PyPanda that will be made with this PR, then you should be able to see the FileMatchTaint instance**.

You would see this in Python under pandare/plog_pb2.py, and search for "file_taint_match"

...


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
N/A
...