### PR TITLE
target/i386: fix long mode segment override prefix decoding

### DIFF
--- a/target/i386/translate.c
+++ b/target/i386/translate.c
@@ -4449,16 +4449,24 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
         prefixes |= PREFIX_LOCK;
         goto next_byte;
     case 0x2e:
-        s->override = R_CS;
+        if (!CODE64(s)) {
+            s->override = R_CS;
+        }
         goto next_byte;
     case 0x36:
-        s->override = R_SS;
+        if (!CODE64(s)) {
+            s->override = R_SS;
+        }
         goto next_byte;
     case 0x3e:
-        s->override = R_DS;
+        if (!CODE64(s)) {
+            s->override = R_DS;
+        }
         goto next_byte;
     case 0x26:
-        s->override = R_ES;
+        if (!CODE64(s)) {
+            s->override = R_ES;
+        }
         goto next_byte;
     case 0x64:
         s->override = R_FS;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've documented or updated the documentation of every API function and struct this PR changes.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Hi! I noticed PANDA has the same [bug](https://gitlab.com/qemu-project/qemu/-/work_items/3391) I recently provided [a fix to QEMU](https://lists.gnu.org/archive/html/qemu-devel/2026-06/msg05815.html) for. I have ported the fix so it can also be applied here.

On x86, the ES/CS/SS/DS segment override prefixes are null prefixes in long mode, and should be ignored. (AMD APM Volume 3, Section 1.2.4)

This patch fixes the prefix decoding to correctly ignore the prefixes in 64-bit mode.

**Test plan**

Running this code will crash with a segfault without the patch applied, and runs correctly with the patch applied (note that running the test requires `-cpu qemu64,+fsgsbase`):
```c
int main()
{
    int data = 0;

    /* Ensure that ignored segment override prefixes are actually ignored */
    asm volatile (
        "wrgsbase %0\n\t"
        ".byte 0x65, 0x26\n\t" /* prefixes: GS + ES */
        "movb $0, 0\n\t"
        ".byte 0x65, 0x2E\n\t" /* prefixes: GS + CS */
        "movb $0, 0\n\t"
        ".byte 0x65, 0x36\n\t" /* prefixes: GS + SS */
        "movb $0, 0\n\t"
        ".byte 0x65, 0x3E\n\t" /* prefixes: GS + DS */
        "movb $0, 0\n\t"
        :
        : "r" (&data)
        : "memory"
    );

    return 0;
}
```

This is the test case I added for the patch to QEMU. It seems PANDA does not have a directory for x86 tests in the same place (`tests/tcg/x86_64`). Please let me know if you would like me to add this test somewhere else.