### PR TITLE
Urgent Fix for DwarfDump Pathing and Action Version Upgrades

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,248 +1,327 @@
 Build:
-  - Dockerfile
-  - panda/build.sh
-  - panda/build-llvm.sh
-  - panda/Makefile.panda
-  - panda/Makefile.panda.target
-  - Makefile
-  - Makefile.objs
-  - Makefile.target
-  - configure
+  - changed-files:
+    - any-glob-to-any-file: Dockerfile
+    - any-glob-to-any-file: panda/build.sh
+    - any-glob-to-any-file: panda/build-llvm.sh
+    - any-glob-to-any-file: panda/Makefile.panda
+    - any-glob-to-any-file: panda/Makefile.panda.target
+    - any-glob-to-any-file: Makefile
+    - any-glob-to-any-file: Makefile.objs
+    - any-glob-to-any-file: Makefile.target
+    - any-glob-to-any-file: configure
 
 Documentation:
-  - '**/*.md'
+  - changed-files:
+    - any-glob-to-any-file: '**/*.md'
 
 Github-files:
-  - .github/**
+  - changed-files:
+    - any-glob-to-any-file: .github/**
 
 PyPanda:
-  - panda/python/**/*.py
-  - panda/python/**/*.h
+  - changed-files:
+    - any-glob-to-any-file: panda/python/**/*.py
+    - any-glob-to-any-file: panda/python/**/*.h
+    - any-glob-to-any-file: panda/python/**/*.json
 
 Debian:
-  - panda/debian/**
+  - changed-files:
+    - any-glob-to-any-file: panda/debian/**
 
 LLVM:
-  - panda/llvm/**
-  - panda/include/panda/tcg-llvm.h
+  - changed-files:
+    - any-glob-to-any-file: panda/llvm/**
+    - any-glob-to-any-file: panda/include/panda/tcg-llvm.h
 
 PANDA-Core:
-  - panda/src/**
+  - changed-files:
+    - any-glob-to-any-file: panda/src/**
 
 PANDA-Tests:
-  - panda/testing/**
-  - panda/plugins/taint2/tests/**
+  - changed-files:
+    - any-glob-to-any-file: panda/testing/**
+    - any-glob-to-any-file: panda/plugins/taint2/tests/**
 
 # All PANDA plug-in tags, used to call specific plug-in tests
 asid_instr_count:
-  - panda/plugins/asid_instr_count/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/asid_instr_count/**
 
 asidstory:
-  - panda/plugins/asidstory/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/asidstory/**
 
 callfunc:
-  - panda/plugins/callfunc/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/callfunc/**
 
 callstack_instr:
-  - panda/plugins/callstack_instr/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/callstack_instr/**
 
 callwitharg:
-  - panda/plugins/callwitharg/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/callwitharg/**
 
 checkpoint:
-  - panda/plugins/checkpoint/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/checkpoint/**
 
 collect_code:
-  - panda/plugins/collect_code/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/collect_code/**
 
 correlatetaps:
-  - panda/plugins/correlatetaps/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/correlatetaps/**
 
 cosi:
-  - panda/plugins/cosi/**
-  - panda/python/core/extras/cosi.py
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/cosi/**
+    - any-glob-to-any-file: panda/python/core/extras/cosi.py
 
 cosi_strace:
-  - panda/plugins/cosi_strace/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/cosi_strace/**
 
 coverage:
-  - panda/plugins/coverage/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/coverage/**
 
 dwarf2:
-  - panda/plugins/dwarf2/**
-  - panda/python/core/extras/dwarfdump.py
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/dwarf2/**
+    - any-glob-to-any-file: panda/python/core/extras/dwarfdump.py
 
 dynamic_symbols:
-  - panda/plugins/dynamic_symbols/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/dynamic_symbols/**
 
 edge_coverage:
-  - panda/plugins/edge_coverage/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/edge_coverage/**
 
 file_taint:
-  - panda/plugins/file_taint/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/file_taint/**
 
 filereadmon:
-  - panda/plugins/filereadmon/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/filereadmon/**
 
 findcall:
-  - panda/plugins/findcall/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/findcall/**
 
 forcedexec:
-  - panda/plugins/forcedexec/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/forcedexec/**
 
 func_stats:
-  - panda/plugins/func_stats/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/func_stats/**
 
 gdb:
-  - panda/plugins/gdb/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/gdb/**
 
 hooks:
-  - panda/plugins/hooks/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/hooks/**
 
 hooks2:
-  - panda/plugins/hooks2/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/hooks2/**
 
 hw_proc_id:
-  - panda/plugins/hw_proc_id/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/hw_proc_id/**
 
 hypercaller:
-  - panda/plugins/hypercaller/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/hypercaller/**
 
 ida_taint2:
-  - panda/plugins/ida_taint2/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/ida_taint2/**
 
 keyfind:
-  - panda/plugins/keyfind/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/keyfind/**
 
 libfi:
-  - panda/plugins/libfi/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/libfi/**
 
 lighthouse_coverage:
-  - panda/plugins/lighthouse_coverage/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/lighthouse_coverage/**
 
 loaded:
-  - panda/plugins/loaded/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/loaded/**
 
 loaded_libs:
-  - panda/plugins/loaded_libs/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/loaded_libs/**
 
 mem_hooks:
-  - panda/plugins/mem_hooks/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/mem_hooks/**
 
 memorymap:
-  - panda/plugins/memorymap/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/memorymap/**
 
 memsavep:
-  - panda/plugins/memsavep/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/memsavep/**
 
 mmio_trace:
-  - panda/plugins/mmio_trace/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/mmio_trace/**
 
 net:
-  - panda/plugins/net/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/net/**
 
 network:
-  - panda/plugins/network/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/network/**
 
 osi:
-  - panda/plugins/osi/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/osi/**
 
 osi_linux:
-  - panda/plugins/osi_linux/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/osi_linux/**
 
 osi_test:
-  - panda/plugins/osi_test/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/osi_test/**
 
 pc_search:
-  - panda/plugins/pc_search/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/pc_search/**
 
 pri_dwarf:
-  - panda/plugins/pri_dwarf/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/pri_dwarf/**
 
 pri_simple:
-  - panda/plugins/pri_simple/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/pri_simple/**
 
 pri_taint:
-  - panda/plugins/pri_taint/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/pri_taint/**
 
 pri_trace:
-  - panda/plugins/pri_trace/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/pri_trace/**
 
 proc_start_linux:
-  - panda/plugins/proc_start_linux/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/proc_start_linux/**
 
 proc_trace:
-  - panda/plugins/proc_trace/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/proc_trace/**
 
 query_file_writes:
-  - panda/plugins/query_file_writes/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/query_file_writes/**
 
 recctrl:
-  - panda/plugins/recctrl/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/recctrl/**
 
 replaymovie:
-  - panda/plugins/replaymovie/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/replaymovie/**
 
 scissors:
-  - panda/plugins/scissors/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/scissors/**
 
 serial_taint:
-  - panda/plugins/serial_taint/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/serial_taint/**
 
 signal:
-  - panda/plugins/signal/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/signal/**
 
 snake_hook:
-  - panda/plugins/snake_hook/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/snake_hook/**
 
 speedtest:
-  - panda/plugins/speedtest/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/speedtest/**
 
 stringsearch:
-  - panda/plugins/stringsearch/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/stringsearch/**
 
 syscalls_logger:
-  - panda/plugins/syscalls_logger/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/syscalls_logger/**
 
 syscalls2:
-  - panda/plugins/syscalls2/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/syscalls2/**
 
 taint2:
-  - panda/plugins/taint2/**
-  - panda/python/core/taint/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/taint2/**
+    - any-glob-to-any-file: panda/python/core/taint/**
 
 tainted_branch:
-  - panda/plugins/tainted_branch/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/tainted_branch/**
 
 tainted_instr:
-  - panda/plugins/tainted_instr/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/tainted_instr/**
 
 tainted_mmio:
-  - panda/plugins/tainted_mmio/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/tainted_mmio/**
 
 tainted_net:
-  - panda/plugins/tainted_net/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/tainted_net/**
 
 tapindex:
-  - panda/plugins/tapindex/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/tapindex/**
 
 targetcmp:
-  - panda/plugins/targetcmp/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/targetcmp/**
 
 textprinter:
-  - panda/plugins/textprinter/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/textprinter/**
 
 trace:
-  - panda/plugins/trace/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/trace/**
 
 track_intexc:
-  - panda/plugins/track_intexc/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/track_intexc/**
 
 tstringsearch:
-  - panda/plugins/tstringsearch/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/tstringsearch/**
 
 unigrams:
-  - panda/plugins/unigrams/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/unigrams/**
 
 wintrospection:
-  - panda/plugins/wintrospection/**
+  - changed-files:
+    - any-glob-to-any-file: panda/plugins/wintrospection/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,8 +12,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v6
       with:
+        sync-labels: true
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/parallel_tests.yml
+++ b/.github/workflows/parallel_tests.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             image=moby/buildkit:master
@@ -92,14 +92,14 @@ jobs:
           sudo update-ca-certificates
 
       - name: Log in to Panda Arc Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.PANDA_ARC_REGISTRY }}
           username: ${{ env.PANDA_ARC_REGISTRY_USER }}
           password: ${{ secrets.PANDA_ARC_REGISTRY_PASSWORD || env.EXTERNAL_REGISTRY_PASS }}
 
       - name: Build panda:latest
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v7
         with:
           push: false # set this to true if you we start using the container
           context: ${{ github.workspace }}
@@ -139,7 +139,7 @@ jobs:
   #       with:
   #         fetch-depth: 0
   #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+  #       uses: docker/setup-buildx-action@v4
   #       with:
   #         driver-opts: |
   #           image=moby/buildkit:master
@@ -156,7 +156,7 @@ jobs:
   #         sudo update-ca-certificates
 
   #     - name: Log in to Panda Arc Registry
-  #       uses: docker/login-action@v3
+  #       uses: docker/login-action@v4
   #       with:
   #         registry: ${{ env.PANDA_ARC_REGISTRY }}
   #         username: ${{ env.PANDA_ARC_REGISTRY_USER }}

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - dev
       - stable
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+        description: "Select the type of version bump for the release"
 
 # Ensure sequential execution of workflows on the same branch.
 # If a workflow is already running, new pushes will wait in a queue
@@ -31,6 +42,7 @@ jobs:
         with:
           release_branch: dev
           use_api: true
+          increment: ${{ github.event.inputs.bump_type || 'patch' }}
   
   build_docker:
     needs: get_version
@@ -38,13 +50,13 @@ jobs:
     if: github.repository == 'panda-re/panda' && github.ref == 'refs/heads/dev'
     steps:
       - name: 'Login to Docker Registry'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: pandare
           password: ${{secrets.pandare_dockerhub}} 
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             image=moby/buildkit:master
@@ -62,19 +74,19 @@ jobs:
           sudo update-ca-certificates
 
       - name: Log in to Rehosting Arc Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.PANDA_ARC_REGISTRY }}
           username: ${{ secrets.PANDA_ARC_REGISTRY_USER }}
           password: ${{ secrets.PANDA_ARC_REGISTRY_PASSWORD }}
       
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Build panda:latest
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: ${{ github.workspace }}
@@ -91,7 +103,7 @@ jobs:
           build-args: |
             REGISTRY=${{ secrets.PANDA_ARC_REGISTRY }}/proxy
       - name: Build pandadev:latest
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: ${{ github.workspace }}
@@ -129,7 +141,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             image=moby/buildkit:master
@@ -151,14 +163,14 @@ jobs:
           VERSION=${VERSION#v}
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV      
       - name: Log in to Rehosting Arc Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ secrets.PANDA_ARC_REGISTRY }}
           username: ${{ secrets.PANDA_ARC_REGISTRY_USER }}
           password: ${{ secrets.PANDA_ARC_REGISTRY_PASSWORD }}
 
       - name: Build panda packager
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v7
         with:
           push: false
           load: true
@@ -266,5 +278,11 @@ jobs:
           git config --global user.email "panda-ci@panda-re.mit.edu"
           git config --global user.name "PANDA Bot"
           git add .
-          git commit -m "Documentation update for PANDA commit ${{ github.sha }} branch ${{ github.ref_name }}"
-          git push || true
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Changes found. Updating docs.panda.re."
+            git commit -m "Documentation update for PANDA commit ${{ github.sha }} branch ${{ github.ref_name }}"
+            git push || true
+          else
+            echo "No changes detected. Skipping push."
+          fi
+

--- a/panda/python/core/pandare/extras/dwarfdump.py
+++ b/panda/python/core/pandare/extras/dwarfdump.py
@@ -2,8 +2,79 @@
 
 import sys
 import json
+import re
+import os
+from typing import Optional
 
-# dwarfdump -dil $PROG
+
+def resolve_real_path(dwarf_path: str, project_root: Optional[str]) -> str:
+    """
+    Heuristically resolves corrupted DWARF file paths caused by recursive build systems.
+
+    Build systems using commands like `make -C src` often duplicate directory names 
+    in the resulting DWARF DW_AT_comp_dir and DW_AT_name fields (e.g., creating 
+    phantom paths like `.../src/src/file.c`). This function detects these stutters 
+    and attempts to map them back to the physical file on disk.
+
+    Args:
+        dwarf_path (str): The absolute path extracted from the DWARF data.
+        project_root (str): The absolute, safe path to the root of the extracted 
+                            project folder. This portion of the path is strictly 
+                            protected from heuristic modifications.
+
+    Returns:
+        str: The corrected absolute file path if found on disk, otherwise 
+             returns the original unmodified dwarf_path.
+             
+    Raises:
+        TypeError: If either dwarf_path or project_root is not a string.
+    """
+    if not isinstance(dwarf_path, str):
+        raise TypeError(f"Expected dwarf_path to be a str, got {type(dwarf_path)}")
+
+    if project_root is None or project_root == "":
+        return dwarf_path
+
+    if not isinstance(project_root, str):
+        raise TypeError(f"Expected project_root to be a str or None, got {type(project_root)}")
+
+    # 1. If it already exists on disk, it's perfect. Return it immediately.
+    if os.path.isfile(dwarf_path):
+        return dwarf_path
+        
+    # Normalize paths to handle trailing slashes consistently
+    norm_root = os.path.normpath(project_root)
+    norm_dwarf = os.path.normpath(dwarf_path)
+    
+    # 2. THE REGEX FIX (Root-Protected)
+    try:
+        in_root = os.path.commonpath([norm_root, norm_dwarf]) == norm_root
+    except ValueError:
+        in_root = False
+
+    if in_root:
+        # Extract the unsafe downstream portion of the path
+        unsafe_suffix = norm_dwarf[len(norm_root):]
+
+        # Apply the stutter fix ONLY to the downstream portion
+        # Turns "/src/src/magic.c" into "/src/magic.c"
+        fixed_suffix = re.sub(r'(/[^/]+)\1/', r'\1/', unsafe_suffix)
+
+        # Recombine the strictly safe root with the healed suffix
+        # Using lstrip to prevent os.path.join from treating fixed_suffix as an absolute path
+        fixed_path = os.path.join(norm_root, fixed_suffix.lstrip('/\\'))
+    else:
+        # Fallback: if the dwarf_path somehow doesn't start with our project root,
+        # try to heal the whole string as a last resort.
+        fixed_path = re.sub(r'(/[^/]+)\1/', r'\1/', norm_dwarf)
+    
+    # 3. Check if our regex fix actually points to a real file!
+    if os.path.isfile(fixed_path):
+        return fixed_path
+        
+    # If even the fixed path doesn't exist, return the original and hope for the best
+    return dwarf_path
+
 
 def parse_die(ent):
     """
@@ -84,6 +155,25 @@ def reprocess_ops(ops):
             out.append(op)
     return out
 
+class TypeInfo(object):
+    """Base class for all DWARF type information."""
+    def __init__(self, name: str):
+        """
+        Initializes TypeInfo.
+
+        Args:
+            name (str): Type name.
+        """
+        self.name = name
+
+    def jsondump(self):
+        """
+        Prepares the base type info for JSON serialization.
+
+        Returns:
+            dict: A dictionary containing the type name.
+        """
+        return {'name': self.name}
 
 class TypeDB(object):
     """
@@ -94,7 +184,7 @@ class TypeDB(object):
         """Initializes an empty dictionary to store type data."""
         self.data = {}
 
-    def insert(self, cu, off, ty):
+    def insert(self, cu: int, off: int, ty: TypeInfo):
         """
         Inserts a TypeInfo object into the database.
 
@@ -130,7 +220,7 @@ class LineDB(object):
         """Initializes an empty dictionary to store line data."""
         self.data = {}
 
-    def _find_best_fit(self, srcfn, lno, addr):
+    def _find_best_fit(self, srcfn: str, lno: int, addr: int):
         """
         (Internal) Finds the best-fitting LineRange entry for a previous line number
         that should be extended to cover the current address range.
@@ -150,7 +240,7 @@ class LineDB(object):
                     r = [i, self.data[srcfn][i].highpc]
         return r[0]
 
-    def insert(self, srcfn, lno, col, addr, func=None):
+    def insert(self, srcfn: str, lno: int, col: int, addr: int, func: int = None):
         """
         Inserts or updates a code address to line number mapping.
 
@@ -161,6 +251,7 @@ class LineDB(object):
             addr (int): Start address of the line range.
             func (int, optional): Address of the enclosing function. Defaults to None.
         """
+        assert srcfn, "Source filename not found in line info"
         if srcfn not in self.data:
             self.data[srcfn] = []
 
@@ -180,7 +271,7 @@ class LineDB(object):
         if i != -1:
             self.data[srcfn][i].highpc = addr
 
-    def update_function(self, base_addr, end_addr, finfo):
+    def update_function(self, base_addr: int, end_addr: int, finfo):
         """
         Updates the function association for a range of line entries.
 
@@ -212,13 +303,8 @@ class LineDB(object):
         """
         jout = {}
         for srcfn in self.data:
-            key = srcfn
-            while srcfn[0] in ['"', "'"]:
-                srcfn = srcfn[1:]
-            while srcfn[-1] in ['"', "'"]:
-                srcfn = srcfn[:-1]
             jout[srcfn] = []
-            for lr in self.data[key]:
+            for lr in self.data[srcfn]:
                 jout[srcfn].append(lr.jsondump())
         return jout
 
@@ -290,7 +376,10 @@ class FunctionDB(object):
 
 
 class VarInfo(object):
-    """Stores DWARF information for a variable (local, global, or parameter)."""
+    """
+    Stores DWARF information for a variable (local, global, or parameter).
+    You will see this populate the _funcinfo.json
+    """
     def __init__(self, name, cu_off):
         """
         Initializes VarInfo.
@@ -323,7 +412,9 @@ class VarInfo(object):
                 'type': self.type}
 
 class FuncInfo(object):
-    """Stores DWARF information for a function (subprogram)."""
+    """
+    Stores DWARF information for a function (subprogram).
+    """
     def __init__(self, cu_off, name, scope, fb_op):
         """
         Initializes FuncInfo.
@@ -356,26 +447,6 @@ class FuncInfo(object):
                 'fn': self.fn,
                 'lno': self.lno,
                 'varlist': [v.jsondump() for v in self.varlist]}
-
-class TypeInfo(object):
-    """Base class for all DWARF type information."""
-    def __init__(self, name):
-        """
-        Initializes TypeInfo.
-
-        Args:
-            name (str): Type name.
-        """
-        self.name = name
-
-    def jsondump(self):
-        """
-        Prepares the base type info for JSON serialization.
-
-        Returns:
-            dict: A dictionary containing the type name.
-        """
-        return {'name': self.name}
 
 class StructType(TypeInfo):
     """Stores DWARF information for a structure or class."""
@@ -438,7 +509,7 @@ class BaseType(TypeInfo):
 
 class SugarType(TypeInfo):
     """Base class for types that are aliases or modifiers (e.g., typedef, const)."""
-    def __init__(self, name, cu_off):
+    def __init__(self, name: str, cu_off: int):
         """
         Initializes SugarType.
 
@@ -467,7 +538,7 @@ class SugarType(TypeInfo):
 
 class PointerType(SugarType):
     """Stores DWARF information for a pointer type."""
-    def __init__(self, name, cu_off, target):
+    def __init__(self, name: str, cu_off: int, target: int):
         """
         Initializes PointerType.
 
@@ -494,7 +565,7 @@ class PointerType(SugarType):
 
 class ArrayType(SugarType):
     """Stores DWARF information for an array type."""
-    def __init__(self, name, cu_off, elemty):
+    def __init__(self, name: str, cu_off: int, elemty: int):
         """
         Initializes ArrayType.
 
@@ -523,7 +594,7 @@ class ArrayType(SugarType):
 
 class ArrayRangeType(SugarType):
     """Stores DWARF information for the size or bounds of an array dimension."""
-    def __init__(self, name, cu_off, rtype, cnt):
+    def __init__(self, name: str, cu_off: int, rtype: int, cnt: int):
         """
         Initializes ArrayRangeType.
 
@@ -580,7 +651,7 @@ class EnumType(TypeInfo):
 
 class SubroutineType(TypeInfo):
     """Stores DWARF information for a function type (signature)."""
-    def __init__(self, name):
+    def __init__(self, name: str):
         """
         Initializes SubroutineType.
 
@@ -604,7 +675,7 @@ class SubroutineType(TypeInfo):
 
 class UnionType(TypeInfo):
     """Stores DWARF information for a union type."""
-    def __init__(self, name, cu_off, size):
+    def __init__(self, name: str, cu_off: int, size: int):
         """
         Initializes UnionType.
 
@@ -636,7 +707,7 @@ class UnionType(TypeInfo):
 
 class Scope(object):
     """Represents a code range (e.g., function body, lexical block)."""
-    def __init__(self, lopc, hipc):
+    def __init__(self, lopc: int, hipc: int):
         """
         Initializes Scope.
 
@@ -658,7 +729,7 @@ class Scope(object):
 
 class LineRange(object):
     """Represents a contiguous range of addresses corresponding to a source line."""
-    def __init__(self, lno, col, lopc, hipc, func):
+    def __init__(self, lno: int, col: int, lopc: int, hipc: int, func: int):
         """
         Initializes LineRange.
 
@@ -690,7 +761,7 @@ class LineRange(object):
                 'func': self.func,
                 }
 
-def parse_dwarfdump(input_data: str, prefix: str=""):
+def parse_dwarfdump(input_data: str, prefix: str="", project_root=None):
     """
     The main parsing routine. Reads dwarfdump output, processes both line info
     and debug info sections, and populates the databases of variables, functions,
@@ -699,6 +770,7 @@ def parse_dwarfdump(input_data: str, prefix: str=""):
     Args:
         input_data (str): The content of the dwarfdump output.
         prefix (str, optional): Prefix for the output JSON filenames. Defaults to "".
+        project_root (str, optional): The absolute path to the root of the extracted project folder, used for path resolution. Defaults to None.
     """
     reloc_base = 0
     line_info = LineDB()
@@ -712,16 +784,23 @@ def parse_dwarfdump(input_data: str, prefix: str=""):
         for line in data[tag]:
             if line is None:
                 continue
+            
             line = line.strip()
             if line.startswith("0x"):
                 addrstr, rest = line.split('[')
                 lnostr, info = rest.split(']')
-                if "uri:" in info:
-                    srcfn = info.split("uri:")[-1].strip()
-                assert srcfn, "Source filename not found in line info"
                 addr = int(addrstr.strip(), 16) + reloc_base
                 lno = int(lnostr.strip().split(',')[0])
                 col = int(lnostr.strip().split(',')[1])
+                if "uri:" in info:
+                    srcfn = info.split("uri:")[-1].strip()
+                    while srcfn and srcfn[0] in ['"', "'"]:
+                        srcfn = srcfn[1:]
+                    while srcfn and srcfn[-1] in ['"', "'"]:
+                        srcfn = srcfn[:-1]
+                    srcfn = resolve_real_path(srcfn, project_root=project_root)
+                # I genuninely have no idea why if line info goes inside the 'if' this scripts breaks...
+                # but don't touch it if it doesn't break any tests!
                 line_info.insert(srcfn, lno, col, addr)
 
     type_overlay = None
@@ -814,7 +893,8 @@ def parse_dwarfdump(input_data: str, prefix: str=""):
                 v.decl_lno = int(res['DW_AT_decl_line'], 16)
                 assert 'DW_AT_decl_file' in res, "DW_AT_decl_file missing in variable"
                 v.decl_fn = res['DW_AT_decl_file']
-                v.decl_fn = v.decl_fn[v.decl_fn.find(' ')+1:]
+                v.decl_fn = v.decl_fn[v.decl_fn.find(' ') + 1:]
+                v.decl_fn = resolve_real_path(v.decl_fn, project_root=project_root)
                 if 'DW_AT_location' not in res:
                     continue
                 for x in res['DW_AT_location'].split(':')[-1].strip().split('DW_OP_'):
@@ -842,7 +922,8 @@ def parse_dwarfdump(input_data: str, prefix: str=""):
                 v.decl_lno = int(res['DW_AT_decl_line'], 16)
                 assert 'DW_AT_decl_file' in res, "DW_AT_decl_file missing in formal parameter"
                 v.decl_fn = res['DW_AT_decl_file']
-                v.decl_fn = v.decl_fn[v.decl_fn.find(' ')+1:]
+                v.decl_fn = v.decl_fn[v.decl_fn.find(' ') + 1:]
+                v.decl_fn = resolve_real_path(v.decl_fn, project_root=project_root)
                 if 'DW_AT_location' not in res:
                     continue
                 for x in res['DW_AT_location'].split(':')[-1].strip().split('DW_OP_'):
@@ -879,6 +960,7 @@ def parse_dwarfdump(input_data: str, prefix: str=""):
                 f = FuncInfo(cu_off, name, scope, fb_op)
 
                 f.fn, f.lno = line_info.update_function(base_addr, end_addr, f)
+                f.fn = resolve_real_path(f.fn, project_root=project_root)
 
                 func_stack.append(f)
                 func_info.insert(cu_off, f)
@@ -1055,32 +1137,29 @@ def dump_json(j, info):
 
 
 if __name__ == '__main__':
-    """
-    Usage (File): python3 dwarfdump.py dump.txt my_prefix
-    Usage (Pipe): dwarfdump -dil bin | python3 dwarfdump.py my_prefix
-    """
-    import os
-
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <dwarfdump_output_file | output_prefix> [output_prefix_if_file_used]")
+        print(f"Usage: {sys.argv[0]} <dwarfdump_output_file | output_prefix> [output_prefix_if_file_used] [project_root]")
         sys.exit(1)
 
     dwarf_content = None
-    prefix = ""
+    prefix = "output"
+    project_root = os.environ.get("PROJECT_ROOT", None) # Can pass via env var
 
-    # Check if the first argument is an existing file
     if os.path.isfile(sys.argv[1]):
         with open(sys.argv[1], 'r', encoding='utf-8') as fd:
             print(f"[*] Reading dwarfdump output from file: {sys.argv[1]}")
             dwarf_content = fd.read()
-        # If a file is provided, prefix is usually the second argument
         prefix = sys.argv[2] if len(sys.argv) > 2 else "output"
+        # Grab project root if passed as 3rd CLI argument
+        if len(sys.argv) > 3:
+            project_root = sys.argv[3]
     else:
-        # If not a file, assume it's a prefix, and we are reading from a pipe
         prefix = sys.argv[1]
         print(f"[*] Reading dwarfdump data from stdin (pipe mode)...")
-        # Read from buffer to get bytes for the internal pandare .decode() call
         dwarf_content = sys.stdin.buffer.read().decode()
+        # Grab project root if passed as 2nd CLI argument in pipe mode
+        if len(sys.argv) > 2:
+            project_root = sys.argv[2]
 
     if not dwarf_content:
         print("[-] Error: No DWARF data found.")
@@ -1088,7 +1167,9 @@ if __name__ == '__main__':
 
     try:
         print(f"[*] Processing DWARF for prefix: {prefix}...")
-        parse_dwarfdump(dwarf_content, prefix)
+        print(f"[*] Using Project Root: {project_root if project_root else None}")
+        
+        parse_dwarfdump(dwarf_content, prefix, project_root=project_root)
         print(f"[+] Success! JSON files generated with prefix '{prefix}'")
     except AssertionError as e:
         print("[-] Error: DWARF parsing failed (AssertionError).")


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every API function and struct in this PR.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently, dwarfdump doesn't correctly generate the path if `make` changes the directory e.g., uses `make -C src`, it will create duplicate entries of subdirectories as shown here

```
        {
                    "name": "phs",
                    "cu_offset": 29106,
                    "scope": {
                        "lowpc": 202080,
                        "highpc": 202220
                    },
                    "decl_lno": 1885,
                    "decl_fn": "/mnt/c/Users/andre/OneDrive/Desktop/lava/target_injections/file/file-5.30/src/src/apprentice.c",
                    "loc_op": [
                        "DW_OP_fbreg",
                        -4768
                    ],
                    "type": 80935
                },
```

A quick fix is to add a function to check the assignment of `fn` and `decl_fn`, where the user provides the known root, e.g. `/mnt/c/Users/andre/OneDrive/Desktop/lava/target_injections/file/file-5.30` and uses regex to cut any duplicates downstream for final assembly.

It performs sanity checks on the hard disk to confirm that the file exists before inserting it into the JSON. See the screenshot showing the corrected files:

<img alt="image" src="https://github.com/user-attachments/assets/d9b2a795-89b6-44cf-b90f-f6f9c2d13b77" />

## GitHub Actions Updates

Also, I put some important CI/CD and bumped the actions because of this warning

https://github.com/panda-re/panda/actions/runs/26796731914

<img alt="image" src="https://github.com/user-attachments/assets/80c71ad3-35c4-47d8-99da-8d1bbef9b2c6" />

As for how I updated the labeler, I used Prowler and LAVA to confirm the labels were updated correctly

https://github.com/prowler-cloud/prowler/blob/master/.github/workflows/labeler.yml

https://github.com/prowler-cloud/prowler/blob/master/.github/labeler.yml

See the updated labeler work on LAVA

https://github.com/panda-re/lava/pull/98

https://github.com/panda-re/lava/pull/99
...

## AARCH64 had a missing entry in kernel.conf

I used the following commands within a recording to fill out the entry

```python3
print("[-->] Injecting kernelinfo.ko into guest...")
panda.copy_to_guest("/mnt/c/Users/andre/OneDrive/Desktop/kernelinfo.ko", absolute_paths=True)

# 3. Execute the kernel module inside the guest
# Note: The double '/kernelinfo.ko/kernelinfo.ko' path is a quirk of how 
# copy_to_guest handled the transfer on this specific snapshot.
print("[-->] Executing kernel module (Operation Not Permitted error is expected!)...")
panda.run_serial_cmd("sudo insmod /mnt/c/Users/andre/OneDrive/Desktop/kernelinfo.ko/kernelinfo.ko", timeout=60)

# 4. Harvest the dynamic offsets from the kernel ring buffer
print("[-->] Harvesting kernel info profile from dmesg:")
dynamic_offsets = panda.run_serial_cmd("sudo dmesg | tail -n 70", timeout=60)
print(dynamic_offsets)

# =======================================================================
# PHASE 2: STATIC SYMBOLS (via kallsyms)
# =======================================================================
print("\n[+] PHASE 2: Hunting Static Kernel Symbols...")

# 5. Grab finish_task_switch (Required for task.switch_task_hook_addr)
# We use the '$' regex anchor to ensure we don't accidentally grab wrapper functions
print("[-->] Getting finish_task_switch...")
switch_hook = panda.run_serial_cmd("cat /proc/kallsyms | grep ' finish_task_switch$'", timeout=15)
print(switch_hook)

# 6. Grab init_task (Required for task.init_addr & task.current_task_addr)
print("\n[-->] Getting init_task...")
init_addr = panda.run_serial_cmd("cat /proc/kallsyms | grep ' init_task$'", timeout=15)
print(init_addr)

print("\n[+] PROFILE EXTRACTION COMPLETE!")
print("[!] Reminder: Convert the static hex addresses to decimal before pasting into kernel.conf.")

```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Or what test cases you added. Ideally, provide screenshots to show that your code changes work as expected -->

I'm manually checking my JSON files from DwarfDump to confirm they return the expected file paths.

...

**Closing issues**
N/A
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...