### PR TITLE
Dwarf2 now supports ARM for LAVA

### DIFF
--- a/panda/plugins/dwarf2/README.md
+++ b/panda/plugins/dwarf2/README.md
@@ -4,9 +4,28 @@ Plugin: dwarf2
 Summary
 -------
 
-The `dwarf2` plugin is to be a replacement of `pri_dwarf` plugin. The workflow is to run 
-`dwarfdump -dil ${TARGET_PROG} | python -c "import sys;from pandare.extras import dwarfdump;dwarfdump.parse_dwarfdump(sys.stdin.read(), '${TARGET_PROG}')"`.
-This is going to generate 4 json DWARF symbol files including: Line Info, Global Variables, Function Info, and Type Info. Place these json files under debug path for this plugin to read.
+The `dwarf2` plugin is to be a replacement of `pri_dwarf` plugin.
+
+Before running the plugin, you need to extract DWARF debug information from the target binary into json files using the `pandare.extras.dwarfdump` module. You can do this by running the following commands:
+
+This plug-in/script is used for [LAVA](https://github.com/panda-re/lava), so it assumes that the binary has the following CFLAGS `-O0 -g -gdwarf-2 -fno-stack-protector`. 
+This is because these flags ensure all the input needed for Python to parse the dwarf dump is available to plant vulnerabilities.
+
+```bash
+# Assume TARGET_PROG is the path to the target program with DWARF debug info
+dwarfdump -dil ${TARGET_PROG} > tmp.dump
+python3 -m pandare.extras.dwarfdump tmp.dump temp
+
+# Alternatively, you can use the following one-liner to achieve the same result:
+dwarfdump -dil <binary> | python3 -m pandare.extras.dwarfdump <binary-prefix>
+```
+This is going to generate 4 JSON DWARF symbol files including: 
+* Line Info
+* Global Variables
+* Function Info
+* Type Info
+
+Place these JSON files under debug path for this plugin to read.
 
 Arguments
 ---------

--- a/panda/python/core/setup.py
+++ b/panda/python/core/setup.py
@@ -9,9 +9,10 @@ if "PRETEND_VERSION" in os.environ:
 else:
     from setuptools_scm import get_version
     version = get_version(root='../../..',
-                          fallback_version="0.0.0.1",
+                          fallback_version="0.0.1",
                           version_scheme="guess-next-dev",
                           local_scheme="no-local-version")
+    version = version.partition(".dev")[0]
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -22,4 +23,3 @@ setup(
     url='https://github.com/panda-re/panda/',
     version=version
 )
-


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every API function and struct this PR changes.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pull request aims to grant dwarf2 support for ARM. Allowing this support would allow for LAVA to inject bugs into the ARM architecture, see [here](https://github.com/panda-re/libhc/pull/8)

---
ARM
Once I built the executable, I used the following command. `readelf --debug-dump=info test_hc_arm | grep "DW_OP_reg"`

<img alt="image" src="https://github.com/user-attachments/assets/9dc054bb-c3c0-43df-b36c-aba2796bc6a7" />

To confirm that I should not use the aliases, and just stick register numbers, use the command `readelf --debug-dump=frames test_hc_aarch64 | grep -E "RA|CFA"`

<img alt="image" src="https://github.com/user-attachments/assets/63459792-7060-4c63-be7b-019142e830da" />

To confirm the macros are identical for i386, I confirmed they both use LSB and are 32-bits.

<img alt="image" src="https://github.com/user-attachments/assets/24ced696-6771-47f6-a33c-2f79e56e48d8" />

---
AARCH64
Once I built the executable, I used the following command. `readelf --debug-dump=info test_hc_aarch64 | grep "DW_OP_reg"`

<img alt="image" src="https://github.com/user-attachments/assets/dcde94a6-37cf-419a-89b1-3835187fac86" />

To confirm that I should not use the aliases, and just stick register numbers, use the command  `readelf --debug-dump=frames test_hc_aarch64 | grep -E "RA|CFA"`

<img alt="image" src="https://github.com/user-attachments/assets/02de789b-93ff-419a-8e54-638c9cdeadf3" />

To confirm that `ELFCLASS64` and `ELFDATA2LSB` are correct macros, refer to the screenshots, which show both as 64-bit and LSB-first. Additionally, the update now supports EM_AARCH64, which aligns with the AARCH64 machine architecture.

<img alt="image" src="https://github.com/user-attachments/assets/8cac40c1-9fce-4e92-8c4a-a24280bd1b21" />

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. Ideally provide screenshots to show the your code changes work as expected -->

Additionally, I followed the guidance provided here on setting registers and mapping.

https://github.com/panda-re/panda/blob/dev/panda/python/core/pandare/arch.py

I did test using dwarfdump.py on dwarf dump output from AARCH/ARM, and that explains the fixes. But given the static code analysis, it is likely the registers would map correctly on AARCH64 for LAVA.

The test would really be testable once ARM/AARCH64 hypercalls are fixed.
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
Bugs were fixed [here](https://github.com/panda-re/panda/pull/1614)
...